### PR TITLE
Implement arguments on Prompt.

### DIFF
--- a/examples/server/everything/stdio/main.go
+++ b/examples/server/everything/stdio/main.go
@@ -53,8 +53,14 @@ func NewMCPServer() *MCPServer {
 		"test://static/resource/{id}",
 		s.handleResourceTemplate,
 	)
-	s.server.AddPrompt(string(SIMPLE), s.handleSimplePrompt)
-	s.server.AddPrompt(string(COMPLEX), s.handleComplexPrompt)
+	s.server.AddPrompt(mcp.Prompt{
+		Name:        string(SIMPLE),
+		Description: "A simple prompt",
+	}, s.handleSimplePrompt)
+	s.server.AddPrompt(mcp.Prompt{
+		Name:        string(COMPLEX),
+		Description: "A complex prompt",
+	}, s.handleComplexPrompt)
 	s.server.AddTool(mcp.Tool{
 		Name:        string(ECHO),
 		Description: "Echoes back the input",


### PR DESCRIPTION
As described in https://github.com/mark3labs/mcp-go/issues/5

I think we should do the same with the other fields, like Resource and ResourceTemplate, and as well hook in the appropriate Completion calls (into the Prompts and Resources handlers somehow.. might require a few breaking changes to the API)

What do you think?