### PR TITLE
Client: return the errors if any

### DIFF
--- a/client/types.go
+++ b/client/types.go
@@ -1,0 +1,8 @@
+package client
+
+import "encoding/json"
+
+type RPCResponse struct {
+	Error    *string
+	Response *json.RawMessage
+}


### PR DESCRIPTION
The client was sending a generic "response failed" error in some cases, make sure to get the error and return to the caller.

This will bubble up errors like schema validations for example