### PR TITLE
fix(client): SSE client can call tools

### DIFF
--- a/client/sse.go
+++ b/client/sse.go
@@ -236,16 +236,7 @@ func (c *SSEMCPClient) sendRequest(
 		Request: mcp.Request{
 			Method: method,
 		},
-	}
-
-	if params != nil {
-		paramsBytes, err := json.Marshal(params)
-		if err != nil {
-			return nil, fmt.Errorf("failed to marshal params: %w", err)
-		}
-		if err := json.Unmarshal(paramsBytes, &request.Params); err != nil {
-			return nil, fmt.Errorf("failed to unmarshal params: %w", err)
-		}
+		Params: params,
 	}
 
 	requestBytes, err := json.Marshal(request)

--- a/client/sse_test.go
+++ b/client/sse_test.go
@@ -19,15 +19,19 @@ func TestSSEMCPClient(t *testing.T) {
 	)
 
 	// Add a test tool
-	mcpServer.AddTool(mcp.Tool{
-		Name:        "test-tool",
-		Description: "Test tool",
-		InputSchema: mcp.ToolInputSchema{
-			Type:       "object",
-			Properties: map[string]interface{}{},
-		},
-	}, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		return &mcp.CallToolResult{}, nil
+	mcpServer.AddTool(mcp.NewTool(
+		"test-tool",
+		mcp.WithDescription("Test tool"),
+		mcp.WithString("parameter-1", mcp.Description("A string tool parameter")),
+	), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{
+			Content: []interface{}{
+				mcp.TextContent{
+					Type: "text",
+					Text: "Input parameter: " + request.Params.Arguments["parameter-1"].(string),
+				},
+			},
+		}, nil
 	})
 
 	// Initialize
@@ -183,4 +187,47 @@ func TestSSEMCPClient(t *testing.T) {
 	// 		t.Error("Expected error when context is cancelled")
 	// 	}
 	// })
+
+	t.Run("CallTool", func(t *testing.T) {
+		client, err := NewSSEMCPClient(testServer.URL + "/sse")
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+		defer client.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		if err := client.Start(ctx); err != nil {
+			t.Fatalf("Failed to start client: %v", err)
+		}
+
+		// Initialize
+		initRequest := mcp.InitializeRequest{}
+		initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+		initRequest.Params.ClientInfo = mcp.Implementation{
+			Name:    "test-client",
+			Version: "1.0.0",
+		}
+
+		_, err = client.Initialize(ctx, initRequest)
+		if err != nil {
+			t.Fatalf("Failed to initialize: %v", err)
+		}
+
+		request := mcp.CallToolRequest{}
+		request.Params.Name = "test-tool"
+		request.Params.Arguments = map[string]interface{}{
+			"parameter-1": "value1",
+		}
+
+		result, err := client.CallTool(ctx, request)
+		if err != nil {
+			t.Fatalf("CallTool failed: %v", err)
+		}
+
+		if len(result.Content) != 1 {
+			t.Errorf("Expected 1 content item, got %d", len(result.Content))
+		}
+	})
 }

--- a/client/stdio.go
+++ b/client/stdio.go
@@ -185,16 +185,13 @@ func (c *StdioMCPClient) sendRequest(
 	id := c.requestID.Add(1)
 
 	// Create the complete request structure
-	request := struct {
-		JSONRPC string      `json:"jsonrpc"`
-		ID      int64       `json:"id"`
-		Method  string      `json:"method"`
-		Params  interface{} `json:"params,omitempty"`
-	}{
+	request := mcp.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      id,
-		Method:  method,
-		Params:  params,
+		Request: mcp.Request{
+			Method: method,
+		},
+		Params: params,
 	}
 
 	responseChan := make(chan RPCResponse, 1)

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -117,8 +117,9 @@ type RequestId interface{}
 
 // JSONRPCRequest represents a request that expects a response.
 type JSONRPCRequest struct {
-	JSONRPC string    `json:"jsonrpc"`
-	ID      RequestId `json:"id"`
+	JSONRPC string      `json:"jsonrpc"`
+	ID      RequestId   `json:"id"`
+	Params  interface{} `json:"params,omitempty"`
 	Request
 }
 


### PR DESCRIPTION
## Description

Fixes #17 

Gives feature parity to the SSE implementation of the MCP client.

This fix includes a test `TestSSEMCPClient/CallTool` that fails in case the production changes are not applied (for easier review).