### PR TITLE
Tools can be built with predefined Input Schema

### DIFF
--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestToolWithBothSchemasError verifies that there will be feedback if the
+// developer mixes raw schema with a schema provided via DSL.
+func TestToolWithBothSchemasError(t *testing.T) {
+	// Create a tool with both schemas set
+	tool := NewTool("dual-schema-tool",
+		WithDescription("A tool with both schemas set"),
+		WithString("input", Description("Test input")),
+	)
+
+	_, err := json.Marshal(tool)
+	assert.Nil(t, err)
+
+	// Set the RawInputSchema as well - this should conflict with the InputSchema
+	// Note: InputSchema.Type is explicitly set to "object" in NewTool
+	tool.RawInputSchema = json.RawMessage(`{"type":"string"}`)
+
+	// Attempt to marshal to JSON
+	_, err = json.Marshal(tool)
+
+	// Should return an error
+	assert.ErrorIs(t, err, errToolSchemaConflict)
+}
+
+func TestToolWithRawSchema(t *testing.T) {
+	// Create a complex raw schema
+	rawSchema := json.RawMessage(`{
+		"type": "object",
+		"properties": {
+			"query": {"type": "string", "description": "Search query"},
+			"limit": {"type": "integer", "minimum": 1, "maximum": 50}
+		},
+		"required": ["query"]
+	}`)
+
+	// Create a tool with raw schema
+	tool := NewToolWithRawSchema("search-tool", "Search API", rawSchema)
+
+	// Marshal to JSON
+	data, err := json.Marshal(tool)
+	assert.NoError(t, err)
+
+	// Unmarshal to verify the structure
+	var result map[string]interface{}
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+
+	// Verify tool properties
+	assert.Equal(t, "search-tool", result["name"])
+	assert.Equal(t, "Search API", result["description"])
+
+	// Verify schema was properly included
+	schema, ok := result["inputSchema"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "object", schema["type"])
+
+	properties, ok := schema["properties"].(map[string]interface{})
+	assert.True(t, ok)
+
+	query, ok := properties["query"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, "string", query["type"])
+
+	required, ok := schema["required"].([]interface{})
+	assert.True(t, ok)
+	assert.Contains(t, required, "query")
+}


### PR DESCRIPTION
Existing LLM projects will have already developed JSON Schemas to define their tool functions.

Some LLM projects use libraries such as invopop/jsonschema, to build JSON Schemas automatically.

This change honors the existing Options-based mechanism for building schemas, while opening a door to allow the use of JSON Schemas defined elsewhere.

In so doing, users of this package are better enabled to validate the parity between Tool JSON schemas and the Go structs that receive the argument.


Let me know if you'd prefer a different approach, etc.  Your implementation is the best in class so far as I can see in the Golang world.  I'd love to see what your road map looks like, in hopes of contributing in places where the goals align with what my primary project is doing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced tool configuration by supporting an alternative JSON schema input method.
  - Improved error messaging to prevent configuration conflicts when multiple schema inputs are provided.

- **Tests**
  - Added comprehensive tests to verify the new configuration approach and robust error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->