### PR TITLE
change to strong ResourceContents type

### DIFF
--- a/client/sse.go
+++ b/client/sse.go
@@ -412,12 +412,7 @@ func (c *SSEMCPClient) ReadResource(
 		return nil, err
 	}
 
-	var result mcp.ReadResourceResult
-	if err := json.Unmarshal(*response, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	return &result, nil
+	return mcp.ParseReadResourceResult(response)
 }
 
 func (c *SSEMCPClient) Subscribe(

--- a/client/stdio.go
+++ b/client/stdio.go
@@ -338,12 +338,7 @@ func (c *StdioMCPClient) ReadResource(
 		return nil, err
 	}
 
-	var result mcp.ReadResourceResult
-	if err := json.Unmarshal(*response, &result); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
-	}
-
-	return &result, nil
+	return mcp.ParseReadResourceResult(response)
 }
 
 func (c *StdioMCPClient) Subscribe(

--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -173,14 +173,12 @@ func runUpdateInterval() {
 func handleReadResource(
 	ctx context.Context,
 	request mcp.ReadResourceRequest,
-) ([]interface{}, error) {
-	return []interface{}{
+) ([]mcp.ResourceContents, error) {
+	return []mcp.ResourceContents{
 		mcp.TextResourceContents{
-			ResourceContents: mcp.ResourceContents{
-				URI:      "test://static/resource",
-				MIMEType: "text/plain",
-			},
-			Text: "This is a sample resource",
+			URI:      "test://static/resource",
+			MIMEType: "text/plain",
+			Text:     "This is a sample resource",
 		},
 	}, nil
 }
@@ -188,14 +186,12 @@ func handleReadResource(
 func handleResourceTemplate(
 	ctx context.Context,
 	request mcp.ReadResourceRequest,
-) ([]interface{}, error) {
-	return []interface{}{
+) ([]mcp.ResourceContents, error) {
+	return []mcp.ResourceContents{
 		mcp.TextResourceContents{
-			ResourceContents: mcp.ResourceContents{
-				URI:      request.Params.URI,
-				MIMEType: "text/plain",
-			},
-			Text: "This is a sample resource",
+			URI:      request.Params.URI,
+			MIMEType: "text/plain",
+			Text:     "This is a sample resource",
 		},
 	}, nil
 }

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -373,7 +373,7 @@ type ReadResourceRequest struct {
 // from the client.
 type ReadResourceResult struct {
 	Result
-	Contents []interface{} `json:"contents"` // Can be TextResourceContents or BlobResourceContents
+	Contents []ResourceContents `json:"contents"` // Can be TextResourceContents or BlobResourceContents
 }
 
 // ResourceListChangedNotification is an optional notification from the server
@@ -459,25 +459,32 @@ type ResourceTemplate struct {
 
 // ResourceContents represents the contents of a specific resource or sub-
 // resource.
-type ResourceContents struct {
+type ResourceContents interface {
+	isResourceContents()
+}
+
+type TextResourceContents struct {
 	// The URI of this resource.
 	URI string `json:"uri"`
 	// The MIME type of this resource, if known.
 	MIMEType string `json:"mimeType,omitempty"`
-}
-
-type TextResourceContents struct {
-	ResourceContents
 	// The text of the item. This must only be set if the item can actually be
 	// represented as text (not binary data).
 	Text string `json:"text"`
 }
 
+func (TextResourceContents) isResourceContents() {}
+
 type BlobResourceContents struct {
-	ResourceContents
+	// The URI of this resource.
+	URI string `json:"uri"`
+	// The MIME type of this resource, if known.
+	MIMEType string `json:"mimeType,omitempty"`
 	// A base64-encoded string representing the binary data of the item.
 	Blob string `json:"blob"`
 }
+
+func (BlobResourceContents) isResourceContents() {}
 
 /* Logging */
 

--- a/server/server.go
+++ b/server/server.go
@@ -29,10 +29,10 @@ type resourceTemplateEntry struct {
 type ServerOption func(*MCPServer)
 
 // ResourceHandlerFunc is a function that returns resource contents.
-type ResourceHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) ([]interface{}, error)
+type ResourceHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error)
 
 // ResourceTemplateHandlerFunc is a function that returns a resource template.
-type ResourceTemplateHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) ([]interface{}, error)
+type ResourceTemplateHandlerFunc func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error)
 
 // PromptHandlerFunc handles prompt requests with given arguments.
 type PromptHandlerFunc func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -674,14 +674,12 @@ func createTestServer() *MCPServer {
 			URI:  "resource://testresource",
 			Name: "My Resource",
 		},
-		func(ctx context.Context, request mcp.ReadResourceRequest) ([]interface{}, error) {
-			return []interface{}{
+		func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			return []mcp.ResourceContents{
 				mcp.TextResourceContents{
-					ResourceContents: mcp.ResourceContents{
-						URI:      "resource://testresource",
-						MIMEType: "text/plain",
-					},
-					Text: "test content",
+					URI:      "resource://testresource",
+					MIMEType: "text/plain",
+					Text:     "test content",
 				},
 			}, nil
 		},


### PR DESCRIPTION
similiar to https://github.com/mark3labs/mcp-go/pull/26, add strong type to ResourceContents


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a unified mechanism for processing resource responses, enabling consistent handling of different resource content types.

- **Refactor**
  - Improved resource parsing and error management for more reliable and clearly structured resource details.
  - Enhanced type specificity across resource operations to ensure consistent and stable outputs for consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->