### PR TITLE
fix: Remove type assertion for prompt arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ s.AddPrompt(mcp.NewPrompt("greeting",
         mcp.ArgumentDescription("Name of the person to greet"),
     ),
 ), func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-    name := request.Params.Arguments["name"].(string)
+    name := request.Params.Arguments["name"]
     if name == "" {
         name = "friend"
     }
@@ -434,7 +434,7 @@ s.AddPrompt(mcp.NewPrompt("code_review",
         mcp.RequiredArgument(),
     ),
 ), func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-    prNumber := request.Params.Arguments["pr_number"].(string)
+    prNumber := request.Params.Arguments["pr_number"]
     if prNumber == "" {
         return nil, fmt.Errorf("pr_number is required")
     }
@@ -465,7 +465,7 @@ s.AddPrompt(mcp.NewPrompt("query_builder",
         mcp.RequiredArgument(),
     ),
 ), func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
-    tableName := request.Params.Arguments["table"].(string)
+    tableName := request.Params.Arguments["table"]
     if tableName == "" {
         return nil, fmt.Errorf("table name is required")
     }


### PR DESCRIPTION
Removed unnecessary type assertions for prompt arguments in the README.md file.

mcp.GetPromptRequest.Params.Arguments is already type of map[string]string，it is unnecessary use type assertions
<img width="957" alt="image" src="https://github.com/user-attachments/assets/7e0ddda5-d1ab-4939-8874-04878bbeed79" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README for clearer guidance on parameter usage, enhancing user understanding without affecting public functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->