### PR TITLE
feat: support RFC 6570 for Resource Templates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,5 +10,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -1,5 +1,7 @@
 package mcp
 
+import "github.com/yosida95/uritemplate/v3"
+
 // ResourceOption is a function that configures a Resource.
 // It provides a flexible way to set various properties of a Resource using the functional options pattern.
 type ResourceOption func(*Resource)
@@ -60,7 +62,7 @@ type ResourceTemplateOption func(*ResourceTemplate)
 // Options are applied in order, allowing for flexible template configuration.
 func NewResourceTemplate(uriTemplate string, name string, opts ...ResourceTemplateOption) ResourceTemplate {
 	template := ResourceTemplate{
-		URITemplate: uriTemplate,
+		URITemplate: uritemplate.MustNew(uriTemplate),
 		Name:        name,
 	}
 

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -2,7 +2,11 @@
 // MCP is a protocol for communication between LLM-powered applications and their supporting services.
 package mcp
 
-import "encoding/json"
+import (
+	"encoding/json"
+
+	"github.com/yosida95/uritemplate/v3"
+)
 
 /* JSON-RPC types */
 
@@ -442,7 +446,7 @@ type ResourceTemplate struct {
 	Annotated
 	// A URI template (according to RFC 6570) that can be used to construct
 	// resource URIs.
-	URITemplate string `json:"uriTemplate"`
+	URITemplate *uritemplate.Template `json:"uriTemplate"`
 	// A human-readable name for the type of resource this template refers to.
 	//
 	// This can be used by clients to populate UI elements.

--- a/server/server.go
+++ b/server/server.go
@@ -5,12 +5,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
 	"sort"
 	"sync"
 	"sync/atomic"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/yosida95/uritemplate/v3"
 )
 
 // resourceEntry holds both a resource and its handler
@@ -455,7 +455,7 @@ func (s *MCPServer) AddResourceTemplate(
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.resourceTemplates[template.URITemplate] = resourceTemplateEntry{
+	s.resourceTemplates[template.URITemplate.Raw()] = resourceTemplateEntry{
 		template: template,
 		handler:  handler,
 	}
@@ -656,10 +656,17 @@ func (s *MCPServer) handleReadResource(
 	// If no direct handler found, try matching against templates
 	var matchedHandler ResourceTemplateHandlerFunc
 	var matched bool
-	for uriTemplate, entry := range s.resourceTemplates {
-		if matchesTemplate(request.Params.URI, uriTemplate) {
+	for _, entry := range s.resourceTemplates {
+		template := entry.template
+		if matchesTemplate(request.Params.URI, template.URITemplate) {
 			matchedHandler = entry.handler
 			matched = true
+			matchedVars := template.URITemplate.Match(request.Params.URI)
+			// Convert matched variables to a map
+			request.Params.Arguments = make(map[string]interface{})
+			for name, value := range matchedVars {
+				request.Params.Arguments[name] = value.V
+			}
 			break
 		}
 	}
@@ -687,17 +694,8 @@ func (s *MCPServer) handleReadResource(
 }
 
 // matchesTemplate checks if a URI matches a URI template pattern
-func matchesTemplate(uri string, template string) bool {
-	// Convert template into a regex pattern
-	pattern := template
-	// Replace {name} with ([^/]+)
-	pattern = regexp.QuoteMeta(pattern)
-	pattern = regexp.MustCompile(`\\\{[^}]+\\\}`).
-		ReplaceAllString(pattern, `([^/]+)`)
-	pattern = "^" + pattern + "$"
-
-	matched, _ := regexp.MatchString(pattern, uri)
-	return matched
+func matchesTemplate(uri string, template *uritemplate.Template) bool {
+	return template.Regexp().MatchString(uri)
 }
 
 func (s *MCPServer) handleListPrompts(

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -777,6 +777,63 @@ func TestMCPServer_Instructions(t *testing.T) {
 	}
 }
 
+func TestMCPServer_ResourceTemplates(t *testing.T) {
+	server := NewMCPServer("test-server", "1.0.0",
+		WithResourceCapabilities(true, true),
+		WithPromptCapabilities(true),
+	)
+
+	server.AddResourceTemplate(
+		mcp.NewResourceTemplate(
+			"test://{a}/test-resource{/b*}",
+			"My Resource",
+		),
+		func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
+			a := request.Params.Arguments["a"].([]string)
+			b := request.Params.Arguments["b"].([]string)
+			// Validate that the template arguments are passed correctly to the handler
+			assert.Equal(t, []string{"something"}, a)
+			assert.Equal(t, []string{"a", "b", "c"}, b)
+			return []mcp.ResourceContents{
+				mcp.TextResourceContents{
+					URI:      "test://something/test-resource/a/b/c",
+					MIMEType: "text/plain",
+					Text:     "test content: " + a[0],
+				},
+			}, nil
+		},
+	)
+
+	message := `{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "resources/read",
+		"params": {
+			"uri": "test://something/test-resource/a/b/c"
+		}
+	}`
+
+	t.Run("Get resource template", func(t *testing.T) {
+		response := server.HandleMessage(
+			context.Background(),
+			[]byte(message),
+		)
+		assert.NotNil(t, response)
+
+		resp, ok := response.(mcp.JSONRPCResponse)
+		assert.True(t, ok)
+		// Validate that the resource values are returned correctly
+		result, ok := resp.Result.(mcp.ReadResourceResult)
+		assert.True(t, ok)
+		assert.Len(t, result.Contents, 1)
+		resultContent, ok := result.Contents[0].(mcp.TextResourceContents)
+		assert.True(t, ok)
+		assert.Equal(t, "test://something/test-resource/a/b/c", resultContent.URI)
+		assert.Equal(t, "text/plain", resultContent.MIMEType)
+		assert.Equal(t, "test content: something", resultContent.Text)
+	})
+}
+
 func createTestServer() *MCPServer {
 	server := NewMCPServer("test-server", "1.0.0",
 		WithResourceCapabilities(true, true),


### PR DESCRIPTION
Closes: https://github.com/mark3labs/mcp-go/issues/53

May help with: https://github.com/mark3labs/mcp-go/issues/51

This PR adds support for conformant templates, and also provides the parameters to the handler, as sometimes the backend for a resource might actually be an API call with params rather than a static file or similar.

The current resource read does not handle templates according to [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) which makes it impossible to implement certain dynamic resource URIs. This support is specified in the specification for template resources for the Model Context Protocol.

I hope the contribution is welcome, and introducing a dependency isn't considered too extreme in the circumstances, but obviously I hope one way or another we can do this in a way that pleases everyone. I discovered this while implementing a resource template and found I was unable to do it with nested dynamic resources.

Thanks for the awesome work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced resource template processing now delivers more robust URI pattern matching and precise parameter extraction during resource handling.
  
- **Tests**
  - Added new automated tests to validate resource template functionality, ensuring improved reliability and consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->