### PR TITLE
fix: ensure resource/template/list is marshalled safely 

### DIFF
--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -62,7 +62,7 @@ type ResourceTemplateOption func(*ResourceTemplate)
 // Options are applied in order, allowing for flexible template configuration.
 func NewResourceTemplate(uriTemplate string, name string, opts ...ResourceTemplateOption) ResourceTemplate {
 	template := ResourceTemplate{
-		URITemplate: uritemplate.MustNew(uriTemplate),
+		URITemplate: &URITemplate{Template: uritemplate.MustNew(uriTemplate)},
 		Name:        name,
 	}
 

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -8,6 +8,27 @@ import (
 	"github.com/yosida95/uritemplate/v3"
 )
 
+type URITemplate struct {
+	*uritemplate.Template
+}
+
+func (t *URITemplate) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.Template.Raw())
+}
+
+func (t *URITemplate) UnmarshalJSON(data []byte) error {
+	var raw string
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	template, err := uritemplate.New(raw)
+	if err != nil {
+		return err
+	}
+	t.Template = template
+	return nil
+}
+
 /* JSON-RPC types */
 
 // JSONRPCMessage represents either a JSONRPCRequest, JSONRPCNotification, JSONRPCResponse, or JSONRPCError
@@ -446,7 +467,7 @@ type ResourceTemplate struct {
 	Annotated
 	// A URI template (according to RFC 6570) that can be used to construct
 	// resource URIs.
-	URITemplate *uritemplate.Template `json:"uriTemplate"`
+	URITemplate *URITemplate `json:"uriTemplate"`
 	// A human-readable name for the type of resource this template refers to.
 	//
 	// This can be used by clients to populate UI elements.

--- a/server/server.go
+++ b/server/server.go
@@ -10,7 +10,6 @@ import (
 	"sync/atomic"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/yosida95/uritemplate/v3"
 )
 
 // resourceEntry holds both a resource and its handler
@@ -731,7 +730,7 @@ func (s *MCPServer) handleReadResource(
 }
 
 // matchesTemplate checks if a URI matches a URI template pattern
-func matchesTemplate(uri string, template *uritemplate.Template) bool {
+func matchesTemplate(uri string, template *mcp.URITemplate) bool {
 	return template.Regexp().MatchString(uri)
 }
 


### PR DESCRIPTION
Fast follow to https://github.com/mark3labs/mcp-go/pull/54 to ensure that json is properly serialized for the `resource/template/list` endpoint, as the new URI Template class does not have Marshall/Unmarshall defined.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to list available resource templates through the updated server interface, allowing users to retrieve comprehensive template details.
  
- **Refactor**
  - Enhanced URI template handling with improved JSON serialization and deserialization for consistent, reliable data exchange.
  - Refined template matching logic and cleaned up unused dependencies to boost overall system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->