### PR TITLE
Add DefaultArray

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -287,6 +287,18 @@ func DefaultBool(value bool) PropertyOption {
 }
 
 //
+// Array Property Options
+//
+
+// DefaultArray sets the default value for an array property.
+// This value will be used if the property is not explicitly provided.
+func DefaultArray[T any](value []T) PropertyOption {
+	return func(schema map[string]interface{}) {
+		schema["default"] = value
+	}
+}
+
+//
 // Property Type Helpers
 //
 


### PR DESCRIPTION
Allows to specify the default for an array parameter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced tool configuration by enabling default values for array properties in input setups. This update extends existing default settings to better support list-based configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->