### PR TITLE
Add Stderr() Method to StdioMCPClient

### DIFF
--- a/testdata/mockstdio_server.go
+++ b/testdata/mockstdio_server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 )
 
@@ -25,6 +26,8 @@ type JSONRPCResponse struct {
 }
 
 func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{}))
+	logger.Info("launch successful")
 	scanner := bufio.NewScanner(os.Stdin)
 	for scanner.Scan() {
 		var request JSONRPCRequest


### PR DESCRIPTION
This PR adds a Stderr() method to StdioMCPClient, allowing the parent process to read from the standard error output (stderr) of the spawned subprocess.

In many cases, the subprocess writes logs or error messages to stderr. By exposing stderr via the Stderr() method, the parent process can now handle this output — for example, for log collection, monitoring, or display purposes.

The Stderr() method returns an io.Reader that allows access to the subprocess’s stderr stream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced logging: The application now captures structured diagnostic messages and error logs from background processes, providing clear, real-time feedback during startup and runtime. Users will see more transparent status updates—including informative launch messages—that improve monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->