### PR TITLE
fix java mcp message endpoint

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -254,16 +254,9 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}()
-	// Use either just the path or the complete URL based on configuration.
-	// This prevents issues with clients that concatenate the base URL themselves.
-	messageEndpoint := s.messageEndpoint
-	if s.useFullURLForMessageEndpoint {
-		messageEndpoint = s.CompleteMessageEndpoint()
-	}
-	messageEndpoint = fmt.Sprintf("%s?sessionId=%s", messageEndpoint, sessionID)
 
 	// Send the initial endpoint event
-	fmt.Fprintf(w, "event: endpoint\ndata: %s\r\n\r\n", messageEndpoint)
+	fmt.Fprintf(w, "event: endpoint\ndata: %s\r\n\r\n", s.GetMessageEndpointForClient(sessionID))
 	flusher.Flush()
 
 	// Main event loop - this runs in the HTTP handler goroutine
@@ -278,6 +271,16 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+}
+
+// GetMessageEndpointForClient returns the appropriate message endpoint URL with session ID
+// based on the useFullURLForMessageEndpoint configuration.
+func (s *SSEServer) GetMessageEndpointForClient(sessionID string) string {
+	messageEndpoint := s.messageEndpoint
+	if s.useFullURLForMessageEndpoint {
+		messageEndpoint = s.CompleteMessageEndpoint()
+	}
+	return fmt.Sprintf("%s?sessionId=%s", messageEndpoint, sessionID)
 }
 
 // handleMessage processes incoming JSON-RPC messages from clients and sends responses

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -418,7 +418,7 @@ func TestSSEServer(t *testing.T) {
 		cancel()
 	})
 
-	t.Run("test isCompleteMessageEndpoint", func(t *testing.T) {
+	t.Run("test useFullURLForMessageEndpoint", func(t *testing.T) {
 		mcpServer := NewMCPServer("test", "1.0.0")
 		sseServer := NewSSEServer(mcpServer)
 
@@ -429,7 +429,7 @@ func TestSSEServer(t *testing.T) {
 		defer ts.Close()
 
 		sseServer.baseURL = ts.URL + "/mcp"
-		sseServer.isCompleteMessageEndpoint = false
+		sseServer.useFullURLForMessageEndpoint = false
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -696,13 +696,13 @@ func TestSSEServer(t *testing.T) {
 		baseURL := "http://localhost:8080/test"
 		messageEndpoint := "/message-test"
 		sseEndpoint := "/sse-test"
-		isCompleteMessageEndpoint := false
+		useFullURLForMessageEndpoint := false
 		srv := &http.Server{}
 		rands := []SSEOption{
 			WithBasePath(basePath),
 			WithBaseURL(baseURL),
 			WithMessageEndpoint(messageEndpoint),
-			WithIsCompleteMessageEndpoint(isCompleteMessageEndpoint),
+			WithUseFullURLForMessageEndpoint(useFullURLForMessageEndpoint),
 			WithSSEEndpoint(sseEndpoint),
 			WithHTTPServer(srv),
 		}
@@ -718,8 +718,8 @@ func TestSSEServer(t *testing.T) {
 			if sseServer.basePath != basePath {
 				t.Fatalf("basePath %v, got: %v", basePath, sseServer.basePath)
 			}
-			if sseServer.isCompleteMessageEndpoint != isCompleteMessageEndpoint {
-				t.Fatalf("isCompleteMessageEndpoint %v, got: %v", isCompleteMessageEndpoint, sseServer.isCompleteMessageEndpoint)
+			if sseServer.useFullURLForMessageEndpoint != useFullURLForMessageEndpoint {
+				t.Fatalf("useFullURLForMessageEndpoint %v, got: %v", useFullURLForMessageEndpoint, sseServer.useFullURLForMessageEndpoint)
 			}
 
 			if sseServer.baseURL != baseURL {

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -418,6 +418,81 @@ func TestSSEServer(t *testing.T) {
 		cancel()
 	})
 
+	t.Run("test isCompleteMessageEndpoint", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		sseServer := NewSSEServer(mcpServer)
+
+		mux := http.NewServeMux()
+		mux.Handle("/mcp/", sseServer)
+
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+
+		sseServer.baseURL = ts.URL + "/mcp"
+		sseServer.isCompleteMessageEndpoint = false
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/sse", sseServer.baseURL), nil)
+		if err != nil {
+			t.Fatalf("Failed to create request: %v", err)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("Failed to connect to SSE endpoint: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Errorf("Expected status 200, got %d", resp.StatusCode)
+		}
+
+		// Read the endpoint event
+		buf := make([]byte, 1024)
+		n, err := resp.Body.Read(buf)
+		if err != nil {
+			t.Fatalf("Failed to read SSE response: %v", err)
+		}
+
+		endpointEvent := string(buf[:n])
+		messageURL := strings.TrimSpace(
+			strings.Split(strings.Split(endpointEvent, "data: ")[1], "\n")[0],
+		)
+		if !strings.HasPrefix(messageURL, sseServer.messageEndpoint) {
+			t.Errorf("Expected messageURL to be %s, got %s", sseServer.messageEndpoint, messageURL)
+		}
+
+		// The messageURL should already be correct since we set the baseURL correctly
+		// Test message endpoint
+		initRequest := map[string]interface{}{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "initialize",
+			"params": map[string]interface{}{
+				"protocolVersion": "2024-11-05",
+				"clientInfo": map[string]interface{}{
+					"name":    "test-client",
+					"version": "1.0.0",
+				},
+			},
+		}
+		requestBody, _ := json.Marshal(initRequest)
+
+		resp, err = http.Post(sseServer.baseURL+messageURL, "application/json", bytes.NewBuffer(requestBody))
+		if err != nil {
+			t.Fatalf("Failed to send message: %v", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusAccepted {
+			t.Errorf("Expected status 202, got %d", resp.StatusCode)
+		}
+
+		// Clean up SSE connection
+		cancel()
+	})
+
 	t.Run("works as http.Handler with custom basePath", func(t *testing.T) {
 		mcpServer := NewMCPServer("test", "1.0.0")
 		sseServer := NewSSEServer(mcpServer, WithBasePath("/mcp"))
@@ -621,11 +696,13 @@ func TestSSEServer(t *testing.T) {
 		baseURL := "http://localhost:8080/test"
 		messageEndpoint := "/message-test"
 		sseEndpoint := "/sse-test"
+		isCompleteMessageEndpoint := false
 		srv := &http.Server{}
 		rands := []SSEOption{
 			WithBasePath(basePath),
 			WithBaseURL(baseURL),
 			WithMessageEndpoint(messageEndpoint),
+			WithIsCompleteMessageEndpoint(isCompleteMessageEndpoint),
 			WithSSEEndpoint(sseEndpoint),
 			WithHTTPServer(srv),
 		}
@@ -640,6 +717,9 @@ func TestSSEServer(t *testing.T) {
 
 			if sseServer.basePath != basePath {
 				t.Fatalf("basePath %v, got: %v", basePath, sseServer.basePath)
+			}
+			if sseServer.isCompleteMessageEndpoint != isCompleteMessageEndpoint {
+				t.Fatalf("isCompleteMessageEndpoint %v, got: %v", isCompleteMessageEndpoint, sseServer.isCompleteMessageEndpoint)
 			}
 
 			if sseServer.baseURL != baseURL {


### PR DESCRIPTION


Because the implementation of java mcp sdk does not handle the problem of messageEndpoint returning CompleteMessageEndpoint URI when splicing messageEndpoint and base URL, it simply splices, resulting in the phenomenon of http://localhost/mcphttp://localhost/mcp/message.
In order to be compatible with it, I added a new parameter and kept the original logic unchanged to avoid affecting users who are already using it.

Here are the references:

https://github.com/modelcontextprotocol/java-sdk/releases/tag/v0.8.1

```java

public Mono<Void> sendMessage(McpSchema.JSONRPCMessage message) {
    if (this.isClosing) {
        return Mono.empty();
    } else {
        try {
            if (!this.closeLatch.await(10L, TimeUnit.SECONDS)) {
                return Mono.error(new McpError("Failed to wait for the message endpoint"));
            }
        } catch (InterruptedException var5) {
            return Mono.error(new McpError("Failed to wait for the message endpoint"));
        }

        String endpoint = (String)this.messageEndpoint.get();
        if (endpoint == null) {
            return Mono.error(new McpError("No message endpoint available"));
        } else {
            try {
                String jsonText = this.objectMapper.writeValueAsString(message);
                HttpRequest request = HttpRequest.newBuilder().uri(URI.create(this.baseUri + endpoint)).header("Content-Type", "application/json").POST(BodyPublishers.ofString(jsonText)).build();
                return Mono.fromFuture(this.httpClient.sendAsync(request, BodyHandlers.discarding()).thenAccept((response) -> {
                    if (response.statusCode() != 200 && response.statusCode() != 201 && response.statusCode() != 202 && response.statusCode() != 206) {
                        logger.error("Error sending message: {}", response.statusCode());
                    }

                }));
            } catch (IOException var6) {
                return !this.isClosing ? Mono.error(new RuntimeException("Failed to serialize message", var6)) : Mono.empty();
            }
        }
    }
}
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced server event handling with a flexible configuration option that now toggles between complete and standard message endpoints.
  - This update delivers more consistent and reliable server responses during event initialization and message processing.
- **Tests**
  - Introduced new test cases to validate the behavior of the SSE endpoint and the configuration of the message endpoint URL, ensuring expected responses and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->