### PR TITLE
feat: add NewToolResultError

### DIFF
--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -252,6 +252,20 @@ func NewToolResultResource(
 	}
 }
 
+// NewToolResultError creates a new CallToolResult with an error message.
+// Any errors that originate from the tool SHOULD be reported inside the result object.
+func NewToolResultError(text string) *CallToolResult {
+	return &CallToolResult{
+		Content: []Content{
+			TextContent{
+				Type: "text",
+				Text: text,
+			},
+		},
+		IsError: true,
+	}
+}
+
 // NewListResourcesResult creates a new ListResourcesResult
 func NewListResourcesResult(
 	resources []Resource,


### PR DESCRIPTION
Added the NewToolResultError method.
In MCP, when an error occurs during a tool invocation, it is defined that the error message should be included in the contents of the Result object, rather than as a protocol level error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a standardized error reporting capability to consistently display tool error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->