### PR TITLE
fix: change the default SSE endpoint to match the standard one used in the official servers

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -143,7 +143,7 @@ func NewSSEServer(server *MCPServer, opts ...SSEOption) *SSEServer {
 	s := &SSEServer{
 		server:                       server,
 		sseEndpoint:                  "/sse",
-		messageEndpoint:              "/message",
+		messageEndpoint:              "/messages",
 		useFullURLForMessageEndpoint: true,
 	}
 


### PR DESCRIPTION
This PR changes the default SSE endpoint to `messages` to match the standard one used in the official servers.

Fixes #71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated the messaging API endpoint from a singular to a pluralized path for improved clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->