### PR TITLE
make context available in hooks, add OnRegisterSession hook

### DIFF
--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -32,25 +32,25 @@ func NewMCPServer() *server.MCPServer {
 
 	hooks := &server.Hooks{}
 
-	hooks.AddBeforeAny(func(id any, method mcp.MCPMethod, message any) {
+	hooks.AddBeforeAny(func(ctx context.Context, id any, method mcp.MCPMethod, message any) {
 		fmt.Printf("beforeAny: %s, %v, %v\n", method, id, message)
 	})
-	hooks.AddOnSuccess(func(id any, method mcp.MCPMethod, message any, result any) {
+	hooks.AddOnSuccess(func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
 		fmt.Printf("onSuccess: %s, %v, %v, %v\n", method, id, message, result)
 	})
-	hooks.AddOnError(func(id any, method mcp.MCPMethod, message any, err error) {
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 		fmt.Printf("onError: %s, %v, %v, %v\n", method, id, message, err)
 	})
-	hooks.AddBeforeInitialize(func(id any, message *mcp.InitializeRequest) {
+	hooks.AddBeforeInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest) {
 		fmt.Printf("beforeInitialize: %v, %v\n", id, message)
 	})
-	hooks.AddAfterInitialize(func(id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
 		fmt.Printf("afterInitialize: %v, %v, %v\n", id, message, result)
 	})
-	hooks.AddAfterCallTool(func(id any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
+	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
 		fmt.Printf("afterCallTool: %v, %v, %v\n", id, message, result)
 	})
-	hooks.AddBeforeCallTool(func(id any, message *mcp.CallToolRequest) {
+	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
 		fmt.Printf("beforeCallTool: %v, %v\n", id, message)
 	})
 

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -3,16 +3,21 @@
 package server
 
 import (
+	"context"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+// OnRegisterSessionHookFunc is a hook that will be called when a new session is registered.
+type OnRegisterSessionHookFunc func(ctx context.Context, session ClientSession)
+
 // BeforeAnyHookFunc is a function that is called after the request is
 // parsed but before the method is called.
-type BeforeAnyHookFunc func(id any, method mcp.MCPMethod, message any)
+type BeforeAnyHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any)
 
 // OnSuccessHookFunc is a hook that will be called after the request
 // successfully generates a result, but before the result is sent to the client.
-type OnSuccessHookFunc func(id any, method mcp.MCPMethod, message any, result any)
+type OnSuccessHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any)
 
 // OnErrorHookFunc is a hook that will be called when an error occurs,
 // either during the request parsing or the method execution.
@@ -20,7 +25,7 @@ type OnSuccessHookFunc func(id any, method mcp.MCPMethod, message any, result an
 // Example usage:
 // ```
 //
-//	hooks.AddOnError(func(id any, method mcp.MCPMethod, message any, err error) {
+//	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 //	  // Check for specific error types using errors.Is
 //	  if errors.Is(err, ErrUnsupported) {
 //	    // Handle capability not supported errors
@@ -47,36 +52,37 @@ type OnSuccessHookFunc func(id any, method mcp.MCPMethod, message any, result an
 //	    log.Printf("Tool not found: %v", err)
 //	  }
 //	})
-type OnErrorHookFunc func(id any, method mcp.MCPMethod, message any, err error)
+type OnErrorHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error)
 
-type OnBeforeInitializeFunc func(id any, message *mcp.InitializeRequest)
-type OnAfterInitializeFunc func(id any, message *mcp.InitializeRequest, result *mcp.InitializeResult)
+type OnBeforeInitializeFunc func(ctx context.Context, id any, message *mcp.InitializeRequest)
+type OnAfterInitializeFunc func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult)
 
-type OnBeforePingFunc func(id any, message *mcp.PingRequest)
-type OnAfterPingFunc func(id any, message *mcp.PingRequest, result *mcp.EmptyResult)
+type OnBeforePingFunc func(ctx context.Context, id any, message *mcp.PingRequest)
+type OnAfterPingFunc func(ctx context.Context, id any, message *mcp.PingRequest, result *mcp.EmptyResult)
 
-type OnBeforeListResourcesFunc func(id any, message *mcp.ListResourcesRequest)
-type OnAfterListResourcesFunc func(id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult)
+type OnBeforeListResourcesFunc func(ctx context.Context, id any, message *mcp.ListResourcesRequest)
+type OnAfterListResourcesFunc func(ctx context.Context, id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult)
 
-type OnBeforeListResourceTemplatesFunc func(id any, message *mcp.ListResourceTemplatesRequest)
-type OnAfterListResourceTemplatesFunc func(id any, message *mcp.ListResourceTemplatesRequest, result *mcp.ListResourceTemplatesResult)
+type OnBeforeListResourceTemplatesFunc func(ctx context.Context, id any, message *mcp.ListResourceTemplatesRequest)
+type OnAfterListResourceTemplatesFunc func(ctx context.Context, id any, message *mcp.ListResourceTemplatesRequest, result *mcp.ListResourceTemplatesResult)
 
-type OnBeforeReadResourceFunc func(id any, message *mcp.ReadResourceRequest)
-type OnAfterReadResourceFunc func(id any, message *mcp.ReadResourceRequest, result *mcp.ReadResourceResult)
+type OnBeforeReadResourceFunc func(ctx context.Context, id any, message *mcp.ReadResourceRequest)
+type OnAfterReadResourceFunc func(ctx context.Context, id any, message *mcp.ReadResourceRequest, result *mcp.ReadResourceResult)
 
-type OnBeforeListPromptsFunc func(id any, message *mcp.ListPromptsRequest)
-type OnAfterListPromptsFunc func(id any, message *mcp.ListPromptsRequest, result *mcp.ListPromptsResult)
+type OnBeforeListPromptsFunc func(ctx context.Context, id any, message *mcp.ListPromptsRequest)
+type OnAfterListPromptsFunc func(ctx context.Context, id any, message *mcp.ListPromptsRequest, result *mcp.ListPromptsResult)
 
-type OnBeforeGetPromptFunc func(id any, message *mcp.GetPromptRequest)
-type OnAfterGetPromptFunc func(id any, message *mcp.GetPromptRequest, result *mcp.GetPromptResult)
+type OnBeforeGetPromptFunc func(ctx context.Context, id any, message *mcp.GetPromptRequest)
+type OnAfterGetPromptFunc func(ctx context.Context, id any, message *mcp.GetPromptRequest, result *mcp.GetPromptResult)
 
-type OnBeforeListToolsFunc func(id any, message *mcp.ListToolsRequest)
-type OnAfterListToolsFunc func(id any, message *mcp.ListToolsRequest, result *mcp.ListToolsResult)
+type OnBeforeListToolsFunc func(ctx context.Context, id any, message *mcp.ListToolsRequest)
+type OnAfterListToolsFunc func(ctx context.Context, id any, message *mcp.ListToolsRequest, result *mcp.ListToolsResult)
 
-type OnBeforeCallToolFunc func(id any, message *mcp.CallToolRequest)
-type OnAfterCallToolFunc func(id any, message *mcp.CallToolRequest, result *mcp.CallToolResult)
+type OnBeforeCallToolFunc func(ctx context.Context, id any, message *mcp.CallToolRequest)
+type OnAfterCallToolFunc func(ctx context.Context, id any, message *mcp.CallToolRequest, result *mcp.CallToolResult)
 
 type Hooks struct {
+	OnRegisterSession             []OnRegisterSessionHookFunc
 	OnBeforeAny                   []BeforeAnyHookFunc
 	OnSuccess                     []OnSuccessHookFunc
 	OnError                       []OnErrorHookFunc
@@ -120,7 +126,7 @@ func (c *Hooks) AddOnSuccess(hook OnSuccessHookFunc) {
 // // Register hook to capture and inspect errors
 // hooks := &Hooks{}
 //
-//	hooks.AddOnError(func(id any, method mcp.MCPMethod, message any, err error) {
+//	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 //	    // For capability-related errors
 //	    if errors.Is(err, ErrUnsupported) {
 //	        // Handle capability not supported
@@ -157,21 +163,21 @@ func (c *Hooks) AddOnError(hook OnErrorHookFunc) {
 	c.OnError = append(c.OnError, hook)
 }
 
-func (c *Hooks) beforeAny(id any, method mcp.MCPMethod, message any) {
+func (c *Hooks) beforeAny(ctx context.Context, id any, method mcp.MCPMethod, message any) {
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeAny {
-		hook(id, method, message)
+		hook(ctx, id, method, message)
 	}
 }
 
-func (c *Hooks) onSuccess(id any, method mcp.MCPMethod, message any, result any) {
+func (c *Hooks) onSuccess(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnSuccess {
-		hook(id, method, message, result)
+		hook(ctx, id, method, message, result)
 	}
 }
 
@@ -189,12 +195,25 @@ func (c *Hooks) onSuccess(id any, method mcp.MCPMethod, message any, result any)
 // - ErrResourceNotFound: When a resource is not found
 // - ErrPromptNotFound: When a prompt is not found
 // - ErrToolNotFound: When a tool is not found
-func (c *Hooks) onError(id any, method mcp.MCPMethod, message any, err error) {
+func (c *Hooks) onError(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnError {
-		hook(id, method, message, err)
+		hook(ctx, id, method, message, err)
+	}
+}
+
+func (c *Hooks) AddOnRegisterSession(hook OnRegisterSessionHookFunc) {
+	c.OnRegisterSession = append(c.OnRegisterSession, hook)
+}
+
+func (c *Hooks) RegisterSession(ctx context.Context, session ClientSession) {
+	if c == nil {
+		return
+	}
+	for _, hook := range c.OnRegisterSession {
+		hook(ctx, session)
 	}
 }
 func (c *Hooks) AddBeforeInitialize(hook OnBeforeInitializeFunc) {
@@ -205,23 +224,23 @@ func (c *Hooks) AddAfterInitialize(hook OnAfterInitializeFunc) {
 	c.OnAfterInitialize = append(c.OnAfterInitialize, hook)
 }
 
-func (c *Hooks) beforeInitialize(id any, message *mcp.InitializeRequest) {
-	c.beforeAny(id, mcp.MethodInitialize, message)
+func (c *Hooks) beforeInitialize(ctx context.Context, id any, message *mcp.InitializeRequest) {
+	c.beforeAny(ctx, id, mcp.MethodInitialize, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeInitialize {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterInitialize(id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
-	c.onSuccess(id, mcp.MethodInitialize, message, result)
+func (c *Hooks) afterInitialize(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
+	c.onSuccess(ctx, id, mcp.MethodInitialize, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterInitialize {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforePing(hook OnBeforePingFunc) {
@@ -232,23 +251,23 @@ func (c *Hooks) AddAfterPing(hook OnAfterPingFunc) {
 	c.OnAfterPing = append(c.OnAfterPing, hook)
 }
 
-func (c *Hooks) beforePing(id any, message *mcp.PingRequest) {
-	c.beforeAny(id, mcp.MethodPing, message)
+func (c *Hooks) beforePing(ctx context.Context, id any, message *mcp.PingRequest) {
+	c.beforeAny(ctx, id, mcp.MethodPing, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforePing {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterPing(id any, message *mcp.PingRequest, result *mcp.EmptyResult) {
-	c.onSuccess(id, mcp.MethodPing, message, result)
+func (c *Hooks) afterPing(ctx context.Context, id any, message *mcp.PingRequest, result *mcp.EmptyResult) {
+	c.onSuccess(ctx, id, mcp.MethodPing, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterPing {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforeListResources(hook OnBeforeListResourcesFunc) {
@@ -259,23 +278,23 @@ func (c *Hooks) AddAfterListResources(hook OnAfterListResourcesFunc) {
 	c.OnAfterListResources = append(c.OnAfterListResources, hook)
 }
 
-func (c *Hooks) beforeListResources(id any, message *mcp.ListResourcesRequest) {
-	c.beforeAny(id, mcp.MethodResourcesList, message)
+func (c *Hooks) beforeListResources(ctx context.Context, id any, message *mcp.ListResourcesRequest) {
+	c.beforeAny(ctx, id, mcp.MethodResourcesList, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeListResources {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterListResources(id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult) {
-	c.onSuccess(id, mcp.MethodResourcesList, message, result)
+func (c *Hooks) afterListResources(ctx context.Context, id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult) {
+	c.onSuccess(ctx, id, mcp.MethodResourcesList, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterListResources {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforeListResourceTemplates(hook OnBeforeListResourceTemplatesFunc) {
@@ -286,23 +305,23 @@ func (c *Hooks) AddAfterListResourceTemplates(hook OnAfterListResourceTemplatesF
 	c.OnAfterListResourceTemplates = append(c.OnAfterListResourceTemplates, hook)
 }
 
-func (c *Hooks) beforeListResourceTemplates(id any, message *mcp.ListResourceTemplatesRequest) {
-	c.beforeAny(id, mcp.MethodResourcesTemplatesList, message)
+func (c *Hooks) beforeListResourceTemplates(ctx context.Context, id any, message *mcp.ListResourceTemplatesRequest) {
+	c.beforeAny(ctx, id, mcp.MethodResourcesTemplatesList, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeListResourceTemplates {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterListResourceTemplates(id any, message *mcp.ListResourceTemplatesRequest, result *mcp.ListResourceTemplatesResult) {
-	c.onSuccess(id, mcp.MethodResourcesTemplatesList, message, result)
+func (c *Hooks) afterListResourceTemplates(ctx context.Context, id any, message *mcp.ListResourceTemplatesRequest, result *mcp.ListResourceTemplatesResult) {
+	c.onSuccess(ctx, id, mcp.MethodResourcesTemplatesList, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterListResourceTemplates {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforeReadResource(hook OnBeforeReadResourceFunc) {
@@ -313,23 +332,23 @@ func (c *Hooks) AddAfterReadResource(hook OnAfterReadResourceFunc) {
 	c.OnAfterReadResource = append(c.OnAfterReadResource, hook)
 }
 
-func (c *Hooks) beforeReadResource(id any, message *mcp.ReadResourceRequest) {
-	c.beforeAny(id, mcp.MethodResourcesRead, message)
+func (c *Hooks) beforeReadResource(ctx context.Context, id any, message *mcp.ReadResourceRequest) {
+	c.beforeAny(ctx, id, mcp.MethodResourcesRead, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeReadResource {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterReadResource(id any, message *mcp.ReadResourceRequest, result *mcp.ReadResourceResult) {
-	c.onSuccess(id, mcp.MethodResourcesRead, message, result)
+func (c *Hooks) afterReadResource(ctx context.Context, id any, message *mcp.ReadResourceRequest, result *mcp.ReadResourceResult) {
+	c.onSuccess(ctx, id, mcp.MethodResourcesRead, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterReadResource {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforeListPrompts(hook OnBeforeListPromptsFunc) {
@@ -340,23 +359,23 @@ func (c *Hooks) AddAfterListPrompts(hook OnAfterListPromptsFunc) {
 	c.OnAfterListPrompts = append(c.OnAfterListPrompts, hook)
 }
 
-func (c *Hooks) beforeListPrompts(id any, message *mcp.ListPromptsRequest) {
-	c.beforeAny(id, mcp.MethodPromptsList, message)
+func (c *Hooks) beforeListPrompts(ctx context.Context, id any, message *mcp.ListPromptsRequest) {
+	c.beforeAny(ctx, id, mcp.MethodPromptsList, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeListPrompts {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterListPrompts(id any, message *mcp.ListPromptsRequest, result *mcp.ListPromptsResult) {
-	c.onSuccess(id, mcp.MethodPromptsList, message, result)
+func (c *Hooks) afterListPrompts(ctx context.Context, id any, message *mcp.ListPromptsRequest, result *mcp.ListPromptsResult) {
+	c.onSuccess(ctx, id, mcp.MethodPromptsList, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterListPrompts {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforeGetPrompt(hook OnBeforeGetPromptFunc) {
@@ -367,23 +386,23 @@ func (c *Hooks) AddAfterGetPrompt(hook OnAfterGetPromptFunc) {
 	c.OnAfterGetPrompt = append(c.OnAfterGetPrompt, hook)
 }
 
-func (c *Hooks) beforeGetPrompt(id any, message *mcp.GetPromptRequest) {
-	c.beforeAny(id, mcp.MethodPromptsGet, message)
+func (c *Hooks) beforeGetPrompt(ctx context.Context, id any, message *mcp.GetPromptRequest) {
+	c.beforeAny(ctx, id, mcp.MethodPromptsGet, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeGetPrompt {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterGetPrompt(id any, message *mcp.GetPromptRequest, result *mcp.GetPromptResult) {
-	c.onSuccess(id, mcp.MethodPromptsGet, message, result)
+func (c *Hooks) afterGetPrompt(ctx context.Context, id any, message *mcp.GetPromptRequest, result *mcp.GetPromptResult) {
+	c.onSuccess(ctx, id, mcp.MethodPromptsGet, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterGetPrompt {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforeListTools(hook OnBeforeListToolsFunc) {
@@ -394,23 +413,23 @@ func (c *Hooks) AddAfterListTools(hook OnAfterListToolsFunc) {
 	c.OnAfterListTools = append(c.OnAfterListTools, hook)
 }
 
-func (c *Hooks) beforeListTools(id any, message *mcp.ListToolsRequest) {
-	c.beforeAny(id, mcp.MethodToolsList, message)
+func (c *Hooks) beforeListTools(ctx context.Context, id any, message *mcp.ListToolsRequest) {
+	c.beforeAny(ctx, id, mcp.MethodToolsList, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeListTools {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterListTools(id any, message *mcp.ListToolsRequest, result *mcp.ListToolsResult) {
-	c.onSuccess(id, mcp.MethodToolsList, message, result)
+func (c *Hooks) afterListTools(ctx context.Context, id any, message *mcp.ListToolsRequest, result *mcp.ListToolsResult) {
+	c.onSuccess(ctx, id, mcp.MethodToolsList, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterListTools {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 func (c *Hooks) AddBeforeCallTool(hook OnBeforeCallToolFunc) {
@@ -421,22 +440,22 @@ func (c *Hooks) AddAfterCallTool(hook OnAfterCallToolFunc) {
 	c.OnAfterCallTool = append(c.OnAfterCallTool, hook)
 }
 
-func (c *Hooks) beforeCallTool(id any, message *mcp.CallToolRequest) {
-	c.beforeAny(id, mcp.MethodToolsCall, message)
+func (c *Hooks) beforeCallTool(ctx context.Context, id any, message *mcp.CallToolRequest) {
+	c.beforeAny(ctx, id, mcp.MethodToolsCall, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeCallTool {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) afterCallTool(id any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
-	c.onSuccess(id, mcp.MethodToolsCall, message, result)
+func (c *Hooks) afterCallTool(ctx context.Context, id any, message *mcp.CallToolRequest, result *mcp.CallToolResult) {
+	c.onSuccess(ctx, id, mcp.MethodToolsCall, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfterCallTool {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }

--- a/server/internal/gen/hooks.go.tmpl
+++ b/server/internal/gen/hooks.go.tmpl
@@ -11,20 +11,24 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+// OnRegisterSessionHookFunc is a hook that will be called when a new session is registered.
+type OnRegisterSessionHookFunc func(ctx context.Context, session ClientSession)
+
+
 // BeforeAnyHookFunc is a function that is called after the request is
 // parsed but before the method is called.
-type BeforeAnyHookFunc func(id any, method mcp.MCPMethod, message any)
+type BeforeAnyHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any)
 
 // OnSuccessHookFunc is a hook that will be called after the request
 // successfully generates a result, but before the result is sent to the client.
-type OnSuccessHookFunc func(id any, method mcp.MCPMethod, message any, result any)
+type OnSuccessHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any)
 
 // OnErrorHookFunc is a hook that will be called when an error occurs,
 // either during the request parsing or the method execution.
 // 
 // Example usage:
 // ```
-// hooks.AddOnError(func(id any, method mcp.MCPMethod, message any, err error) {
+// hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 //   // Check for specific error types using errors.Is
 //   if errors.Is(err, ErrUnsupported) {
 //     // Handle capability not supported errors
@@ -51,14 +55,15 @@ type OnSuccessHookFunc func(id any, method mcp.MCPMethod, message any, result an
 //     log.Printf("Tool not found: %v", err)
 //   }
 // })
-type OnErrorHookFunc func(id any, method mcp.MCPMethod, message any, err error)
+type OnErrorHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error)
 
 {{range .}}
-type OnBefore{{.HookName}}Func func(id any, message *mcp.{{.ParamType}})
-type OnAfter{{.HookName}}Func func(id any, message *mcp.{{.ParamType}}, result *mcp.{{.ResultType}})
+type OnBefore{{.HookName}}Func func(ctx context.Context, id any, message *mcp.{{.ParamType}})
+type OnAfter{{.HookName}}Func func(ctx context.Context, id any, message *mcp.{{.ParamType}}, result *mcp.{{.ResultType}})
 {{end}}
 
 type Hooks struct {
+    OnRegisterSession []OnRegisterSessionHookFunc
 	OnBeforeAny      []BeforeAnyHookFunc
 	OnSuccess        []OnSuccessHookFunc
 	OnError          []OnErrorHookFunc
@@ -87,7 +92,7 @@ func (c *Hooks) AddOnSuccess(hook OnSuccessHookFunc) {
 // 
 // // Register hook to capture and inspect errors
 // hooks := &Hooks{}
-// hooks.AddOnError(func(id any, method mcp.MCPMethod, message any, err error) {
+// hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 //     // For capability-related errors
 //     if errors.Is(err, ErrUnsupported) {
 //         // Handle capability not supported
@@ -124,21 +129,21 @@ func (c *Hooks) AddOnError(hook OnErrorHookFunc) {
 	c.OnError = append(c.OnError, hook)
 }
 
-func (c *Hooks) beforeAny(id any, method mcp.MCPMethod, message any) {
+func (c *Hooks) beforeAny(ctx context.Context, id any, method mcp.MCPMethod, message any) {
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBeforeAny {
-		hook(id, method, message)
+		hook(ctx, id, method, message)
 	}
 }
 
-func (c *Hooks) onSuccess(id any, method mcp.MCPMethod, message any, result any) {
+func (c *Hooks) onSuccess(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnSuccess {
-		hook(id, method, message, result)
+		hook(ctx, id, method, message, result)
 	}
 }
 
@@ -156,13 +161,26 @@ func (c *Hooks) onSuccess(id any, method mcp.MCPMethod, message any, result any)
 // - ErrResourceNotFound: When a resource is not found
 // - ErrPromptNotFound: When a prompt is not found
 // - ErrToolNotFound: When a tool is not found
-func (c *Hooks) onError(id any, method mcp.MCPMethod, message any, err error) {
+func (c *Hooks) onError(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnError {
-		hook(id, method, message, err)
+		hook(ctx, id, method, message, err)
 	}
+}
+
+func (c *Hooks) AddOnRegisterSession(hook OnRegisterSessionHookFunc) {
+    c.OnRegisterSession = append(c.OnRegisterSession, hook)
+}
+
+func (c *Hooks) RegisterSession(ctx context.Context, session ClientSession) {
+    if c == nil {
+        return
+    }
+    for _, hook := range c.OnRegisterSession {
+        hook(ctx, session)
+    }
 }
 
 {{- range .}}
@@ -174,23 +192,23 @@ func (c *Hooks) AddAfter{{.HookName}}(hook OnAfter{{.HookName}}Func) {
 	c.OnAfter{{.HookName}} = append(c.OnAfter{{.HookName}}, hook)
 }
 
-func (c *Hooks) before{{.HookName}}(id any, message *mcp.{{.ParamType}}) {
-	c.beforeAny(id, mcp.{{.MethodName}}, message)
+func (c *Hooks) before{{.HookName}}(ctx context.Context, id any, message *mcp.{{.ParamType}}) {
+	c.beforeAny(ctx, id, mcp.{{.MethodName}}, message)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnBefore{{.HookName}} {
-		hook(id, message)
+		hook(ctx, id, message)
 	}
 }
 
-func (c *Hooks) after{{.HookName}}(id any, message *mcp.{{.ParamType}}, result *mcp.{{.ResultType}}) {
-	c.onSuccess(id, mcp.{{.MethodName}}, message, result)
+func (c *Hooks) after{{.HookName}}(ctx context.Context, id any, message *mcp.{{.ParamType}}, result *mcp.{{.ResultType}}) {
+	c.onSuccess(ctx, id, mcp.{{.MethodName}}, message, result)
 	if c == nil {
 		return
 	}
 	for _, hook := range c.OnAfter{{.HookName}} {
-		hook(id, message, result)
+		hook(ctx, id, message, result)
 	}
 }
 {{- end -}}

--- a/server/internal/gen/request_handler.go.tmpl
+++ b/server/internal/gen/request_handler.go.tmpl
@@ -74,14 +74,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.before{{.HookName}}(baseMessage.ID, &request)
+			s.hooks.before{{.HookName}}(ctx, baseMessage.ID, &request)
 			result, err = s.{{.HandlerFunc}}(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.after{{.HookName}}(baseMessage.ID, &request, result)
+		s.hooks.after{{.HookName}}(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	{{- end }}
 	default:

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -66,14 +66,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeInitialize(baseMessage.ID, &request)
+			s.hooks.beforeInitialize(ctx, baseMessage.ID, &request)
 			result, err = s.handleInitialize(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterInitialize(baseMessage.ID, &request, result)
+		s.hooks.afterInitialize(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodPing:
 		var request mcp.PingRequest
@@ -85,14 +85,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforePing(baseMessage.ID, &request)
+			s.hooks.beforePing(ctx, baseMessage.ID, &request)
 			result, err = s.handlePing(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterPing(baseMessage.ID, &request, result)
+		s.hooks.afterPing(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodResourcesList:
 		var request mcp.ListResourcesRequest
@@ -110,14 +110,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeListResources(baseMessage.ID, &request)
+			s.hooks.beforeListResources(ctx, baseMessage.ID, &request)
 			result, err = s.handleListResources(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterListResources(baseMessage.ID, &request, result)
+		s.hooks.afterListResources(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodResourcesTemplatesList:
 		var request mcp.ListResourceTemplatesRequest
@@ -135,14 +135,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeListResourceTemplates(baseMessage.ID, &request)
+			s.hooks.beforeListResourceTemplates(ctx, baseMessage.ID, &request)
 			result, err = s.handleListResourceTemplates(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterListResourceTemplates(baseMessage.ID, &request, result)
+		s.hooks.afterListResourceTemplates(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodResourcesRead:
 		var request mcp.ReadResourceRequest
@@ -160,14 +160,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeReadResource(baseMessage.ID, &request)
+			s.hooks.beforeReadResource(ctx, baseMessage.ID, &request)
 			result, err = s.handleReadResource(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterReadResource(baseMessage.ID, &request, result)
+		s.hooks.afterReadResource(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodPromptsList:
 		var request mcp.ListPromptsRequest
@@ -185,14 +185,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeListPrompts(baseMessage.ID, &request)
+			s.hooks.beforeListPrompts(ctx, baseMessage.ID, &request)
 			result, err = s.handleListPrompts(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterListPrompts(baseMessage.ID, &request, result)
+		s.hooks.afterListPrompts(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodPromptsGet:
 		var request mcp.GetPromptRequest
@@ -210,14 +210,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeGetPrompt(baseMessage.ID, &request)
+			s.hooks.beforeGetPrompt(ctx, baseMessage.ID, &request)
 			result, err = s.handleGetPrompt(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterGetPrompt(baseMessage.ID, &request, result)
+		s.hooks.afterGetPrompt(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodToolsList:
 		var request mcp.ListToolsRequest
@@ -235,14 +235,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeListTools(baseMessage.ID, &request)
+			s.hooks.beforeListTools(ctx, baseMessage.ID, &request)
 			result, err = s.handleListTools(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterListTools(baseMessage.ID, &request, result)
+		s.hooks.afterListTools(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodToolsCall:
 		var request mcp.CallToolRequest
@@ -260,14 +260,14 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparseableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			s.hooks.beforeCallTool(baseMessage.ID, &request)
+			s.hooks.beforeCallTool(ctx, baseMessage.ID, &request)
 			result, err = s.handleToolCall(ctx, baseMessage.ID, request)
 		}
 		if err != nil {
-			s.hooks.onError(baseMessage.ID, baseMessage.Method, &request, err)
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
 			return err.ToJSONRPCError()
 		}
-		s.hooks.afterCallTool(baseMessage.ID, &request, result)
+		s.hooks.afterCallTool(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
 	default:
 		return createErrorResponse(

--- a/server/server.go
+++ b/server/server.go
@@ -172,12 +172,14 @@ func (s *MCPServer) WithContext(
 
 // RegisterSession saves session that should be notified in case if some server attributes changed.
 func (s *MCPServer) RegisterSession(
+	ctx context.Context,
 	session ClientSession,
 ) error {
 	sessionID := session.SessionID()
 	if _, exists := s.sessions.LoadOrStore(sessionID, session); exists {
 		return fmt.Errorf("session %s is already registered", sessionID)
 	}
+	s.hooks.RegisterSession(ctx, session)
 	return nil
 }
 

--- a/server/sse.go
+++ b/server/sse.go
@@ -216,7 +216,7 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	s.sessions.Store(sessionID, session)
 	defer s.sessions.Delete(sessionID)
 
-	if err := s.server.RegisterSession(session); err != nil {
+	if err := s.server.RegisterSession(r.Context(), session); err != nil {
 		http.Error(w, fmt.Sprintf("Session registration failed: %v", err), http.StatusInternalServerError)
 		return
 	}

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -191,7 +191,7 @@ func (s *StdioServer) Listen(
 	stdout io.Writer,
 ) error {
 	// Set a static client context since stdio only has one client
-	if err := s.server.RegisterSession(&stdioSessionInstance); err != nil {
+	if err := s.server.RegisterSession(ctx, &stdioSessionInstance); err != nil {
 		return fmt.Errorf("register session: %w", err)
 	}
 	defer s.server.UnregisterSession(stdioSessionInstance.SessionID())


### PR DESCRIPTION
Hi,

I wanted to make use of the sessionId generated by the McpServer to manage my own session data. The issue I was facing was, I could not get the sessionId from the `/sse` route and correlate to the message's sessionId. Also, I had no way of accessing the session information in the hooks.  `SSEContextFunc` combined with `OnRegisterSession` will allow us to connect the initial `/sse` session to all messages outside the library.
I think `context` should be available on all hooks to trace it back to the request which may  contain context information added by upstream http middlewares.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an enhanced client session hook to improve session registration and handling.

- **Refactor**
  - Standardized context propagation across core server operations, improving request cancellation, deadline management, and error reporting.
  - Enhanced the message processing and session management workflows for increased stability and responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->