### PR TITLE
fix: mcp-client should also include configurable http headers in the /sse request

### DIFF
--- a/client/sse.go
+++ b/client/sse.go
@@ -93,6 +93,9 @@ func (c *SSEMCPClient) Start(ctx context.Context) error {
 	req.Header.Set("Accept", "text/event-stream")
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION

fix: mcp-client should also include configurable http headers in the /sse request 

reasons
- In the official python sdk, custom headers can also take effect on the /sse API
- In some scenarios, /sse also requires these http header parameters, such as authentication, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced streaming connections by supporting additional custom HTTP headers for improved request customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->