### PR TITLE
fix(tools): add `omitempty` to properties

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -105,7 +105,7 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 
 type ToolInputSchema struct {
 	Type       string                 `json:"type"`
-	Properties map[string]interface{} `json:"properties"`
+	Properties map[string]interface{} `json:"properties,omitempty"`
 	Required   []string               `json:"required,omitempty"`
 }
 


### PR DESCRIPTION
When there is no input to a tool, the `Properies` map is `nil` if the Tool is not created using `NewTool`. This causes the `property` field to be set to `null` and clients such as `claude-desktop` to skip the tools silently.

Annotating the field as `omitempty` is inline with the behavior of the [typescript-sdk](https://github.com/modelcontextprotocol/typescript-sdk/blob/fbdeb06a4185ba2f7581603a768cd7171c64d6fc/src/types.ts#L749).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved JSON responses by omitting empty data fields, resulting in cleaner and more concise outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->