### PR TITLE
feat(client): HTTP Headers Support for SSE MCP Client at Start

### DIFF
--- a/client/sse.go
+++ b/client/sse.go
@@ -58,6 +58,15 @@ func WithSSEReadTimeout(timeout time.Duration) ClientOption {
 
 // NewSSEMCPClient creates a new SSE-based MCP client with the given base URL.
 // Returns an error if the URL is invalid.
+// Example:
+//
+//	// Create a client with authentication headers
+//	client, err := NewSSEMCPClient(
+//	    "https://mcp.example.com",
+//	    WithHeaders(map[string]string{
+//	        "Authorization": "Bearer your-token-here",
+//	    }),
+//	)
 func NewSSEMCPClient(baseURL string, options ...ClientOption) (*SSEMCPClient, error) {
 	parsedURL, err := url.Parse(baseURL)
 	if err != nil {
@@ -97,7 +106,7 @@ func (c *SSEMCPClient) Start(ctx context.Context) error {
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
 
-	// set custom http headers
+	// Set custom http headers
 	for k, v := range c.headers {
 		// Skip standard headers that should not be overridden
 		switch k {
@@ -314,7 +323,7 @@ func (c *SSEMCPClient) sendRequest(
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	// set custom http headers
+	// Set custom http headers
 	for k, v := range c.headers {
 		// Skip standard headers that should not be overridden
 		switch k {
@@ -409,8 +418,13 @@ func (c *SSEMCPClient) Initialize(
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	// set custom http headers
+	// Set custom http headers
 	for k, v := range c.headers {
+		// Skip standard headers that should not be overridden
+		switch k {
+		case "Accept", "Cache-Control", "Connection", "Content-Type":
+			continue
+		}
 		req.Header.Set(k, v)
 	}
 

--- a/client/sse.go
+++ b/client/sse.go
@@ -94,6 +94,11 @@ func (c *SSEMCPClient) Start(ctx context.Context) error {
 	req.Header.Set("Cache-Control", "no-cache")
 	req.Header.Set("Connection", "keep-alive")
 
+	// set custom http headers
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to connect to SSE stream: %w", err)

--- a/client/sse.go
+++ b/client/sse.go
@@ -41,6 +41,9 @@ type SSEMCPClient struct {
 
 type ClientOption func(*SSEMCPClient)
 
+// WithHeaders sets custom HTTP headers that will be included in all requests made by the client.
+// This is particularly useful for authentication (e.g., bearer tokens, API keys) and other
+// custom header requirements.
 func WithHeaders(headers map[string]string) ClientOption {
 	return func(sc *SSEMCPClient) {
 		sc.headers = headers
@@ -96,6 +99,11 @@ func (c *SSEMCPClient) Start(ctx context.Context) error {
 
 	// set custom http headers
 	for k, v := range c.headers {
+		// Skip standard headers that should not be overridden
+		switch k {
+		case "Accept", "Cache-Control", "Connection", "Content-Type":
+			continue
+		}
 		req.Header.Set(k, v)
 	}
 
@@ -308,6 +316,11 @@ func (c *SSEMCPClient) sendRequest(
 	req.Header.Set("Content-Type", "application/json")
 	// set custom http headers
 	for k, v := range c.headers {
+		// Skip standard headers that should not be overridden
+		switch k {
+		case "Accept", "Cache-Control", "Connection", "Content-Type":
+			continue
+		}
 		req.Header.Set(k, v)
 	}
 
@@ -396,6 +409,10 @@ func (c *SSEMCPClient) Initialize(
 	}
 
 	req.Header.Set("Content-Type", "application/json")
+	// set custom http headers
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
### Overview
This change implements custom HTTP headers support for the SSE MCP Client into the `Start` method of the SSE client, particularly useful for **authentication scenarios** with bearer token.

### Changes Made
- Added ability to set custom HTTP headers when creating a new SSE MCP Client
- Implementation through a simple map of string key-value pairs

### Example Usage
To create a client with authentication:
```golang
mcpClient, err := client.NewSSEMCPClient(
    baseURL + "/sse",
    client.WithHeaders(map[string]string{
        "Authorization": "Bearer " + bearerToken,
    }),
)
```

### Benefits
- Simple Implementation
- Flexibility: Supports any custom HTTP headers, not just authentication

### Use Cases
- **Bearer token authentication**
- API key authentication
- Custom headers for proxies
- Session tracking
- Client identification

This change makes the SSE MCP Client more versatile by supporting authenticated connections while maintaining a clean and simple API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved the server connection process by enabling the use of custom HTTP headers during setup, allowing for enhanced and more flexible interactions with the server.
  - Added a method to set custom HTTP headers for all requests made by the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->