### PR TITLE
feat: Tool Handler Middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ func main() {
         "1.0.0",
         server.WithResourceCapabilities(true, true),
         server.WithLogging(),
+        server.WithRecovery(),
     )
 
     // Add a calculator tool

--- a/README.md
+++ b/README.md
@@ -523,6 +523,12 @@ initialization.
 Add the `Hooks` to the server at the time of creation using the
 `server.WithHooks` option.
 
+### Tool Handler Middleware
+
+Add middleware to tool call handlers using the `server.WithToolHandlerMiddleware` option. Middlewares can be registered on server creation and are applied on every tool call.
+
+A recovery middleware option is available to recover from panics in a tool call and can be added to the server with the `server.WithRecovery` option.
+
 ## Contributing
 
 <details>


### PR DESCRIPTION
While trying out [mcp host](https://github.com/mark3labs/mcphost) with model `--model ollama:llama3.2:latest` and the mcp calculator server example, I noticed the tool call sometimes gets stuck. After some investigation, I figured out that the values of x and y are sometimes received as `string` instead of `float64`.

Because of this, the `toolHandlerFunc` in the server will panic (as the type cast is not being checked in the example) and the client will hang until the context times out.

From a client perspective it's hard to figure out what is going on when a toolHandlerFunc panics, as it [waits until it receives a message](https://github.com/mark3labs/mcp-go/blob/main/client/stdio.go#L153) where an ID is set.

I think this issue might be related as well: https://github.com/mark3labs/mcphost/issues/11

In order to address this, this PR adds a `ToolHandlerMiddlware` which can be added via the `ServerOption`.

This PR includes:
- A `WithToolHandlerMiddleware` option to add toolHandler middlewares
- A `WithRecovery` option to let the server recover from panics in toolHandler function calls
- A section in the README describing how to use toolHandlerMiddlewares
- A recovery option in the calculator example 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced recovery middleware for enhanced error handling during tool calls.
  - Added a new section on tool handler middleware in documentation.
- **Documentation**
  - Updated README to include details on new middleware options for improved server resilience.
- **Tests**
  - Added tests to ensure the server recovers gracefully from panics in tool handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->