### PR TITLE
feat: support go1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mark3labs/mcp-go
 
-go 1.23
+go 1.18
 
 require (
 	github.com/google/uuid v1.6.0

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -208,7 +208,7 @@ func TestMCPServer_Tools(t *testing.T) {
 		{
 			name: "SetTools sends single notifications/tools/list_changed per each active session",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				for i := range 5 {
+				for i := 0; i < 5; i++ {
 					err := server.RegisterSession(context.TODO(), &fakeSession{
 						sessionID:           fmt.Sprintf("test%d", i),
 						notificationChannel: notificationChannel,
@@ -217,7 +217,7 @@ func TestMCPServer_Tools(t *testing.T) {
 					require.NoError(t, err)
 				}
 				// also let's register inactive sessions
-				for i := range 5 {
+				for i := 0; i < 5; i++ {
 					err := server.RegisterSession(context.TODO(), &fakeSession{
 						sessionID:           fmt.Sprintf("test%d", i+5),
 						notificationChannel: notificationChannel,
@@ -527,12 +527,12 @@ func TestMCPServer_SendNotificationToClient(t *testing.T) {
 				})
 			},
 			validate: func(t *testing.T, ctx context.Context, srv *MCPServer) {
-				for range 10 {
+				for i := 0; i < 10; i++ {
 					require.NoError(t, srv.SendNotificationToClient(ctx, "method", nil))
 				}
 				session, ok := ClientSessionFromContext(ctx).(fakeSession)
 				require.True(t, ok, "session not found or of incorrect type")
-				for range 10 {
+				for i := 0; i < 10; i++ {
 					select {
 					case record := <-session.notificationChannel:
 						assert.Equal(t, "method", record.Method)


### PR DESCRIPTION
Hi! I'm wondering if maybe the package can support even a lower go version such as go1.18 so I forked the repo and tested by myself. It seems fine (passed all tests) after I modified the go version and did some minor changes (for i := range 5 is supported > go1.22 so I changed it back to the old school way). Looking forward to receiving suggestions / comments. If you guys don't think it's necessary to downgrade to 1.18 then I can simply use the forked one in my project. (Sorry, my project is a very old one still using 1.18)

The test output as following
```
@HChengH ➜ /workspaces/mcp-go (feat/support1.18) $ go test -v './...'
go: downloading github.com/yosida95/uritemplate/v3 v3.0.2
go: downloading github.com/stretchr/testify v1.9.0
go: downloading github.com/google/uuid v1.6.0
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.1
=== RUN   TestSSEMCPClient
=== RUN   TestSSEMCPClient/Can_create_client
=== RUN   TestSSEMCPClient/Can_initialize_and_make_requests
=== RUN   TestSSEMCPClient/Handles_errors_properly
=== RUN   TestSSEMCPClient/CallTool
--- PASS: TestSSEMCPClient (0.01s)
    --- PASS: TestSSEMCPClient/Can_create_client (0.00s)
    --- PASS: TestSSEMCPClient/Can_initialize_and_make_requests (0.01s)
    --- PASS: TestSSEMCPClient/Handles_errors_properly (0.00s)
    --- PASS: TestSSEMCPClient/CallTool (0.00s)
=== RUN   TestStdioMCPClient
=== RUN   TestStdioMCPClient/Initialize
=== RUN   TestStdioMCPClient/Ping
=== RUN   TestStdioMCPClient/ListResources
=== RUN   TestStdioMCPClient/ReadResource
=== RUN   TestStdioMCPClient/Subscribe_and_Unsubscribe
=== RUN   TestStdioMCPClient/ListPrompts
=== RUN   TestStdioMCPClient/GetPrompt
=== RUN   TestStdioMCPClient/ListTools
=== RUN   TestStdioMCPClient/CallTool
=== RUN   TestStdioMCPClient/SetLevel
=== RUN   TestStdioMCPClient/Complete
=== RUN   TestStdioMCPClient/CheckLogs
--- PASS: TestStdioMCPClient (0.25s)
    --- PASS: TestStdioMCPClient/Initialize (0.00s)
    --- PASS: TestStdioMCPClient/Ping (0.00s)
    --- PASS: TestStdioMCPClient/ListResources (0.00s)
    --- PASS: TestStdioMCPClient/ReadResource (0.00s)
    --- PASS: TestStdioMCPClient/Subscribe_and_Unsubscribe (0.00s)
    --- PASS: TestStdioMCPClient/ListPrompts (0.00s)
    --- PASS: TestStdioMCPClient/GetPrompt (0.00s)
    --- PASS: TestStdioMCPClient/ListTools (0.00s)
    --- PASS: TestStdioMCPClient/CallTool (0.00s)
    --- PASS: TestStdioMCPClient/SetLevel (0.00s)
    --- PASS: TestStdioMCPClient/Complete (0.00s)
    --- PASS: TestStdioMCPClient/CheckLogs (0.00s)
PASS
ok      github.com/mark3labs/mcp-go/client      0.268s
?       github.com/mark3labs/mcp-go/examples/custom_context     [no test files]
?       github.com/mark3labs/mcp-go/examples/everything [no test files]
?       github.com/mark3labs/mcp-go/examples/filesystem_stdio_client    [no test files]
=== RUN   TestToolWithBothSchemasError
--- PASS: TestToolWithBothSchemasError (0.00s)
=== RUN   TestToolWithRawSchema
--- PASS: TestToolWithRawSchema (0.00s)
=== RUN   TestUnmarshalToolWithRawSchema
--- PASS: TestUnmarshalToolWithRawSchema (0.00s)
=== RUN   TestUnmarshalToolWithoutRawSchema
--- PASS: TestUnmarshalToolWithoutRawSchema (0.00s)
=== RUN   TestToolWithObjectAndArray
--- PASS: TestToolWithObjectAndArray (0.00s)
PASS
ok      github.com/mark3labs/mcp-go/mcp 0.004s
=== RUN   TestMCPServer_NewMCPServer
--- PASS: TestMCPServer_NewMCPServer (0.00s)
=== RUN   TestMCPServer_Capabilities
=== RUN   TestMCPServer_Capabilities/No_capabilities
=== RUN   TestMCPServer_Capabilities/All_capabilities
=== RUN   TestMCPServer_Capabilities/Specific_capabilities
--- PASS: TestMCPServer_Capabilities (0.00s)
    --- PASS: TestMCPServer_Capabilities/No_capabilities (0.00s)
    --- PASS: TestMCPServer_Capabilities/All_capabilities (0.00s)
    --- PASS: TestMCPServer_Capabilities/Specific_capabilities (0.00s)
=== RUN   TestMCPServer_Tools
=== RUN   TestMCPServer_Tools/SetTools_sends_no_notifications/tools/list_changed_without_active_sessions
=== RUN   TestMCPServer_Tools/SetTools_sends_single_notifications/tools/list_changed_with_one_active_session
=== RUN   TestMCPServer_Tools/SetTools_sends_single_notifications/tools/list_changed_per_each_active_session
=== RUN   TestMCPServer_Tools/AddTool_sends_multiple_notifications/tools/list_changed
=== RUN   TestMCPServer_Tools/DeleteTools_sends_single_notifications/tools/list_changed
--- PASS: TestMCPServer_Tools (1.00s)
    --- PASS: TestMCPServer_Tools/SetTools_sends_no_notifications/tools/list_changed_without_active_sessions (1.00s)
    --- PASS: TestMCPServer_Tools/SetTools_sends_single_notifications/tools/list_changed_with_one_active_session (0.00s)
    --- PASS: TestMCPServer_Tools/SetTools_sends_single_notifications/tools/list_changed_per_each_active_session (0.00s)
    --- PASS: TestMCPServer_Tools/AddTool_sends_multiple_notifications/tools/list_changed (0.00s)
    --- PASS: TestMCPServer_Tools/DeleteTools_sends_single_notifications/tools/list_changed (0.00s)
=== RUN   TestMCPServer_HandleValidMessages
=== RUN   TestMCPServer_HandleValidMessages/Initialize_request
=== RUN   TestMCPServer_HandleValidMessages/Ping_request
=== RUN   TestMCPServer_HandleValidMessages/List_resources
--- PASS: TestMCPServer_HandleValidMessages (0.00s)
    --- PASS: TestMCPServer_HandleValidMessages/Initialize_request (0.00s)
    --- PASS: TestMCPServer_HandleValidMessages/Ping_request (0.00s)
    --- PASS: TestMCPServer_HandleValidMessages/List_resources (0.00s)
=== RUN   TestMCPServer_HandlePagination
=== RUN   TestMCPServer_HandlePagination/List_resources_with_cursor
--- PASS: TestMCPServer_HandlePagination (0.00s)
    --- PASS: TestMCPServer_HandlePagination/List_resources_with_cursor (0.00s)
=== RUN   TestMCPServer_HandleNotifications
--- PASS: TestMCPServer_HandleNotifications (0.00s)
=== RUN   TestMCPServer_SendNotificationToClient
=== RUN   TestMCPServer_SendNotificationToClient/no_active_session
=== RUN   TestMCPServer_SendNotificationToClient/uninit_session
=== RUN   TestMCPServer_SendNotificationToClient/active_session
=== RUN   TestMCPServer_SendNotificationToClient/session_with_blocked_channel
--- PASS: TestMCPServer_SendNotificationToClient (0.00s)
    --- PASS: TestMCPServer_SendNotificationToClient/no_active_session (0.00s)
    --- PASS: TestMCPServer_SendNotificationToClient/uninit_session (0.00s)
    --- PASS: TestMCPServer_SendNotificationToClient/active_session (0.00s)
    --- PASS: TestMCPServer_SendNotificationToClient/session_with_blocked_channel (0.00s)
=== RUN   TestMCPServer_PromptHandling
=== RUN   TestMCPServer_PromptHandling/List_prompts
=== RUN   TestMCPServer_PromptHandling/Get_prompt
=== RUN   TestMCPServer_PromptHandling/Get_prompt_with_missing_argument
--- PASS: TestMCPServer_PromptHandling (0.00s)
    --- PASS: TestMCPServer_PromptHandling/List_prompts (0.00s)
    --- PASS: TestMCPServer_PromptHandling/Get_prompt (0.00s)
    --- PASS: TestMCPServer_PromptHandling/Get_prompt_with_missing_argument (0.00s)
=== RUN   TestMCPServer_HandleInvalidMessages
=== RUN   TestMCPServer_HandleInvalidMessages/Invalid_JSON
=== RUN   TestMCPServer_HandleInvalidMessages/Invalid_method
=== RUN   TestMCPServer_HandleInvalidMessages/Invalid_parameters
=== RUN   TestMCPServer_HandleInvalidMessages/Missing_JSONRPC_version
--- PASS: TestMCPServer_HandleInvalidMessages (0.00s)
    --- PASS: TestMCPServer_HandleInvalidMessages/Invalid_JSON (0.00s)
    --- PASS: TestMCPServer_HandleInvalidMessages/Invalid_method (0.00s)
    --- PASS: TestMCPServer_HandleInvalidMessages/Invalid_parameters (0.00s)
    --- PASS: TestMCPServer_HandleInvalidMessages/Missing_JSONRPC_version (0.00s)
=== RUN   TestMCPServer_HandleUndefinedHandlers
=== RUN   TestMCPServer_HandleUndefinedHandlers/Undefined_tool
=== RUN   TestMCPServer_HandleUndefinedHandlers/Undefined_prompt
=== RUN   TestMCPServer_HandleUndefinedHandlers/Undefined_resource
--- PASS: TestMCPServer_HandleUndefinedHandlers (0.00s)
    --- PASS: TestMCPServer_HandleUndefinedHandlers/Undefined_tool (0.00s)
    --- PASS: TestMCPServer_HandleUndefinedHandlers/Undefined_prompt (0.00s)
    --- PASS: TestMCPServer_HandleUndefinedHandlers/Undefined_resource (0.00s)
=== RUN   TestMCPServer_HandleMethodsWithoutCapabilities
=== RUN   TestMCPServer_HandleMethodsWithoutCapabilities/Tools_without_capabilities
=== RUN   TestMCPServer_HandleMethodsWithoutCapabilities/Prompts_without_capabilities
=== RUN   TestMCPServer_HandleMethodsWithoutCapabilities/Resources_without_capabilities
--- PASS: TestMCPServer_HandleMethodsWithoutCapabilities (0.00s)
    --- PASS: TestMCPServer_HandleMethodsWithoutCapabilities/Tools_without_capabilities (0.00s)
    --- PASS: TestMCPServer_HandleMethodsWithoutCapabilities/Prompts_without_capabilities (0.00s)
    --- PASS: TestMCPServer_HandleMethodsWithoutCapabilities/Resources_without_capabilities (0.00s)
=== RUN   TestMCPServer_Instructions
=== RUN   TestMCPServer_Instructions/No_instructions
=== RUN   TestMCPServer_Instructions/With_instructions
=== RUN   TestMCPServer_Instructions/With_multiline_instructions
--- PASS: TestMCPServer_Instructions (0.00s)
    --- PASS: TestMCPServer_Instructions/No_instructions (0.00s)
    --- PASS: TestMCPServer_Instructions/With_instructions (0.00s)
    --- PASS: TestMCPServer_Instructions/With_multiline_instructions (0.00s)
=== RUN   TestMCPServer_ResourceTemplates
=== RUN   TestMCPServer_ResourceTemplates/Get_resource_template
--- PASS: TestMCPServer_ResourceTemplates (0.00s)
    --- PASS: TestMCPServer_ResourceTemplates/Get_resource_template (0.00s)
=== RUN   TestMCPServer_WithHooks
--- PASS: TestMCPServer_WithHooks (0.00s)
=== RUN   TestSSEServer
=== RUN   TestSSEServer/Can_instantiate
=== RUN   TestSSEServer/Can_send_and_receive_messages
=== RUN   TestSSEServer/Can_handle_multiple_sessions
=== RUN   TestSSEServer/Can_be_used_as_http.Handler
=== RUN   TestSSEServer/Works_with_middleware
=== RUN   TestSSEServer/Works_with_custom_mux
=== RUN   TestSSEServer/test_useFullURLForMessageEndpoint
=== RUN   TestSSEServer/works_as_http.Handler_with_custom_basePath
=== RUN   TestSSEServer/Can_use_a_custom_context_function
=== RUN   TestSSEServer/SSEOption_should_not_have_negative_effects_when_used_repeatedly_but_should_always_remain_consistent.
--- PASS: TestSSEServer (0.33s)
    --- PASS: TestSSEServer/Can_instantiate (0.00s)
    --- PASS: TestSSEServer/Can_send_and_receive_messages (0.01s)
    --- PASS: TestSSEServer/Can_handle_multiple_sessions (0.00s)
    --- PASS: TestSSEServer/Can_be_used_as_http.Handler (0.10s)
    --- PASS: TestSSEServer/Works_with_middleware (0.10s)
    --- PASS: TestSSEServer/Works_with_custom_mux (0.00s)
    --- PASS: TestSSEServer/test_useFullURLForMessageEndpoint (0.00s)
    --- PASS: TestSSEServer/works_as_http.Handler_with_custom_basePath (0.10s)
    --- PASS: TestSSEServer/Can_use_a_custom_context_function (0.00s)
    --- PASS: TestSSEServer/SSEOption_should_not_have_negative_effects_when_used_repeatedly_but_should_always_remain_consistent. (0.00s)
=== RUN   TestStdioServer
=== RUN   TestStdioServer/Can_instantiate
=== RUN   TestStdioServer/Can_send_and_receive_messages
=== RUN   TestStdioServer/Can_use_a_custom_context_function
--- PASS: TestStdioServer (0.00s)
    --- PASS: TestStdioServer/Can_instantiate (0.00s)
    --- PASS: TestStdioServer/Can_send_and_receive_messages (0.00s)
    --- PASS: TestStdioServer/Can_use_a_custom_context_function (0.00s)
PASS
ok      github.com/mark3labs/mcp-go/server      1.336s
?       github.com/mark3labs/mcp-go/server/internal/gen [no test files]
@HChengH ➜ /workspaces/mcp-go (feat/support1.18) $ 
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the build configuration to require Go 1.18, ensuring compatibility with supported versions.
  
- **Tests**
	- Refined test iteration patterns for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->