### PR TITLE
fix: prevent SSEServer.Start() from overriding http server

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -170,9 +170,11 @@ func NewTestServer(server *MCPServer, opts ...SSEOption) *httptest.Server {
 // Start begins serving SSE connections on the specified address.
 // It sets up HTTP handlers for SSE and message endpoints.
 func (s *SSEServer) Start(addr string) error {
-	s.srv = &http.Server{
-		Addr:    addr,
-		Handler: s,
+	if s.srv == nil {
+		s.srv = &http.Server{
+			Addr:    addr,
+			Handler: s,
+		}
 	}
 
 	return s.srv.ListenAndServe()


### PR DESCRIPTION
`s.srv` can be set via `WithHTTPServer`. so if we end up using `WithHTTPServer` and _then_ invoke `Start`, `s.srv` will be overwritten

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the server's startup process to ensure a single, stable initialization, preventing issues when starting the service multiple times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->