### PR TITLE
fix(client): allow interface to be implemented

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -108,13 +108,17 @@ type MCPClient interface {
 
 	// OnNotification registers a handler for notifications
 	OnNotification(handler func(notification mcp.JSONRPCNotification))
+}
+
+type mcpClient interface {
+	MCPClient
 
 	sendRequest(ctx context.Context, method string, params interface{}) (*json.RawMessage, error)
 }
 
 func listByPage[T any](
 	ctx context.Context,
-	client MCPClient,
+	client mcpClient,
 	request mcp.PaginatedRequest,
 	method string,
 ) (*T, error) {


### PR DESCRIPTION
The addition of the unexported `sendRequest` method prevents external packages from implmenting the `MCPClient` interface. Since it is only used by the unexported `listByPage`, create an unexported `mcpClient` interface, which embeds the exported `MCPClient` as well as the `sendRequest` method.

Add build time checking that internal implementations implement the unexported interface.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced backend communication to support more robust request handling.
  - Improved internal operations while maintaining the current user experience and preparing for future enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->