### PR TITLE
feat(SSEServer): add WithAppendQueryToMessageEndpoint()

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -68,6 +68,8 @@ type SSEServer struct {
 	keepAliveInterval time.Duration
 
 	mu sync.RWMutex
+
+	appendQueryToMessageEndpoint bool
 }
 
 // SSEOption defines a function type for configuring SSEServer
@@ -111,6 +113,17 @@ func WithBasePath(basePath string) SSEOption {
 func WithMessageEndpoint(endpoint string) SSEOption {
 	return func(s *SSEServer) {
 		s.messageEndpoint = endpoint
+	}
+}
+
+// WithAppendQueryToMessageEndpoint configures the SSE server to append the original request's
+// query parameters to the message endpoint URL that is sent to clients during the SSE connection
+// initialization. This is useful when you need to preserve query parameters from the initial
+// SSE connection request and carry them over to subsequent message requests, maintaining
+// context or authentication details across the communication channel.
+func WithAppendQueryToMessageEndpoint() SSEOption {
+	return func(s *SSEServer) {
+		s.appendQueryToMessageEndpoint = true
 	}
 }
 
@@ -308,7 +321,11 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Send the initial endpoint event
-	fmt.Fprintf(w, "event: endpoint\ndata: %s\r\n\r\n", s.GetMessageEndpointForClient(sessionID))
+	endpoint := s.GetMessageEndpointForClient(sessionID)
+	if s.appendQueryToMessageEndpoint && len(r.URL.RawQuery) > 0 {
+		endpoint += "&" + r.URL.RawQuery
+	}
+	fmt.Fprintf(w, "event: endpoint\ndata: %s\r\n\r\n", endpoint)
 	flusher.Flush()
 
 	// Main event loop - this runs in the HTTP handler goroutine


### PR DESCRIPTION
Configures the SSE server to append the original request's RawQuery to message endpoint.

The `WithAppendQueryToMessageEndpoint` configures the SSE server to append the query string of the original request to the message endpoint URL sent to the client during SSE connection initialization. This is useful when it is necessary to retain the query parameters from the initial SSE connection request and pass them on to subsequent message requests, thereby maintaining context, target orientation, and authentication details throughout the communication channel.

For examples:

```plain
## handleSSE
GET      "/mcp/sse?token=ohmy-tk-4nz4rc3vmwao"
## handleMessage
POST     "/mcp/message?sessionId=8c82d889-e63d-4b4b-80f9-9acfb96cd2ce&token=ohmy-tk-4nz4rc3vmwao"
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved streaming connection setup: The system now appends query parameters from your initial request to the message endpoint URL. This enhancement helps preserve context and can improve session handling during communications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->