### PR TITLE
introduce NewToolResultErrorWithErr and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,20 +370,20 @@ s.AddTool(httpTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp
         req, err = http.NewRequest(method, url, nil)
     }
     if err != nil {
-        return mcp.NewToolResultErrorWithErr("unable to create request", err), nil
+        return mcp.NewToolResultErrorFromErr("unable to create request", err), nil
     }
 
     client := &http.Client{}
     resp, err := client.Do(req)
     if err != nil {
-        return mcp.NewToolResultErrorWithErr("unable to execute request", err), nil
+        return mcp.NewToolResultErrorFromErr("unable to execute request", err), nil
     }
     defer resp.Body.Close()
 
     // Return response
     respBody, err := io.ReadAll(resp.Body)
     if err != nil {
-        return mcp.NewToolResultErrorWithErr("unable to read request response", err), nil
+        return mcp.NewToolResultErrorFromErr("unable to read request response", err), nil
     }
 
     return mcp.NewToolResultText(fmt.Sprintf("Status: %d\nBody: %s", resp.StatusCode, string(respBody))), nil

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ func main() {
             result = x * y
         case "divide":
             if y == 0 {
-                return nil, errors.New("Cannot divide by zero")
+                return mcp.NewToolResultError("cannot divide by zero"), nil
             }
             result = x / y
         }
@@ -325,7 +325,7 @@ s.AddTool(calculatorTool, func(ctx context.Context, request mcp.CallToolRequest)
         result = x * y
     case "divide":
         if y == 0 {
-            return nil, errors.New("Division by zero is not allowed")
+            return mcp.NewToolResultError("cannot divide by zero"), nil
         }
         result = x / y
     }
@@ -370,20 +370,20 @@ s.AddTool(httpTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp
         req, err = http.NewRequest(method, url, nil)
     }
     if err != nil {
-        return nil, fmt.Errorf("Failed to create request: %v", err)
+        return mcp.NewToolResultErrorWithErr("unable to create request", err), nil
     }
 
     client := &http.Client{}
     resp, err := client.Do(req)
     if err != nil {
-        return nil, fmt.Errorf("Request failed: %v", err)
+        return mcp.NewToolResultErrorWithErr("unable to execute request", err), nil
     }
     defer resp.Body.Close()
 
     // Return response
     respBody, err := io.ReadAll(resp.Body)
     if err != nil {
-        return nil, fmt.Errorf("Failed to read response: %v", err)
+        return mcp.NewToolResultErrorWithErr("unable to read request response", err), nil
     }
 
     return mcp.NewToolResultText(fmt.Sprintf("Status: %d\nBody: %s", resp.StatusCode, string(respBody))), nil

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -266,6 +266,24 @@ func NewToolResultError(text string) *CallToolResult {
 	}
 }
 
+// NewToolResultErrorWithErr creates a new CallToolResult with an error message.
+// If an error is provided, its details will be appended to the text message.
+// Any errors that originate from the tool SHOULD be reported inside the result object.
+func NewToolResultErrorWithErr(text string, err error) *CallToolResult {
+	if err != nil {
+		text = fmt.Sprintf("%s: %v", text, err)
+	}
+	return &CallToolResult{
+		Content: []Content{
+			TextContent{
+				Type: "text",
+				Text: text,
+			},
+		},
+		IsError: true,
+	}
+}
+
 // NewListResourcesResult creates a new ListResourcesResult
 func NewListResourcesResult(
 	resources []Resource,

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -266,10 +266,10 @@ func NewToolResultError(text string) *CallToolResult {
 	}
 }
 
-// NewToolResultErrorWithErr creates a new CallToolResult with an error message.
+// NewToolResultErrorFromErr creates a new CallToolResult with an error message.
 // If an error is provided, its details will be appended to the text message.
 // Any errors that originate from the tool SHOULD be reported inside the result object.
-func NewToolResultErrorWithErr(text string, err error) *CallToolResult {
+func NewToolResultErrorFromErr(text string, err error) *CallToolResult {
 	if err != nil {
 		text = fmt.Sprintf("%s: %v", text, err)
 	}


### PR DESCRIPTION
This is a proposal for a follow-up on https://github.com/mark3labs/mcp-go/pull/87

It introduces a `NewToolResultErrorWithErr` function that takes an error as a parameter to aggregate it in the result.

It also updates the documentation in the README to show when to use the regular `NewToolResultError` VS `NewToolResultErrorWithErr`.

@daimatz happy to hear your thoughts. 

I've updated all errors handling to use this function because I don't think that there is a particular example in the README that covers a "regular" error raising, e.g.:

> However, any errors in _finding_ the tool, an error indicating that the server does not support tool calls, or any other exceptional conditions, should be reported as an MCP error response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized error messages for division operations and HTTP request issues. End-users will now encounter consistent and clearer feedback when errors occur, such as division by zero or problems with network requests, ensuring a more predictable and informative experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->