### PR TITLE
Add `mcptest` package for in-process MCP testing

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -33,6 +33,20 @@ type Stdio struct {
 	notifyMu       sync.RWMutex
 }
 
+// NewIO returns a new stdio-based transport using existing input, output, and
+// logging streams instead of spawning a subprocess.
+// This is useful for testing and simulating client behavior.
+func NewIO(input io.Reader, output io.WriteCloser, logging io.ReadCloser) *Stdio {
+	return &Stdio{
+		stdin:  output,
+		stdout: bufio.NewReader(input),
+		stderr: logging,
+
+		responses: make(map[int64]chan *JSONRPCResponse),
+		done:      make(chan struct{}),
+	}
+}
+
 // NewStdio creates a new stdio transport to communicate with a subprocess.
 // It launches the specified command with given arguments and sets up stdin/stdout pipes for communication.
 // Returns an error if the subprocess cannot be started or the pipes cannot be created.
@@ -55,6 +69,26 @@ func NewStdio(
 }
 
 func (c *Stdio) Start(ctx context.Context) error {
+	if err := c.startProc(ctx); err != nil {
+		return err
+	}
+
+	ready := make(chan struct{})
+	go func() {
+		close(ready)
+		c.readResponses()
+	}()
+	<-ready
+
+	return nil
+}
+
+// startProc spawns a new process running c.command.
+func (c *Stdio) startProc(ctx context.Context) error {
+	if c.command == "" {
+		return nil
+	}
+
 	cmd := exec.CommandContext(ctx, c.command, c.args...)
 
 	mergedEnv := os.Environ()
@@ -86,14 +120,6 @@ func (c *Stdio) Start(ctx context.Context) error {
 		return fmt.Errorf("failed to start command: %w", err)
 	}
 
-	// Start reading responses in a goroutine and wait for it to be ready
-	ready := make(chan struct{})
-	go func() {
-		close(ready)
-		c.readResponses()
-	}()
-	<-ready
-
 	return nil
 }
 
@@ -107,7 +133,12 @@ func (c *Stdio) Close() error {
 	if err := c.stderr.Close(); err != nil {
 		return fmt.Errorf("failed to close stderr: %w", err)
 	}
-	return c.cmd.Wait()
+
+	if c.cmd != nil {
+		return c.cmd.Wait()
+	}
+
+	return nil
 }
 
 // OnNotification registers a handler function to be called when notifications are received.

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -69,7 +69,7 @@ func NewStdio(
 }
 
 func (c *Stdio) Start(ctx context.Context) error {
-	if err := c.startProc(ctx); err != nil {
+	if err := c.spawnCommand(ctx); err != nil {
 		return err
 	}
 
@@ -83,8 +83,8 @@ func (c *Stdio) Start(ctx context.Context) error {
 	return nil
 }
 
-// startProc spawns a new process running c.command.
-func (c *Stdio) startProc(ctx context.Context) error {
+// spawnCommand spawns a new process running c.command.
+func (c *Stdio) spawnCommand(ctx context.Context) error {
 	if c.command == "" {
 		return nil
 	}

--- a/mcptest/mcptest.go
+++ b/mcptest/mcptest.go
@@ -1,0 +1,121 @@
+// Package mcptest implements helper functions for testing MCP servers.
+package mcptest
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// Server encapsulates an MCP server and manages resources like pipes and context.
+type Server struct {
+	name  string
+	tools []server.ServerTool
+
+	ctx    context.Context
+	cancel func()
+
+	serverReader io.Reader
+	serverWriter io.Writer
+	clientReader io.Reader
+	clientWriter io.WriteCloser
+
+	logBuffer bytes.Buffer
+
+	transport transport.Interface
+}
+
+// NewServer starts a new MCP server with the provided tools and returns the server instance.
+func NewServer(t *testing.T, tools ...server.ServerTool) (*Server, error) {
+	server := NewUnstartedServer(t)
+	server.AddTools(tools...)
+
+	if err := server.Start(); err != nil {
+		return nil, err
+	}
+
+	return server, nil
+}
+
+// NewUnstartedServer creates a new MCP server instance with the given name, but does not start the server.
+// Useful for tests where you need to add tools before starting the server.
+func NewUnstartedServer(t *testing.T) *Server {
+	server := &Server{
+		name: t.Name(),
+	}
+
+	// Use t.Context() once we switch to go >= 1.24
+	ctx := context.TODO()
+
+	// Set up context with cancellation, used to stop the server
+	server.ctx, server.cancel = context.WithCancel(ctx)
+
+	// Set up pipes for client-server communication
+	server.serverReader, server.clientWriter = io.Pipe()
+	server.clientReader, server.serverWriter = io.Pipe()
+
+	// Return the configured server
+	return server
+}
+
+// AddTools adds multiple tools to an unstarted server.
+func (s *Server) AddTools(tools ...server.ServerTool) {
+	s.tools = append(s.tools, tools...)
+}
+
+// AddTool adds a tool to an unstarted server.
+func (s *Server) AddTool(tool mcp.Tool, handler server.ToolHandlerFunc) {
+	s.tools = append(s.tools, server.ServerTool{
+		Tool:    tool,
+		Handler: handler,
+	})
+}
+
+// Start starts the server in a goroutine. Make sure to defer Close() after Start().
+// When using NewServer(), the returned server is already started.
+func (s *Server) Start() error {
+	// Start the MCP server in a goroutine
+	go func() {
+		mcpServer := server.NewMCPServer(s.name, "1.0.0")
+
+		mcpServer.AddTools(s.tools...)
+
+		logger := log.New(&s.logBuffer, "", 0)
+
+		stdioServer := server.NewStdioServer(mcpServer)
+		stdioServer.SetErrorLogger(logger)
+
+		if err := stdioServer.Listen(s.ctx, s.serverReader, s.serverWriter); err != nil {
+			logger.Println("StdioServer.Listen failed:", err)
+		}
+	}()
+
+	s.transport = transport.NewIO(s.clientReader, s.clientWriter, io.NopCloser(&s.logBuffer))
+
+	return s.transport.Start(s.ctx)
+}
+
+// Close stops the server and cleans up resources like temporary directories.
+func (s *Server) Close() {
+	if s.transport != nil {
+		s.transport.Close()
+		s.transport = nil
+	}
+
+	if s.cancel != nil {
+		s.cancel()
+		s.cancel = nil
+	}
+}
+
+// Client returns an MCP client connected to the server.
+func (s *Server) Client() client.MCPClient {
+	return client.NewClient(s.transport)
+}

--- a/mcptest/mcptest_test.go
+++ b/mcptest/mcptest_test.go
@@ -1,0 +1,88 @@
+package mcptest_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/mcptest"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestServer(t *testing.T) {
+	ctx := context.Background()
+
+	srv, err := mcptest.NewServer(t, server.ServerTool{
+		Tool: mcp.NewTool("hello",
+			mcp.WithDescription("Says hello to the provided name, or world."),
+			mcp.WithString("name", mcp.Description("The name to say hello to.")),
+		),
+		Handler: helloWorldHandler,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	client := srv.Client()
+
+	var initReq mcp.InitializeRequest
+
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+
+	if _, err := client.Initialize(ctx, initReq); err != nil {
+		t.Fatal("Initialize:", err)
+	}
+
+	var req mcp.CallToolRequest
+
+	req.Params.Name = "hello"
+	req.Params.Arguments = map[string]any{
+		"name": "Claude",
+	}
+
+	result, err := client.CallTool(ctx, req)
+	if err != nil {
+		t.Fatal("CallTool:", err)
+	}
+
+	got, err := resultToString(result)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := "Hello, Claude!"
+	if got != want {
+		t.Errorf("Got %q, want %q", got, want)
+	}
+}
+
+func helloWorldHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	// Extract name from request arguments
+	name, ok := request.Params.Arguments["name"].(string)
+	if !ok {
+		name = "World"
+	}
+
+	return mcp.NewToolResultText(fmt.Sprintf("Hello, %s!", name)), nil
+}
+
+func resultToString(result *mcp.CallToolResult) (string, error) {
+	var b strings.Builder
+
+	for _, content := range result.Content {
+		text, ok := content.(mcp.TextContent)
+		if !ok {
+			return "", fmt.Errorf("unsupported content type: %T", content)
+		}
+		b.WriteString(text.Text)
+	}
+
+	if result.IsError {
+		return "", fmt.Errorf("%s", b.String())
+	}
+
+	return b.String(), nil
+}

--- a/mcptest/mcptest_test.go
+++ b/mcptest/mcptest_test.go
@@ -28,16 +28,7 @@ func TestServer(t *testing.T) {
 
 	client := srv.Client()
 
-	var initReq mcp.InitializeRequest
-
-	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
-
-	if _, err := client.Initialize(ctx, initReq); err != nil {
-		t.Fatal("Initialize:", err)
-	}
-
 	var req mcp.CallToolRequest
-
 	req.Params.Name = "hello"
 	req.Params.Arguments = map[string]any{
 		"name": "Claude",


### PR DESCRIPTION
This PR introduces a new `mcptest` package that simplifies end-to-end testing of MCP implementations without spawning external processes. The package provides utilities for creating an in-process MCP server and connecting it to a client within the same test, making functional tests more reliable and easier to write.

## Key features of `mcptest`

- Connect clients to in-process servers without having to build an executable first
- Test full request/response cycles in a controlled environment
- Simplified setup for testing tool implementations

## Example usage

👉 Look at `mcptest/mcptest_test.go` for an unabridged example

```go
func TestMyTool(t *testing.T) {
    // Create a server with your tool
    srv := mcptest.NewServer(t, server.ServerTool{
        Tool: myCustomTool,
        Handler: myToolHandler,
    })
    defer srv.Close()

    // Get a client connected to the server
    client := srv.Client()
    
    // Initialize the client
    var initReq mcp.InitializeRequest
    initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
    _, err := client.Initialize(context.Background(), initReq)
    if err != nil {
        t.Fatal(err)
    }
    
    // Test your tool by calling it and verifying results
    // ...
}
```

## Implementation notes

- Added a new `NewStdioMCPClientWithIO` function that allows creating an `StdioMCPClient` using provided `io.Reader` and `io.Writer` interfaces instead of spawning a subprocess
- Implemented a new testing package with robust resource management
- Included a test demonstrating the package's usage

This PR significantly improves testability for MCP implementations and should make writing functional tests much more straightforward.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced utilities for testing MCP servers, including the ability to start, stop, and interact with test servers and clients.
  - Added a new transport option that allows simulated client-server communication using in-memory streams, enabling testing without launching subprocesses.

- **Tests**
  - Added comprehensive tests for server tool behavior, including request handling and response validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->