### PR TITLE
fix(sse): don't throw error when get http.StatusNoContent

### DIFF
--- a/client/sse.go
+++ b/client/sse.go
@@ -305,7 +305,8 @@ func (c *SSEMCPClient) sendRequest(
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK &&
-		resp.StatusCode != http.StatusAccepted {
+		resp.StatusCode != http.StatusAccepted &&
+		resp.StatusCode != http.StatusNoContent {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf(
 			"request failed with status %d: %s",


### PR DESCRIPTION
In our scenario, the successful return value of the MCP SSE server initialize request is 204 NoContent, which currently causes the SSE initialization to fail. Therefore, modify the sendRequest function to also handle http.StatusNoContent to prevent errors from being thrown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of server responses to better recognize additional successful status codes, ensuring more reliable interactions with the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->