### PR TITLE
new feat: tool annotation

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -800,6 +800,13 @@ func TestMCPServer_HandleUndefinedHandlers(t *testing.T) {
 			Type:       "object",
 			Properties: map[string]interface{}{},
 		},
+		Annotations: mcp.ToolAnnotation{
+			Title:           "test-tool",
+			ReadOnlyHint:    true,
+			DestructiveHint: false,
+			IdempotentHint:  false,
+			OpenWorldHint:   false,
+		},
 	}, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return &mcp.CallToolResult{}, nil
 	})


### PR DESCRIPTION
- Introduce
> Tool annotations provide additional metadata about a tool’s behavior, helping clients understand how to present and manage tools. These annotations are hints that describe the nature and impact of a tool, but should not be relied upon for security decisions.

- Definition, default value and demo
![image](https://github.com/user-attachments/assets/132a8698-153b-4297-ab1a-13a6b3403ea3)
demo
```json
// A read-only search tool
{
  name: "web_search",
  description: "Search the web for information",
  inputSchema: {
    type: "object",
    properties: {
      query: { type: "string" }
    },
    required: ["query"]
  },
  annotations: {
    title: "Web Search",
    readOnlyHint: true,
    openWorldHint: true
  }
}
```


- detail: https://modelcontextprotocol.io/docs/concepts/tools#tool-annotations


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Tools now include descriptive annotations, such as title and behavioral hints (e.g., read-only, destructive).
- **Tests**
  - Updated tests to cover the new tool annotation fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

