### PR TITLE
fix: add mutex to SSEServer to avoid data race between Start and Shutdown; fix test error on Windows (#166 #172)

### DIFF
--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -31,6 +32,10 @@ func compileTestServer(outputPath string) error {
 func TestStdio(t *testing.T) {
 	// Compile mock server
 	mockServerPath := filepath.Join(os.TempDir(), "mockstdio_server")
+		// Add .exe suffix on Windows
+		if runtime.GOOS == "windows" {
+			mockServerPath += ".exe"
+		}
 	if err := compileTestServer(mockServerPath); err != nil {
 		t.Fatalf("Failed to compile mock server: %v", err)
 	}
@@ -304,6 +309,10 @@ func TestStdioErrors(t *testing.T) {
 	t.Run("RequestBeforeStart", func(t *testing.T) {
 		// 创建一个新的 Stdio 实例但不调用 Start 方法
 		mockServerPath := filepath.Join(os.TempDir(), "mockstdio_server")
+		// Add .exe suffix on Windows
+		if runtime.GOOS == "windows" {
+			mockServerPath += ".exe"
+		}
 		if err := compileTestServer(mockServerPath); err != nil {
 			t.Fatalf("Failed to compile mock server: %v", err)
 		}
@@ -331,6 +340,10 @@ func TestStdioErrors(t *testing.T) {
 	t.Run("RequestAfterClose", func(t *testing.T) {
 		// Compile mock server
 		mockServerPath := filepath.Join(os.TempDir(), "mockstdio_server")
+		// Add .exe suffix on Windows
+		if runtime.GOOS == "windows" {
+			mockServerPath += ".exe"
+		}
 		if err := compileTestServer(mockServerPath); err != nil {
 			t.Fatalf("Failed to compile mock server: %v", err)
 		}

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -307,7 +307,6 @@ func TestStdioErrors(t *testing.T) {
 	})
 
 	t.Run("RequestBeforeStart", func(t *testing.T) {
-		// 创建一个新的 Stdio 实例但不调用 Start 方法
 		mockServerPath := filepath.Join(os.TempDir(), "mockstdio_server")
 		// Add .exe suffix on Windows
 		if runtime.GOOS == "windows" {
@@ -320,7 +319,7 @@ func TestStdioErrors(t *testing.T) {
 
 		uninitiatedStdio := NewStdio(mockServerPath, nil)
 
-		// 准备一个请求
+		// Prepare a request
 		request := JSONRPCRequest{
 			JSONRPC: "2.0",
 			ID:      99,

--- a/server/sse.go
+++ b/server/sse.go
@@ -209,7 +209,6 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 	s.mu.RUnlock()
 
 	if srv != nil {
-		// 关闭所有会话
 		s.sessions.Range(func(key, value interface{}) bool {
 			if session, ok := value.(*sseSession); ok {
 				close(session.done)

--- a/server/sse.go
+++ b/server/sse.go
@@ -344,10 +344,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 		s.writeJSONRPCError(w, nil, mcp.INVALID_PARAMS, "Missing sessionId")
 		return
 	}
-
-	s.mu.RLock()
 	sessionI, ok := s.sessions.Load(sessionID)
-	s.mu.RUnlock()
 	if !ok {
 		s.writeJSONRPCError(w, nil, mcp.INVALID_PARAMS, "Invalid session ID")
 		return

--- a/server/sse.go
+++ b/server/sse.go
@@ -65,6 +65,8 @@ type SSEServer struct {
 
 	keepAlive         bool
 	keepAliveInterval time.Duration
+	
+	mu               sync.RWMutex
 }
 
 // SSEOption defines a function type for configuring SSEServer
@@ -189,10 +191,12 @@ func NewTestServer(server *MCPServer, opts ...SSEOption) *httptest.Server {
 // Start begins serving SSE connections on the specified address.
 // It sets up HTTP handlers for SSE and message endpoints.
 func (s *SSEServer) Start(addr string) error {
+	s.mu.Lock()
 	s.srv = &http.Server{
 		Addr:    addr,
 		Handler: s,
 	}
+	s.mu.Unlock()
 
 	return s.srv.ListenAndServe()
 }
@@ -200,7 +204,12 @@ func (s *SSEServer) Start(addr string) error {
 // Shutdown gracefully stops the SSE server, closing all active sessions
 // and shutting down the HTTP server.
 func (s *SSEServer) Shutdown(ctx context.Context) error {
-	if s.srv != nil {
+	s.mu.RLock()
+	srv := s.srv
+	s.mu.RUnlock()
+
+	if srv != nil {
+		// 关闭所有会话
 		s.sessions.Range(func(key, value interface{}) bool {
 			if session, ok := value.(*sseSession); ok {
 				close(session.done)
@@ -209,7 +218,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 			return true
 		})
 
-		return s.srv.Shutdown(ctx)
+		return srv.Shutdown(ctx)
 	}
 	return nil
 }
@@ -336,7 +345,9 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	s.mu.RLock()
 	sessionI, ok := s.sessions.Load(sessionID)
+	s.mu.RUnlock()
 	if !ok {
 		s.writeJSONRPCError(w, nil, mcp.INVALID_PARAMS, "Invalid session ID")
 		return


### PR DESCRIPTION
## What this PR does

1. This PR fixes a data race issue between `SSEServer.Start` and `SSEServer.Shutdown` by adding a `sync.RWMutex` to the `SSEServer` struct. 
2. Fix test error on Windows

- `Start` uses `mu.Lock` when setting `s.srv`
- `Shutdown` uses `mu.RLock` when accessing `s.srv`
- Add `'.exe'` to `mockServerPath`



## Related Issue

Closes #166
Closes #172


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved server shutdown reliability by ensuring all active sessions are properly closed.
  - Enhanced thread safety to prevent potential issues during server start and shutdown.
  - Fixed test compatibility for Windows by correctly handling mock server executable filenames.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->