### PR TITLE
Fix for `Start` in stdio.go

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -89,8 +89,8 @@ func (c *Stdio) Start(ctx context.Context) error {
 	// Start reading responses in a goroutine and wait for it to be ready
 	ready := make(chan struct{})
 	go func() {
-		close(ready)
 		c.readResponses()
+		close(ready)
 	}()
 	<-ready
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved readiness signaling to ensure the system is marked as ready only after response handling is fully complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->