### PR TITLE
feat(server): Add hooks.AddOnUnregisterSession functionality

### DIFF
--- a/server/hooks.go
+++ b/server/hooks.go
@@ -11,6 +11,9 @@ import (
 // OnRegisterSessionHookFunc is a hook that will be called when a new session is registered.
 type OnRegisterSessionHookFunc func(ctx context.Context, session ClientSession)
 
+// OnUnregisterSessionHookFunc is a hook that will be called when a session is being unregistered.
+type OnUnregisterSessionHookFunc func(ctx context.Context, session ClientSession)
+
 // BeforeAnyHookFunc is a function that is called after the request is
 // parsed but before the method is called.
 type BeforeAnyHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any)
@@ -83,6 +86,7 @@ type OnAfterCallToolFunc func(ctx context.Context, id any, message *mcp.CallTool
 
 type Hooks struct {
 	OnRegisterSession             []OnRegisterSessionHookFunc
+	OnUnregisterSession           []OnUnregisterSessionHookFunc
 	OnBeforeAny                   []BeforeAnyHookFunc
 	OnSuccess                     []OnSuccessHookFunc
 	OnError                       []OnErrorHookFunc
@@ -213,6 +217,19 @@ func (c *Hooks) RegisterSession(ctx context.Context, session ClientSession) {
 		return
 	}
 	for _, hook := range c.OnRegisterSession {
+		hook(ctx, session)
+	}
+}
+
+func (c *Hooks) AddOnUnregisterSession(hook OnUnregisterSessionHookFunc) {
+	c.OnUnregisterSession = append(c.OnUnregisterSession, hook)
+}
+
+func (c *Hooks) UnregisterSession(ctx context.Context, session ClientSession) {
+	if c == nil {
+		return
+	}
+	for _, hook := range c.OnUnregisterSession {
 		hook(ctx, session)
 	}
 }

--- a/server/internal/gen/hooks.go.tmpl
+++ b/server/internal/gen/hooks.go.tmpl
@@ -14,6 +14,8 @@ import (
 // OnRegisterSessionHookFunc is a hook that will be called when a new session is registered.
 type OnRegisterSessionHookFunc func(ctx context.Context, session ClientSession)
 
+// OnUnregisterSessionHookFunc is a hook that will be called when a session is being unregistered.
+type OnUnregisterSessionHookFunc func(ctx context.Context, session ClientSession)
 
 // BeforeAnyHookFunc is a function that is called after the request is
 // parsed but before the method is called.
@@ -63,7 +65,8 @@ type OnAfter{{.HookName}}Func func(ctx context.Context, id any, message *mcp.{{.
 {{end}}
 
 type Hooks struct {
-    OnRegisterSession []OnRegisterSessionHookFunc
+    OnRegisterSession   []OnRegisterSessionHookFunc
+	OnUnregisterSession   []OnUnregisterSessionHookFunc
 	OnBeforeAny      []BeforeAnyHookFunc
 	OnSuccess        []OnSuccessHookFunc
 	OnError          []OnErrorHookFunc
@@ -179,6 +182,19 @@ func (c *Hooks) RegisterSession(ctx context.Context, session ClientSession) {
         return
     }
     for _, hook := range c.OnRegisterSession {
+        hook(ctx, session)
+    }
+}
+
+func (c *Hooks) AddOnUnregisterSession(hook OnUnregisterSessionHookFunc) {
+    c.OnUnregisterSession = append(c.OnUnregisterSession, hook)
+}
+
+func (c *Hooks) UnregisterSession(ctx context.Context, session ClientSession) {
+    if c == nil {
+        return
+    }
+    for _, hook := range c.OnUnregisterSession {
         hook(ctx, session)
     }
 }

--- a/server/server.go
+++ b/server/server.go
@@ -206,9 +206,11 @@ func (s *MCPServer) RegisterSession(
 
 // UnregisterSession removes from storage session that is shut down.
 func (s *MCPServer) UnregisterSession(
+	ctx context.Context,
 	sessionID string,
 ) {
-	s.sessions.Delete(sessionID)
+	session, _ := s.sessions.LoadAndDelete(sessionID)
+	s.hooks.UnregisterSession(ctx, session.(ClientSession))
 }
 
 // sendNotificationToAllClients sends a notification to all the currently active clients.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -340,7 +340,6 @@ func TestMCPServer_Tools(t *testing.T) {
 			}`))
 			tt.validate(t, notifications, toolsList.(mcp.JSONRPCMessage))
 		})
-
 	}
 }
 
@@ -725,8 +724,8 @@ func TestMCPServer_HandleInvalidMessages(t *testing.T) {
 			message:     `{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": "invalid"}`,
 			expectedErr: mcp.INVALID_REQUEST,
 			validateErr: func(t *testing.T, err error) {
-				var unparseableErr = &UnparseableMessageError{}
-				var ok = errors.As(err, &unparseableErr)
+				unparseableErr := &UnparseableMessageError{}
+				ok := errors.As(err, &unparseableErr)
 				assert.True(t, ok, "Error should be UnparseableMessageError")
 				assert.Equal(t, mcp.MethodInitialize, unparseableErr.GetMethod())
 				assert.Equal(t, json.RawMessage(`{"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": "invalid"}`), unparseableErr.GetMessage())
@@ -1125,7 +1124,6 @@ func TestMCPServer_ResourceTemplates(t *testing.T) {
 		assert.Equal(t, "test://something/test-resource/a/b/c", resultContent.URI)
 		assert.Equal(t, "text/plain", resultContent.MIMEType)
 		assert.Equal(t, "test content: something", resultContent.Text)
-
 	})
 }
 
@@ -1351,6 +1349,76 @@ func TestMCPServer_WithHooks(t *testing.T) {
 	require.Len(t, onSuccessData, 1, "Expected one OnSuccess Ping message/result pair")
 	assert.IsType(t, afterPingData[0].msg, onSuccessData[0].msg, "OnSuccess message should be same type as AfterPing message")
 	assert.IsType(t, afterPingData[0].res, onSuccessData[0].res, "OnSuccess result should be same type as AfterPing result")
+}
+
+func TestMCPServer_SessionHooks(t *testing.T) {
+	var (
+		registerCalled   bool
+		unregisterCalled bool
+
+		registeredContext   context.Context
+		unregisteredContext context.Context
+
+		registeredSession   ClientSession
+		unregisteredSession ClientSession
+	)
+
+	hooks := &Hooks{}
+	hooks.AddOnRegisterSession(func(ctx context.Context, session ClientSession) {
+		registerCalled = true
+		registeredContext = ctx
+		registeredSession = session
+	})
+	hooks.AddOnUnregisterSession(func(ctx context.Context, session ClientSession) {
+		unregisterCalled = true
+		unregisteredContext = ctx
+		unregisteredSession = session
+	})
+
+	server := NewMCPServer(
+		"test-server",
+		"1.0.0",
+		WithHooks(hooks),
+	)
+
+	testSession := &fakeSession{
+		sessionID:           "test-session-id",
+		notificationChannel: make(chan mcp.JSONRPCNotification, 5),
+		initialized:         false,
+	}
+
+	ctx := context.WithoutCancel(context.Background())
+	err := server.RegisterSession(ctx, testSession)
+	require.NoError(t, err)
+
+	assert.True(t, registerCalled, "Register session hook was not called")
+	assert.Equal(t, testSession.SessionID(), registeredSession.SessionID(),
+		"Register hook received wrong session")
+
+	server.UnregisterSession(ctx, testSession.SessionID())
+
+	assert.True(t, unregisterCalled, "Unregister session hook was not called")
+	assert.Equal(t, testSession.SessionID(), unregisteredSession.SessionID(),
+		"Unregister hook received wrong session")
+
+	assert.Equal(t, ctx, unregisteredContext, "Unregister hook received wrong context")
+	assert.Equal(t, ctx, registeredContext, "Register hook received wrong context")
+}
+
+func TestMCPServer_SessionHooks_NilHooks(t *testing.T) {
+	server := NewMCPServer("test-server", "1.0.0")
+
+	testSession := &fakeSession{
+		sessionID:           "test-session-id",
+		notificationChannel: make(chan mcp.JSONRPCNotification, 5),
+		initialized:         false,
+	}
+
+	ctx := context.WithoutCancel(context.Background())
+	err := server.RegisterSession(ctx, testSession)
+	require.NoError(t, err)
+
+	server.UnregisterSession(ctx, testSession.SessionID())
 }
 
 func TestMCPServer_WithRecover(t *testing.T) {

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -204,7 +204,7 @@ func (s *StdioServer) Listen(
 	if err := s.server.RegisterSession(ctx, &stdioSessionInstance); err != nil {
 		return fmt.Errorf("register session: %w", err)
 	}
-	defer s.server.UnregisterSession(stdioSessionInstance.SessionID())
+	defer s.server.UnregisterSession(ctx, stdioSessionInstance.SessionID())
 	ctx = s.server.WithContext(ctx, &stdioSessionInstance)
 
 	// Add in any custom context.


### PR DESCRIPTION
Add OnUnregisterSession hook functionality to complement the existing  OnRegisterSession hooks, allowing code to run when a client session  is being removed from the server. In some cases, the server may want to do additional work when a session has been closed. For example, in the SSE server case where you may end up managing various logs for the duration of the session -- you would want to indicate that the session was finished.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for hooks that trigger when a client session is unregistered.

- **Tests**
  - Introduced new tests to verify that session registration and unregistration hooks are called as expected, and to ensure correct behavior when no hooks are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->