### PR TITLE
Export SendNotificationToAllClients

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -211,8 +211,8 @@ func (s *MCPServer) UnregisterSession(
 	s.sessions.Delete(sessionID)
 }
 
-// sendNotificationToAllClients sends a notification to all the currently active clients.
-func (s *MCPServer) sendNotificationToAllClients(
+// SendNotificationToAllClients sends a notification to all the currently active clients.
+func (s *MCPServer) SendNotificationToAllClients(
 	method string,
 	params map[string]any,
 ) {
@@ -472,7 +472,7 @@ func (s *MCPServer) AddTools(tools ...ServerTool) {
 	s.toolsMu.Unlock()
 
 	// Send notification to all initialized sessions
-	s.sendNotificationToAllClients("notifications/tools/list_changed", nil)
+	s.SendNotificationToAllClients("notifications/tools/list_changed", nil)
 }
 
 // SetTools replaces all existing tools with the provided list
@@ -492,7 +492,7 @@ func (s *MCPServer) DeleteTools(names ...string) {
 	s.toolsMu.Unlock()
 
 	// Send notification to all initialized sessions
-	s.sendNotificationToAllClients("notifications/tools/list_changed", nil)
+	s.SendNotificationToAllClients("notifications/tools/list_changed", nil)
 }
 
 // AddNotificationHandler registers a new handler for incoming notifications


### PR DESCRIPTION
[First PR to project]

Export sendNotificationToAllClients so it can be called from the MCP server to send unsolicited notifications to all clients (sessions).

I have a use-case for my MCP server where I need to send notifications of state change to all sessions.  My MCP server is fronting a device hub, and the device's on the hub would like to send notifications up to the LLM.

There is probably a reason why this was not exported, so please forgive this PR if that's the case.  I just could not figure out what the spec says about this.

In any case, I added a test and tested with the Inspector.  The Inspectory sees the unsolicited notifications.  Cool!  I also tried with Cursor and Claude, but neither seem to recognize notifications, no matter how hard I tried to convince them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added tests to verify that notifications are correctly sent to all active client sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->