### PR TITLE
Refact: pre-allocate memory for memory-efficiency

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -429,7 +429,7 @@ func (s *MCPServer) RemoveResource(uri string) {
 
 	// Send notification to all initialized sessions if listChanged capability is enabled
 	if s.capabilities.resources != nil && s.capabilities.resources.listChanged {
-		s.sendNotificationToAllClients("resources/list_changed", nil)
+		s.SendNotificationToAllClients("resources/list_changed", nil)
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -492,7 +492,7 @@ func (s *MCPServer) AddTools(tools ...ServerTool) {
 // SetTools replaces all existing tools with the provided list
 func (s *MCPServer) SetTools(tools ...ServerTool) {
 	s.toolsMu.Lock()
-	s.tools = make(map[string]ServerTool)
+	s.tools = make(map[string]ServerTool, len(tools))
 	s.toolsMu.Unlock()
 	s.AddTools(tools...)
 }
@@ -714,7 +714,7 @@ func (s *MCPServer) handleReadResource(
 			matched = true
 			matchedVars := template.URITemplate.Match(request.Params.URI)
 			// Convert matched variables to a map
-			request.Params.Arguments = make(map[string]interface{})
+			request.Params.Arguments = make(map[string]interface{}, len(matchedVars))
 			for name, value := range matchedVars {
 				request.Params.Arguments[name] = value.V
 			}

--- a/server/sse.go
+++ b/server/sse.go
@@ -179,10 +179,7 @@ func NewSSEServer(server *MCPServer, opts ...SSEOption) *SSEServer {
 
 // NewTestServer creates a test server for testing purposes
 func NewTestServer(server *MCPServer, opts ...SSEOption) *httptest.Server {
-	sseServer := NewSSEServer(server)
-	for _, opt := range opts {
-		opt(sseServer)
-	}
+	sseServer := NewSSEServer(server, opts...)
 
 	testServer := httptest.NewServer(sseServer)
 	sseServer.baseURL = testServer.URL


### PR DESCRIPTION
1. fix one bug for function calling  `s.sendNotificationToAllClients` ----> `s.SendNotificationToAllClients` , the former of which is not defined for `MCPServer`
2. pre-allocate memory for `map` whose final capacity could be known at the beginning for memory efficiency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal efficiency by optimizing resource allocation.
  - Streamlined server configuration setup for better maintainability.

No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->