### PR TITLE
refact: optimize usage of RWMutex in MCPServer for performance

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -407,11 +407,18 @@ func (s *MCPServer) AddResource(
 	resource mcp.Resource,
 	handler ResourceHandlerFunc,
 ) {
-	s.capabilitiesMu.Lock()
+	s.capabilitiesMu.RLock()
 	if s.capabilities.resources == nil {
-		s.capabilities.resources = &resourceCapabilities{}
+		s.capabilitiesMu.RUnlock()
+
+		s.capabilitiesMu.Lock()
+		if s.capabilities.resources == nil {
+			s.capabilities.resources = &resourceCapabilities{}
+		}
+		s.capabilitiesMu.Unlock()
+	} else {
+		s.capabilitiesMu.RUnlock()
 	}
-	s.capabilitiesMu.Unlock()
 
 	s.resourcesMu.Lock()
 	defer s.resourcesMu.Unlock()
@@ -438,11 +445,17 @@ func (s *MCPServer) AddResourceTemplate(
 	template mcp.ResourceTemplate,
 	handler ResourceTemplateHandlerFunc,
 ) {
-	s.capabilitiesMu.Lock()
+	s.capabilitiesMu.RLock()
 	if s.capabilities.resources == nil {
+		s.capabilitiesMu.RUnlock()
+
+		s.capabilitiesMu.Lock()
 		s.capabilities.resources = &resourceCapabilities{}
+		s.capabilitiesMu.Unlock()
+	} else {
+		s.capabilitiesMu.RUnlock()
 	}
-	s.capabilitiesMu.Unlock()
+
 
 	s.resourcesMu.Lock()
 	defer s.resourcesMu.Unlock()
@@ -454,11 +467,16 @@ func (s *MCPServer) AddResourceTemplate(
 
 // AddPrompt registers a new prompt handler with the given name
 func (s *MCPServer) AddPrompt(prompt mcp.Prompt, handler PromptHandlerFunc) {
-	s.capabilitiesMu.Lock()
+	s.capabilitiesMu.RLock()
 	if s.capabilities.prompts == nil {
+		s.capabilitiesMu.RUnlock()
+
+		s.capabilitiesMu.Lock()
 		s.capabilities.prompts = &promptCapabilities{}
+		s.capabilitiesMu.Unlock()
+	} else {
+		s.capabilitiesMu.RUnlock()
 	}
-	s.capabilitiesMu.Unlock()
 
 	s.promptsMu.Lock()
 	defer s.promptsMu.Unlock()
@@ -473,11 +491,16 @@ func (s *MCPServer) AddTool(tool mcp.Tool, handler ToolHandlerFunc) {
 
 // AddTools registers multiple tools at once
 func (s *MCPServer) AddTools(tools ...ServerTool) {
-	s.capabilitiesMu.Lock()
+	s.capabilitiesMu.RLock()
 	if s.capabilities.tools == nil {
+		s.capabilitiesMu.RUnlock()
+
+		s.capabilitiesMu.Lock()
 		s.capabilities.tools = &toolCapabilities{}
+		s.capabilitiesMu.Unlock()
+	} else {
+		s.capabilitiesMu.RUnlock()
 	}
-	s.capabilitiesMu.Unlock()
 
 	s.toolsMu.Lock()
 	for _, entry := range tools {

--- a/server/server.go
+++ b/server/server.go
@@ -450,7 +450,9 @@ func (s *MCPServer) AddResourceTemplate(
 		s.capabilitiesMu.RUnlock()
 
 		s.capabilitiesMu.Lock()
-		s.capabilities.resources = &resourceCapabilities{}
+		if s.capabilities.resources == nil {
+			s.capabilities.resources = &resourceCapabilities{}
+		}
 		s.capabilitiesMu.Unlock()
 	} else {
 		s.capabilitiesMu.RUnlock()
@@ -472,7 +474,9 @@ func (s *MCPServer) AddPrompt(prompt mcp.Prompt, handler PromptHandlerFunc) {
 		s.capabilitiesMu.RUnlock()
 
 		s.capabilitiesMu.Lock()
-		s.capabilities.prompts = &promptCapabilities{}
+		if s.capabilities.prompts == nil {
+			s.capabilities.prompts = &promptCapabilities{}
+		}
 		s.capabilitiesMu.Unlock()
 	} else {
 		s.capabilitiesMu.RUnlock()
@@ -496,7 +500,9 @@ func (s *MCPServer) AddTools(tools ...ServerTool) {
 		s.capabilitiesMu.RUnlock()
 
 		s.capabilitiesMu.Lock()
-		s.capabilities.tools = &toolCapabilities{}
+		if s.capabilities.tools == nil {
+			s.capabilities.tools = &toolCapabilities{}
+		}
 		s.capabilitiesMu.Unlock()
 	} else {
 		s.capabilitiesMu.RUnlock()


### PR DESCRIPTION
&emsp; Note that field `capabilitiesMu` is a `RWMutex` in `MCPServer` for controlling concurrent read/write operations to field `capabilities`.
&emsp;At most of  time, `capabilities` 's members `resource/tools/prompts/` will only be set not to be `nil` for one time when we call func `NewMCPServer` at the beginning or when we call func `AddResource/AddResourceTemplate/AddPrompt/AddTools` for the first time. 
&emsp; So, for field `capabilitiesMu`,  the number of its read operations far exceeds the number of write operations, for which we could utilize `RLock` and double-checking technique to optimizes the concurrency performance for the `AddXxx` functions mentioned above.
**experiment**
<img width="429" alt="benchmark" src="https://github.com/user-attachments/assets/4110de60-b4f6-4e5b-966a-c64543893809" />
<img width="891" alt="benchmark2" src="https://github.com/user-attachments/assets/a941d0ea-3571-4d72-aab3-481a884aed24" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal locking mechanisms to enhance performance and responsiveness when adding resources, templates, prompts, or tools. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->