### PR TITLE
Add example to demonstrate how to custom transport

### DIFF
--- a/examples/local/client.go
+++ b/examples/local/client.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/examples/local/server"
+	"github.com/mark3labs/mcp-go/examples/local/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func NewLocalClient(ctx context.Context) *client.Client {
+	localServer := server.CreateLocalServer(ctx)
+	localTransport := transport.NewLocalTransport(localServer)
+	client := client.NewClient(localTransport)
+
+	_ = client.Start(ctx)
+
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "example-client",
+		Version: "1.0.0",
+	}
+	_, _ = client.Initialize(ctx, initRequest)
+
+	return client
+}
+
+func main() {
+	ctx := context.Background()
+	localClient := NewLocalClient(ctx)
+	tools, err := localClient.ListTools(ctx, mcp.ListToolsRequest{})
+	if err != nil {
+		log.Fatalf("Failed to list tools: %v", err)
+		return
+	}
+	for _, tool := range tools.Tools {
+		fmt.Printf("%s: %s\n", tool.Name, tool.Description)
+	}
+
+	for _, tool := range tools.Tools {
+		toolsCallRequest := mcp.CallToolRequest{}
+		toolsCallRequest.Params.Name = tool.Name
+		callToolResp, err := localClient.CallTool(ctx, toolsCallRequest)
+		if err != nil {
+			log.Fatalf("Failed to call tool: %v", err)
+			return
+		}
+		fmt.Printf("Call tool [%s] result: %+v\n", tool.Name, callToolResp)
+	}
+}

--- a/examples/local/server/local_server.go
+++ b/examples/local/server/local_server.go
@@ -1,0 +1,35 @@
+package server
+
+import (
+	"context"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+type LocalServer struct {
+	Server *server.MCPServer
+}
+
+func CreateLocalServer(ctx context.Context) *LocalServer {
+	mcpServer := server.NewMCPServer("test", "1.0.0")
+
+	mcpServer.AddTool(mcp.Tool{
+		Name:        "test-tool",
+		Description: "test tool",
+		InputSchema: mcp.ToolInputSchema{},
+	}, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{
+				mcp.TextContent{
+					Type: "text",
+					Text: "test tool result",
+				},
+			},
+		}, nil
+	})
+
+	return &LocalServer{
+		Server: mcpServer,
+	}
+}

--- a/examples/local/transport/local_transport.go
+++ b/examples/local/transport/local_transport.go
@@ -1,0 +1,66 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/examples/local/server"
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+type LocalTransport struct {
+	server *server.LocalServer
+}
+
+func NewLocalTransport(server *server.LocalServer) *LocalTransport {
+	return &LocalTransport{
+		server: server,
+	}
+}
+
+func (t *LocalTransport) Start(ctx context.Context) error {
+	return nil
+}
+
+func (t *LocalTransport) SendRequest(ctx context.Context, request transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	requestBytes, err := json.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	requestBytes = append(requestBytes, '\n')
+
+	var resp mcp.JSONRPCMessage
+	switch request.Method {
+	case "initialize":
+		resp = transport.JSONRPCResponse{}
+	case "tools/list", "tools/call":
+		resp = t.server.Server.HandleMessage(ctx, requestBytes)
+	default:
+		return nil, errors.New("not support method")
+	}
+
+	marshal, _ := json.Marshal(resp)
+	rpcResp := transport.JSONRPCResponse{}
+	err = json.Unmarshal(marshal, &rpcResp)
+	if err != nil {
+		return nil, err
+	}
+
+	return &rpcResp, nil
+}
+
+func (t *LocalTransport) SendNotification(ctx context.Context, notify mcp.JSONRPCNotification) error {
+	// note ignore
+	return nil
+}
+
+func (t *LocalTransport) SetNotificationHandler(handler func(notification mcp.JSONRPCNotification)) {
+	// note ignore
+}
+
+func (t *LocalTransport) Close() error {
+	return nil
+}


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a local client example that demonstrates listing and calling tools without network communication.
  - Added a local server that registers a sample tool and returns a static result for demonstration.
  - Provided a local transport layer to enable communication between the client and server within the same process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## The reason for adding this example
We are exploring the use of MCP to manage all the tools, **which may include some golang methods**. In this case, a local transport layer is required to support communication within the same process.

This example demonstrates how to create a local transport layer and local server.

## NOTE
Feel free to close this PR if `local transport layer` demonstration is not so usefully.