### PR TITLE
fix(client): prevent panics

### DIFF
--- a/client/stdio.go
+++ b/client/stdio.go
@@ -31,10 +31,13 @@ func NewStdioMCPClient(
 
 // GetStderr returns a reader for the stderr output of the subprocess.
 // This can be used to capture error messages or logs from the subprocess.
-//
-// Note: This method only works with stdio transport, or it will panic.
-func GetStderr(c *Client) io.Reader {
+func GetStderr(c *Client) (io.Reader, bool) {
 	t := c.GetTransport()
-	stdio := t.(*transport.Stdio)
-	return stdio.Stderr()
+
+	stdio, ok := t.(*transport.Stdio)
+	if !ok {
+		return nil, false
+	}
+
+	return stdio.Stderr(), true
 }

--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -47,7 +47,13 @@ func TestStdioMCPClient(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		dec := json.NewDecoder(GetStderr(client))
+
+		stderr, ok := GetStderr(client)
+		if !ok {
+			return
+		}
+
+		dec := json.NewDecoder(stderr)
 		for {
 			var record map[string]any
 			if err := dec.Decode(&record); err != nil {


### PR DESCRIPTION
The type assertation should be checked to prevent panicing allowing the caller to handle gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent crashes when accessing the standard error stream if unavailable.

- **Tests**
  - Updated tests to safely handle cases where the standard error stream may not be accessible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->