### PR TITLE
fix: correct JSON key for client capabilities

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -131,7 +131,7 @@ func (c *Client) Initialize(
 	params := struct {
 		ProtocolVersion string                 `json:"protocolVersion"`
 		ClientInfo      mcp.Implementation     `json:"clientInfo"`
-		Capabilities    mcp.ClientCapabilities `json:"serverCapabilities"`
+		Capabilities    mcp.ClientCapabilities `json:"capabilities"`
 	}{
 		ProtocolVersion: request.Params.ProtocolVersion,
 		ClientInfo:      request.Params.ClientInfo,


### PR DESCRIPTION
The current client has a BUG. Specifically, running `examples/filesystem_stdio_client` will report an error. Because one of the JSON keys is set incorrectly.

```
2025/04/23 13:56:15 Failed to initialize: [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [
      "params",
      "capabilities"
    ],
    "message": "Required"
  }
]
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the JSON key used for capabilities in client initialization requests to ensure proper communication with the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->