### PR TITLE
fix(client): check stdio started before sending notification

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -214,6 +214,10 @@ func (c *Stdio) SendNotification(
 	ctx context.Context,
 	notification mcp.JSONRPCNotification,
 ) error {
+	if c.stdin == nil {
+		return fmt.Errorf("stdio client not started")
+	}
+	
 	notificationBytes, err := json.Marshal(notification)
 	if err != nil {
 		return fmt.Errorf("failed to marshal notification: %w", err)


### PR DESCRIPTION
&emsp; Just like func `SendRequest()` , it could be better if we check whether `Stdio` client has been started or not before we send notification to its subprocess.

**Why we did we call func  `SendRequest` would always be successful without `error/panic` ?**
&emsp;Because when we create `Stdio` client through func `NewStdioMCPClient()`, we always call  func `Stdio.Start()`. However, it incurs another problem where we may call `Stdio.Start` for two times(issue:  #193 )
&emsp;to fix #193 , I think we may have two options at least:
1. utilizes `sync.Once.Do()` to help us initialize `Stdio` for once
2. use `atomic.Bool` to record whether we have initialized `Stdio` just like what we do in  client `SSE` 
3. ... others more efficient options....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent notifications from being sent when the client is not properly started. Users will now receive a clear error message if the client is not initialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->