### PR TITLE
Use correct name in Go documentation

### DIFF
--- a/client/interface.go
+++ b/client/interface.go
@@ -1,4 +1,4 @@
-// Package client provides MCP (Model Control Protocol) client implementations.
+// Package client provides MCP (Model Context Protocol) client implementations.
 package client
 
 import (

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1,4 +1,4 @@
-// Package mcp defines the core types and interfaces for the Model Control Protocol (MCP).
+// Package mcp defines the core types and interfaces for the Model Context Protocol (MCP).
 // MCP is a protocol for communication between LLM-powered applications and their supporting services.
 package mcp
 

--- a/server/server.go
+++ b/server/server.go
@@ -1,4 +1,4 @@
-// Package server provides MCP (Model Control Protocol) server implementations.
+// Package server provides MCP (Model Context Protocol) server implementations.
 package server
 
 import (
@@ -138,7 +138,7 @@ var (
 // NotificationHandlerFunc handles incoming notifications.
 type NotificationHandlerFunc func(ctx context.Context, notification mcp.JSONRPCNotification)
 
-// MCPServer implements a Model Control Protocol server that can handle various types of requests
+// MCPServer implements a Model Context Protocol server that can handle various types of requests
 // including resources, prompts, and tools.
 type MCPServer struct {
 	// Separate mutexes for different resource types


### PR DESCRIPTION
Besides just reducing confusion, this should improve the modules
ranking when searching pkg.go.dev.
