### PR TITLE
refactor: Pull out `Annotations` structure rather than being an anonymous inner struct

### DIFF
--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -43,10 +43,7 @@ func WithMIMEType(mimeType string) ResourceOption {
 func WithAnnotations(audience []Role, priority float64) ResourceOption {
 	return func(r *Resource) {
 		if r.Annotations == nil {
-			r.Annotations = &struct {
-				Audience []Role  `json:"audience,omitempty"`
-				Priority float64 `json:"priority,omitempty"`
-			}{}
+			r.Annotations = &Annotations{}
 		}
 		r.Annotations.Audience = audience
 		r.Annotations.Priority = priority
@@ -94,10 +91,7 @@ func WithTemplateMIMEType(mimeType string) ResourceTemplateOption {
 func WithTemplateAnnotations(audience []Role, priority float64) ResourceTemplateOption {
 	return func(t *ResourceTemplate) {
 		if t.Annotations == nil {
-			t.Annotations = &struct {
-				Audience []Role  `json:"audience,omitempty"`
-				Priority float64 `json:"priority,omitempty"`
-			}{}
+			t.Annotations = &Annotations{}
 		}
 		t.Annotations.Audience = audience
 		t.Annotations.Priority = priority

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -659,24 +659,26 @@ type SamplingMessage struct {
 	Content interface{} `json:"content"` // Can be TextContent or ImageContent
 }
 
+type Annotations struct {
+	// Describes who the intended customer of this object or data is.
+	//
+	// It can include multiple entries to indicate content useful for multiple
+	// audiences (e.g., `["user", "assistant"]`).
+	Audience []Role `json:"audience,omitempty"`
+
+	// Describes how important this data is for operating the server.
+	//
+	// A value of 1 means "most important," and indicates that the data is
+	// effectively required, while 0 means "least important," and indicates that
+	// the data is entirely optional.
+	Priority float64 `json:"priority,omitempty"`
+}
+
 // Annotated is the base for objects that include optional annotations for the
 // client. The client can use annotations to inform how objects are used or
 // displayed
 type Annotated struct {
-	Annotations *struct {
-		// Describes who the intended customer of this object or data is.
-		//
-		// It can include multiple entries to indicate content useful for multiple
-		// audiences (e.g., `["user", "assistant"]`).
-		Audience []Role `json:"audience,omitempty"`
-
-		// Describes how important this data is for operating the server.
-		//
-		// A value of 1 means "most important," and indicates that the data is
-		// effectively required, while 0 means "least important," and indicates that
-		// the data is entirely optional.
-		Priority float64 `json:"priority,omitempty"`
-	} `json:"annotations,omitempty"`
+	Annotations *Annotations `json:"annotations,omitempty"`
 }
 
 type Content interface {


### PR DESCRIPTION
Fixes #177 

Note: I guess this technically would be a breaking change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal structure for annotation metadata, making the system more maintainable without affecting user-facing behavior. No visible changes to the interface or data format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->