### PR TITLE
fix(client):  resource leak in `SSEClient.SendRequest()` 

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -243,53 +243,54 @@ func (c *SSE) SendRequest(
 		return nil, fmt.Errorf("endpoint not received")
 	}
 
+	// Marshal request
 	requestBytes, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	responseChan := make(chan *JSONRPCResponse, 1)
-	c.mu.Lock()
-	c.responses[request.ID] = responseChan
-	c.mu.Unlock()
-
-	req, err := http.NewRequestWithContext(
-		ctx,
-		"POST",
-		c.endpoint.String(),
-		bytes.NewReader(requestBytes),
-	)
+	// Create HTTP request
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint.String(), bytes.NewReader(requestBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 
+	// Set headers
 	req.Header.Set("Content-Type", "application/json")
-	// set custom http headers
 	for k, v := range c.headers {
 		req.Header.Set(k, v)
 	}
 
+	// Resgiter response channel
+	responseChan := make(chan *JSONRPCResponse, 1)
+	c.mu.Lock()
+	c.responses[request.ID] = responseChan
+	c.mu.Unlock()
+	deleteResponseChan := func() {
+		c.mu.Lock()
+		delete(c.responses, request.ID)
+		c.mu.Unlock()
+	}
+
+	// Send request
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
+		deleteResponseChan()
 		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK &&
-		resp.StatusCode != http.StatusAccepted {
+	// Check if we got an error response
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {
+		deleteResponseChan()
+
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf(
-			"request failed with status %d: %s",
-			resp.StatusCode,
-			body,
-		)
+		return nil, fmt.Errorf("request failed with status %d: %s", resp.StatusCode, body)
 	}
 
 	select {
 	case <-ctx.Done():
-		c.mu.Lock()
-		delete(c.responses, request.ID)
-		c.mu.Unlock()
+		deleteResponseChan()
 		return nil, ctx.Err()
 	case response := <-responseChan:
 		return response, nil

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -261,7 +261,7 @@ func (c *SSE) SendRequest(
 		req.Header.Set(k, v)
 	}
 
-	// Resgiter response channel
+	// Register response channel
 	responseChan := make(chan *JSONRPCResponse, 1)
 	c.mu.Lock()
 	c.responses[request.ID] = responseChan


### PR DESCRIPTION
&emsp; Currently, func `SendRequest()` in SSE client has potential risk of not removing the `responseChan` for request forever because func  `SendRequest` create `responseChan` at the very beginning, and the following situations will cause resource leak in our program:
1.  we fail to create a `http.Request` object when we call func `http.NewRequestWithContext`
2.  `http.Request` fails to send request to MCPserver when we call `c.httpClient.Do(req)`
3.  the response status code that MCPServer returns ≠ `http.StatusOK/http.StatusAccepted`

**How about using `defer` to remove `responseChan` ?**
&emsp; Note  func `SSE.handleSSEEvent` will finally remove the channel for this request after we receive data from MCPServer and write back data to `responseChan` . Though deleting a key from a map for twice is ok, it is not efficient in concurrent scenario because we have to `lock` the exclusive mutex in SSEClient every time when we want to modify `SSEClient.responses` and `defer` is redundant  but also tries to `lock` when every thing goes well( actually, this is most of the cases will happen, the boundary cases mentioned above is rather low possible)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved internal request handling for better clarity and resource management.
  - Enhanced reliability by ensuring response channels are consistently cleaned up to prevent resource leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->