### PR TITLE
fix(client): risk of resource leak and closing closed channel

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -100,7 +100,14 @@ func (c *Stdio) Start(ctx context.Context) error {
 // Close shuts down the stdio client, closing the stdin pipe and waiting for the subprocess to exit.
 // Returns an error if there are issues closing stdin or waiting for the subprocess to terminate.
 func (c *Stdio) Close() error {
+	select {
+	case <-c.done:
+		return nil
+	default:
+	}
+	// cancel all in-flight request
 	close(c.done)
+	
 	if err := c.stdin.Close(); err != nil {
 		return fmt.Errorf("failed to close stdin: %w", err)
 	}


### PR DESCRIPTION
**Changes:**
1. refactor func `StdIo.SendRequest()` to remove the potential risk of resource leak whose situation and boundary cases are similar to and have been  discussed in  pull request #206 
2. fix the potential risk of `panic: close of closed channel`  when we call func `StdIo.Close()` for more than  one times. That is, we had better check whether the channel `c.done` in Client `StdIo` have been closed or not before we  execute `close(c.done)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resource cleanup to prevent potential leaks during request handling and cancellation.
  - Enhanced robustness by avoiding duplicate close operations.

- **Chores**
  - Added clarifying comments regarding request cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->