### PR TITLE
fix: Improve content type handling in streamable_http.go

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"strings"
@@ -206,7 +207,8 @@ func (c *StreamableHTTP) SendRequest(
 	}
 
 	// Handle different response types
-	switch resp.Header.Get("Content-Type") {
+	mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	switch mediaType {
 	case "application/json":
 		// Single response
 		var response JSONRPCResponse
@@ -248,13 +250,13 @@ func (c *StreamableHTTP) handleSSEResponse(ctx context.Context, reader io.ReadCl
 		c.readSSE(ctx, reader, func(event, data string) {
 
 			// (unsupported: batching)
-	
+
 			var message JSONRPCResponse
 			if err := json.Unmarshal([]byte(data), &message); err != nil {
 				fmt.Printf("failed to unmarshal message: %v\n", err)
 				return
 			}
-	
+
 			// Handle notification
 			if message.ID == nil {
 				var notification mcp.JSONRPCNotification
@@ -269,7 +271,7 @@ func (c *StreamableHTTP) handleSSEResponse(ctx context.Context, reader io.ReadCl
 				c.notifyMu.RUnlock()
 				return
 			}
-	
+
 			responseChan <- &message
 		})
 	}()


### PR DESCRIPTION
### Optimized content type header parsing

- Changed from direct string comparison to proper media type parsing using `mime.ParseMediaType()`
- This handles cases where the Content-Type header includes additional parameters (like charset)
- More robust parsing of content types while maintaining the same functionality
- Fixes potential false negatives when comparing raw Content-Type strings


### Test case

```go
package main

import (
	"fmt"
	"mime"
)


func main() {
	tests := []struct {
		name     string
		input    string
	}{
		{"Standard JSON", "application/json"},
		{"With charset", "application/json; charset=utf-8"},
		{"Mixed case", "APPLICATION/JSON"},
		{"Whitespace", "  application/json  "},
		{"Plain text", "text/plain"},
		{"Event stream", "text/event-stream"},
		{"Empty string", ""},
		{"Broken param", "application/json;=broken"},
		{"Subtype", "application/json-seq"},
		{"With boundary", "application/json; boundary=foo"},
	}
	for _, t := range tests {
		mediaType, _, err := mime.ParseMediaType(t.input)
		if err != nil {
			fmt.Println("err:", err)
			continue
		}
		fmt.Println(mediaType)
	}
	
}
```

```
application/json
application/json
application/json
application/json
text/plain
text/event-stream
err: mime: no media type
err: mime: invalid media parameter
application/json-seq
application/json

```

### Other

I didn't handle the error here. If processing fails, it will default to the original code's default case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of HTTP response Content-Type headers for more accurate recognition of supported formats.
- **Style**
  - Minor formatting improvements for cleaner code structure (no impact on functionality).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->