### PR TITLE
perf(server): release Mutex early for performance

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -421,11 +421,11 @@ func (s *MCPServer) AddResource(
 	}
 
 	s.resourcesMu.Lock()
-	defer s.resourcesMu.Unlock()
 	s.resources[resource.URI] = resourceEntry{
 		resource: resource,
 		handler:  handler,
 	}
+	s.resourcesMu.Unlock()
 
 	// When the list of available resources changes, servers that declared the listChanged capability SHOULD send a notification
 	if s.capabilities.resources.listChanged {
@@ -466,11 +466,11 @@ func (s *MCPServer) AddResourceTemplate(
 
 
 	s.resourcesMu.Lock()
-	defer s.resourcesMu.Unlock()
 	s.resourceTemplates[template.URITemplate.Raw()] = resourceTemplateEntry{
 		template: template,
 		handler:  handler,
 	}
+	s.resourcesMu.Unlock()
 
 	// When the list of available resources changes, servers that declared the listChanged capability SHOULD send a notification
 	if s.capabilities.resources.listChanged {
@@ -495,9 +495,9 @@ func (s *MCPServer) AddPrompt(prompt mcp.Prompt, handler PromptHandlerFunc) {
 	}
 
 	s.promptsMu.Lock()
-	defer s.promptsMu.Unlock()
 	s.prompts[prompt.Name] = prompt
 	s.promptHandlers[prompt.Name] = handler
+	s.promptsMu.Unlock()
 
 	// When the list of available resources changes, servers that declared the listChanged capability SHOULD send a notification.
 	if s.capabilities.prompts.listChanged {


### PR DESCRIPTION
&emsp; Note that in func `MCPServer.AddResource()/AddResourceTemplate()/AddPrompt()`, we utilize `defer s.resourcesMu.Unlock() / defer s.promptsMu.Unlock()` to release the corresponding exclusive mutex, which makes the functions mentioned could only release the mutex after we finish calling func `SendNotificationToAllClients()` to send notifications to all clients connected to  MCPServer. And this could be a bottleneck in concurrent scenario when there are too many clients and there are also too many request of calling func `AddResource() / AddResourceTemplate() /AddPrompt()`

**Is it  safe to release the mutex as soon as we finish modifying `s.resources/s.resourceTemplates/s.prompts`  but don't wait func `SendNotificationToAllClients` to finish?**
&emsp; I think the answer to this question is YES, because func `SendNotificationToAllClients` only iterates over all registered sessions and  send notifications to them, it doesn't modify  `s.resources/s.resourceTemplates/s.prompts` and even don't read these fields.
```Go 
//func (s *MCPServer) SendNotificationToAllClients()
	s.sessions.Range(func(k, v any) bool {
		if session, ok := v.(ClientSession); ok && session.Initialized() {
			select {
			case session.NotificationChannel() <- notification:
			default:
				// TODO: log blocked channel in the future versions
			}
		}
		return true
	})
```
**experiment**
<img width="434" alt="benchmark" src="https://github.com/user-attachments/assets/34578dae-cf3d-4924-9435-caad4fe0d31a" />
<img width="933" alt="benchmark2" src="https://github.com/user-attachments/assets/a23c7ce2-4058-4826-a79c-f7c8503bc109" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal locking mechanism for better efficiency during resource and prompt updates. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->