### PR TITLE
fix(client/test): verify mock server binary exists after compilation

### DIFF
--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -26,6 +26,9 @@ func compileTestServer(outputPath string) error {
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("compilation failed: %v\nOutput: %s", err, output)
 	}
+	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
+		return fmt.Errorf("mock server binary not found at %s after compilation", outputPath)
+	}
 	return nil
 }
 


### PR DESCRIPTION
This is just a minor internal improvement to the test harness here. I have seen a few test failures like [in this GHA run](https://github.com/mark3labs/mcp-go/actions/runs/14697791041/job/41241994839?pr=214) that are basically suggesting that the mock test server isn't present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of test server setup by verifying the existence of the mock server binary after compilation and providing a clear error message if it is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->