### PR TITLE
Fix/log blocked chan

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -233,7 +233,12 @@ func (s *MCPServer) SendNotificationToAllClients(
 			select {
 			case session.NotificationChannel() <- notification:
 			default:
-				// TODO: log blocked channel in the future versions
+				sessionID := session.SessionID()
+				if s.hooks != nil {
+					s.hooks.onError(context.Background(), nil, "", nil,
+						fmt.Errorf("notification channel blocked for session %s (method: %s)",
+							sessionID, method))
+				}
 			}
 		}
 		return true
@@ -265,6 +270,12 @@ func (s *MCPServer) SendNotificationToClient(
 	case session.NotificationChannel() <- notification:
 		return nil
 	default:
+		sessionID := session.SessionID()
+		if s.hooks != nil {
+			s.hooks.onError(ctx, nil, "", nil,
+				fmt.Errorf("notification channel blocked for session %s (method: %s)",
+					sessionID, method))
+		}
 		return fmt.Errorf("notification channel full or blocked")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -464,7 +464,6 @@ func (s *MCPServer) AddResourceTemplate(
 		s.capabilitiesMu.RUnlock()
 	}
 
-
 	s.resourcesMu.Lock()
 	defer s.resourcesMu.Unlock()
 	s.resourceTemplates[template.URITemplate.Raw()] = resourceTemplateEntry{


### PR DESCRIPTION
This pull request introduces error handling improvements for blocked notification channels and includes a minor cleanup in the `server/server.go` file. The most significant changes enhance logging and error reporting when notification channels are blocked.

### Error handling improvements:

* [`func (s *MCPServer) SendNotificationToAllClients`](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4L236-R241): Added logic to log an error using `s.hooks.onError` when a notification channel is blocked, including the session ID and method name in the error message.
* [`func (s *MCPServer) SendNotificationToClient`](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4R273-R278): Enhanced error reporting by logging blocked notification channels with `s.hooks.onError`, providing session ID and method details, and returning a descriptive error message.

### Code cleanup:

* [`func (s *MCPServer) AddResourceTemplate`](diffhunk://#diff-78f42ba40d0f10b08c73b7e6bb8376f398e249c963cf549e89591d6b6826b9a4L467): Removed an unnecessary blank line for minor code cleanup.