### PR TITLE
fix: Prevent panic in parsing functions for null results

### DIFF
--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/spf13/cast"
 )
 
@@ -433,6 +434,10 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 }
 
 func ParseGetPromptResult(rawMessage *json.RawMessage) (*GetPromptResult, error) {
+	if rawMessage == nil {
+		return nil, fmt.Errorf("response is nil")
+	}
+
 	var jsonContent map[string]any
 	if err := json.Unmarshal(*rawMessage, &jsonContent); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
@@ -495,6 +500,10 @@ func ParseGetPromptResult(rawMessage *json.RawMessage) (*GetPromptResult, error)
 }
 
 func ParseCallToolResult(rawMessage *json.RawMessage) (*CallToolResult, error) {
+	if rawMessage == nil {
+		return nil, fmt.Errorf("response is nil")
+	}
+
 	var jsonContent map[string]any
 	if err := json.Unmarshal(*rawMessage, &jsonContent); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
@@ -573,6 +582,10 @@ func ParseResourceContents(contentMap map[string]any) (ResourceContents, error) 
 }
 
 func ParseReadResourceResult(rawMessage *json.RawMessage) (*ReadResourceResult, error) {
+	if rawMessage == nil {
+		return nil, fmt.Errorf("response is nil")
+	}
+
 	var jsonContent map[string]any
 	if err := json.Unmarshal(*rawMessage, &jsonContent); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)


### PR DESCRIPTION
This PR addresses a potential panic in ParseGetPromptResult, ParseCallToolResult, and ParseReadResourceResult.  The panic could occur if the input rawMessage pointer is nil, as json. Unmarshal would attempt to dereference this nil pointer.

The functions now check for a nil rawMessage at the beginning.  Instead of proceeding (which would lead to a panic) or returning (nil, nil), they now return nil for the result object and a specific error (fmt. Errorf("rawMessage is nil")).

Reasoning:

While a nil rawMessage could conceptually represent a null JSON value, in the context of the expected protocol (e.g., Model Context Protocol), receiving a nil message pointer without a preceding transport-level error is often indicative of an upstream issue or a protocol violation.

Returning an explicit error in this scenario, rather than (nil, nil), provides clearer feedback about unexpected input and helps surface potential problems in the data source or transport layer, rather than silently treating it as a valid "empty" response.  This approach prioritizes stricter input validation and better error visibility.

Fixes #207

Summary by CodeRabbit
Bug Fixes
Enhanced the stability of message parsing functions (ParseGetPromptResult, ParseCallToolResult, ParseReadResourceResult) by adding checks for nil input messages, preventing potential crashes and returning specific errors instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling to prevent crashes when certain responses are missing or invalid. Users will now receive clearer error messages if unexpected issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->