### PR TITLE
fix: marshal `ToolInputSchema.Properties` to {} when len=0

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -113,6 +113,23 @@ type ToolInputSchema struct {
 	Required   []string               `json:"required,omitempty"`
 }
 
+// MarshalJSON implements the json.Marshaler interface for ToolInputSchema.
+func (tis ToolInputSchema) MarshalJSON() ([]byte, error) {
+	m := make(map[string]interface{})
+	m["type"] = tis.Type
+
+	// Marshal Properties to '{}' rather than `nil` when its length equals zero
+	if tis.Properties != nil {
+		m["properties"] = tis.Properties
+	}
+
+	if len(tis.Required) > 0 {
+		m["required"] = tis.Required
+	}
+
+	return json.Marshal(m)
+}
+
 type ToolAnnotation struct {
 	// Human-readable title for the tool
 	Title string `json:"title,omitempty"`


### PR DESCRIPTION
Fix: #224 
Related: #116 
&emsp;This PR customize function `MarshalJSON()` for `ToolInputSchema` which ensures that we could marshal `Properties` to `{}` rather than `null` when a Tool's input argument is empty 
> The "omitempty" option specifies that the field should be omitted from the encoding if the field has an empty value, defined as false, 0, a nil pointer, a nil interface value, **and any array, slice, map, or string of length zero.** 
[go package encoding/json.Marshal](https://pkg.go.dev/encoding/json?spm=5176.28103460.0.0.6ecc1db82JtWMc#Marshal) 

**How about deleting the `omitempty` field ?** 
&emsp; From #116, I think `omitempty` is necessary so that clients such as claude-desktop could work.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JSON serialization so that empty or nil fields in tool input schemas are now omitted, resulting in cleaner and more accurate JSON output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->