### PR TITLE
fix: Add Accept Header in StreamableHTTP Client

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -356,6 +356,7 @@ func (c *StreamableHTTP) SendNotification(ctx context.Context, notification mcp.
 
 	// Set headers
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")	
 	if sessionID := c.sessionID.Load(); sessionID != "" {
 		req.Header.Set(headerKeySessionID, sessionID.(string))
 	}


### PR DESCRIPTION
Per [Spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#sending-messages-to-the-server) , The client MUST include an Accept header, listing both application/json and text/event-stream as supported content types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured HTTP notifications now include the correct "Accept" header for improved compatibility with servers expecting "application/json, text/event-stream".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->