### PR TITLE
Fix bug with MarshalJSON for NotificationParams

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -132,7 +132,7 @@ type NotificationParams struct {
 }
 
 // MarshalJSON implements custom JSON marshaling
-func (p *NotificationParams) MarshalJSON() ([]byte, error) {
+func (p NotificationParams) MarshalJSON() ([]byte, error) {
 	// Create a map to hold all fields
 	m := make(map[string]interface{})
 


### PR DESCRIPTION
I have noticed the bug when tried to work with a server notifications to clients.
I have used the method SendNotificationToAllClients

The argument params is later used to build the notification := mcp.JSONRPCNotification object.

When this object is serialised to JSON then the dict "params" is always empty. Values originally provided to SendNotificationToAllClients are ignored and not sent to a clients.

This happens because of the 

```
func (p *NotificationParams) MarshalJSON() ([]byte, error) {
```

was used by a pointer but 

```
type Notification struct {
	Method string             `json:"method"`
	Params NotificationParams `json:"params,omitempty"`
}
```

So, or `Params NotificationParams `json:"params,omitempty"`` should be set by a pointer or a pointer should be removed from `func (p NotificationParams) MarshalJSON() ([]byte, error) {`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of JSON marshaling for notifications to improve consistency. No changes to visible functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->