### PR TITLE
fix: write back error message if the response marshal failed

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -457,7 +457,6 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 	go func() {
 		// Process message through MCPServer
 		response := s.server.HandleMessage(ctx, rawMessage)
-
 		// Only send response if there is one (not for notifications)
 		if response != nil {
 			var message string
@@ -465,7 +464,6 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 				// If there is an error marshalling the response, send a generic error response
 				log.Printf("failed to marshal response: %v", err)
 				message = fmt.Sprintf("event: message\ndata: {\"error\": \"internal error\",\"jsonrpc\": \"2.0\", \"id\": null}\n\n")
-				return
 			} else {
 				message = fmt.Sprintf("event: message\ndata: %s\n\n", eventData)
 			}


### PR DESCRIPTION
[#163] adds a logic to construct a error message when response marshal failed but return before sending to eventQueue.
This fix writes back the response.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling to ensure clients always receive an error message if a server-side processing issue occurs.

- **Tests**
	- Added a new test to verify proper server behavior when response formatting fails.
	- Renamed a test helper function for clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->