### PR TITLE
fix(server/sse): potential goroutine leak in Heartbeat sender

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -367,7 +367,12 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 					}
 					messageBytes, _ := json.Marshal(message)
 					pingMsg := fmt.Sprintf("event: message\ndata:%s\n\n", messageBytes)
-					session.eventQueue <- pingMsg
+					select {
+					case session.eventQueue <- pingMsg:
+						// Message sent successfully
+					case <-session.done:
+						return
+					}
 				case <-session.done:
 					return
 				case <-r.Context().Done():


### PR DESCRIPTION
&emsp; Currently, there's one potential goroutine leak scenario caused by blocking sends to the `session.eventQueue` channel in the SSEServer heartbeat logic. The problematic case occurs under the following conditions:
1. The `session.eventQueue` channel **is full**(buffered channel with a fixed size of 100)
2. The heartbeat goroutine **attempts to send a ping message but is blocked** because the channel is full:
```Go
session.eventQueue <- pingMsg
```
3. Meanwhile, the **main SSE handler goroutine exists**(e.g., due to `r.Context.Done()` or `session.done` being closed), and **no one is left consuming from `session.eventQueue`**
4. As a result, the heartbeat goroutine becomes permanently blocked and never exits, which leads to:
4.1 A goroutine leak
4.2 The `session` and its associated channels(`eventQueue`, etc.) staying alive longer than needed
4.3 Potential memory pressure and scalability issues under high-concurrency or long-running conditions

&emsp;This issue can be reproduced in edge cases where the client disconnects or becomes slow, and the server continues trying to send heartbeat messages at a fixed interval.

**[Que1 ]Why not add `case <- r.Context.Done()` in the new added `select` statement ?**
&emsp; Note that the main SSE handler will `close(session.done)` when `r.Context` is cancelled, so I think there's no need to monitor this case in the added `select` statement
**[Que2] Is it possible that the main SSE handler will exit when `session.eventQueue` is full?**
&emsp;Due to Go's select semantics, when multiple cases are ready (e.g., a message is available in eventQueue and r.Context().Done() is also ready), the runtime **picks one at random**. This can cause the main goroutine to exit before draining eventQueue, leaving producer goroutines blocked indefinitely.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the reliability of server-sent events by ensuring keep-alive ping messages do not cause blocking or deadlocks when a session is closed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->