### PR TITLE
refactor(server/sse): rename WithBasePath to WithStaticBasePath

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -135,11 +135,20 @@ func WithBaseURL(baseURL string) SSEOption {
 	}
 }
 
-// WithBasePath adds a new option for setting a static base path
-func WithBasePath(basePath string) SSEOption {
+// WithStaticBasePath adds a new option for setting a static base path
+func WithStaticBasePath(basePath string) SSEOption {
 	return func(s *SSEServer) {
 		s.basePath = normalizeURLPath(basePath)
 	}
+}
+
+// WithBasePath adds a new option for setting a static base path.
+//
+// Deprecated: Use WithStaticBasePath instead. This will be removed in a future version.
+//
+//go:deprecated
+func WithBasePath(basePath string) SSEOption {
+	return WithStaticBasePath(basePath)
 }
 
 // WithDynamicBasePath accepts a function for generating the base path. This is

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -24,7 +24,7 @@ func TestSSEServer(t *testing.T) {
 		mcpServer := NewMCPServer("test", "1.0.0")
 		sseServer := NewSSEServer(mcpServer,
 			WithBaseURL("http://localhost:8080"),
-			WithBasePath("/mcp"),
+			WithStaticBasePath("/mcp"),
 		)
 
 		if sseServer == nil {
@@ -499,7 +499,7 @@ func TestSSEServer(t *testing.T) {
 
 	t.Run("works as http.Handler with custom basePath", func(t *testing.T) {
 		mcpServer := NewMCPServer("test", "1.0.0")
-		sseServer := NewSSEServer(mcpServer, WithBasePath("/mcp"))
+		sseServer := NewSSEServer(mcpServer, WithStaticBasePath("/mcp"))
 
 		ts := httptest.NewServer(sseServer)
 		defer ts.Close()
@@ -717,7 +717,7 @@ func TestSSEServer(t *testing.T) {
 		useFullURLForMessageEndpoint := false
 		srv := &http.Server{}
 		rands := []SSEOption{
-			WithBasePath(basePath),
+			WithStaticBasePath(basePath),
 			WithBaseURL(baseURL),
 			WithMessageEndpoint(messageEndpoint),
 			WithUseFullURLForMessageEndpoint(useFullURLForMessageEndpoint),


### PR DESCRIPTION
The new name makes its relationship to `WithDynamicBasePath` clearer.

---

I preserved `WithBasePath` but added a build time deprecation warning (when using go 1.21+).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved naming for SSE server configuration to enhance clarity.
- **Chores**
  - Deprecated the previous configuration option and added guidance for transitioning.
  - Updated tests to reflect the new configuration option name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->