### PR TITLE
test: build mockstdio_server with isolated cache to prevent flaky CI

### DIFF
--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -24,9 +24,13 @@ func compileTestServer(outputPath string) error {
 		outputPath,
 		"../testdata/mockstdio_server.go",
 	)
+	tmpCache, _ := os.MkdirTemp("", "gocache")
+	cmd.Env = append(os.Environ(), "GOCACHE="+tmpCache)
+
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("compilation failed: %v\nOutput: %s", err, output)
 	}
+	// Verify the binary was actually created
 	if _, err := os.Stat(outputPath); os.IsNotExist(err) {
 		return fmt.Errorf("mock server binary not found at %s after compilation", outputPath)
 	}

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -23,6 +23,9 @@ func compileTestServer(outputPath string) error {
 		outputPath,
 		"../../testdata/mockstdio_server.go",
 	)
+	tmpCache, _ := os.MkdirTemp("", "gocache")
+	cmd.Env = append(os.Environ(), "GOCACHE="+tmpCache)
+
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("compilation failed: %v\nOutput: %s", err, output)
 	}


### PR DESCRIPTION
CI occasionally failed with the linker error:

    /link: cannot open file DO NOT USE - main build pseudo-cache built

This is most likely because several parallel `go build` invocations shared the same `$GOCACHE`, letting one job evict the object file another job had promised the linker. The placeholder path then leaked through and the build aborted.

This gives each compile its own cache by setting  `GOCACHE=$(mktemp -d)` for the helper’s `go build` call.

---

I hadn't seen #240 when I started working on this and it addresses the issue as well. I think these changes are complimentary though and using isolated `GOCACHE` is probably still a useful change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process for test servers to use an isolated build cache and removed a specific build flag. No changes to user-facing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->