### PR TITLE
fix(MCPServer): Session tool handler not used due to variable shadowing

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -856,7 +856,7 @@ func (s *MCPServer) handleToolCall(
 
 	session := ClientSessionFromContext(ctx)
 	if session != nil {
-		if sessionWithTools, ok := session.(SessionWithTools); ok {
+		if sessionWithTools, typeAssertOk := session.(SessionWithTools); typeAssertOk {
 			if sessionTools := sessionWithTools.GetSessionTools(); sessionTools != nil {
 				var sessionOk bool
 				tool, sessionOk = sessionTools[request.Params.Name]


### PR DESCRIPTION
**Problem**
&emsp; This PR fixes a bug where **session-specific tool handlers were never used**, and MCPServer always fell back to global tool handlers.
&emsp; The issue was caused by **variable shadowing** in the following block of code:
```Go
if sessionWithTools, ok := session.(SessionWithTools); ok {
    ...
    if sessionOk {
        ok = true
    }
}
```
&emsp; The `ok` declared in `if sessionWithTools, ok :=  ....` shadows the outer `ok` variable declared in the function:
```Go
var ok bool
```
&emsp; As a result, setting `ok = true` inside this `if` block had **no effect on the outer variable**, and the following loginc:
```Go
if !ok {
    //fallback to global tools
}
```
was **always executed**, even if a session tool was actually found.

**Fix**
&emsp; This fix simply avoids shadowing by renaming the inner variable:
```Go
if sessionWithTools, typeAssertOk := session.(SessionWithTools); typeAssertOk {
```
&emsp; This ensures that the outer `ok` variable reflects whether a session-specific tool was found and used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a test to verify that session-specific tools correctly override global tools with the same name when called within a session context.

- **Refactor**
  - Improved variable naming in session tool handling to prevent naming conflicts and enhance code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->