### PR TITLE
fix: Use detached context for SSE message handling

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -465,10 +465,19 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Create a context that preserves all values from parent ctx but won't be canceled when the parent is canceled.
+	// this is required because the http ctx will be canceled when the client disconnects
+	detachedCtx := context.WithoutCancel(ctx)
+
 	// quick return request, send 202 Accepted with no body, then deal the message and sent response via SSE
 	w.WriteHeader(http.StatusAccepted)
 
-	go func() {
+	// Create a new context for handling the message that will be canceled when the message handling is done
+	sessionCtx, cancel := context.WithCancel(detachedCtx)
+
+	go func(ctx context.Context) {
+		defer cancel()
+		// Use the context that will be canceled when session is done
 		// Process message through MCPServer
 		response := s.server.HandleMessage(ctx, rawMessage)
 		// Only send response if there is one (not for notifications)
@@ -493,7 +502,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 				log.Printf("Event queue full for session %s", sessionID)
 			}
 		}
-	}()
+	}(sessionCtx)
 }
 
 // writeJSONRPCError writes a JSON-RPC error response with the given error details.

--- a/server/sse.go
+++ b/server/sse.go
@@ -473,7 +473,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 
 	// Create a new context for handling the message that will be canceled when the message handling is done
-	sessionCtx, cancel := context.WithCancel(detachedCtx)
+	messageCtx, cancel := context.WithCancel(detachedCtx)
 
 	go func(ctx context.Context) {
 		defer cancel()
@@ -502,7 +502,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 				log.Printf("Event queue full for session %s", sessionID)
 			}
 		}
-	}(sessionCtx)
+	}(messageCtx)
 }
 
 // writeJSONRPCError writes a JSON-RPC error response with the given error details.


### PR DESCRIPTION
Prevents premature cancellation of message processing when HTTP request ends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message processing to continue handling messages fully even if the client disconnects.  
- **Tests**
  - Added coverage to verify that request processing completes after client disconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->