### PR TITLE
Define session storage interface

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -146,7 +146,7 @@ type MCPServer struct {
 	notificationHandlers   map[string]NotificationHandlerFunc
 	capabilities           serverCapabilities
 	paginationLimit        *int
-	sessions               sync.Map
+	sessions               SessionStore
 	hooks                  *Hooks
 }
 
@@ -292,6 +292,7 @@ func NewMCPServer(
 			prompts:   nil,
 			logging:   false,
 		},
+		sessions: &localSessionStore{},
 	}
 
 	for _, opt := range opts {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -596,7 +596,7 @@ func TestMCPServer_SendNotificationToAllClients(t *testing.T) {
 		}
 
 		// Verify each session received all 10 notifications
-		srv.sessions.Range(func(k, v any) bool {
+		srv.sessions.Range(func(k string, v ClientSession) bool {
 			session := v.(ClientSession)
 			fakeSess := session.(*fakeSession)
 			notificationCount := 0

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -596,8 +596,7 @@ func TestMCPServer_SendNotificationToAllClients(t *testing.T) {
 		}
 
 		// Verify each session received all 10 notifications
-		srv.sessions.Range(func(k string, v ClientSession) bool {
-			session := v.(ClientSession)
+		srv.sessions.Range(func(k string, session ClientSession) bool {
 			fakeSess := session.(*fakeSession)
 			notificationCount := 0
 

--- a/server/session.go
+++ b/server/session.go
@@ -91,7 +91,7 @@ func (s *MCPServer) SendNotificationToAllClients(
 		},
 	}
 
-	s.sessions.Range(func(k, v any) bool {
+	s.sessions.Range(func(k string, v ClientSession) bool {
 		if session, ok := v.(ClientSession); ok && session.Initialized() {
 			select {
 			case session.NotificationChannel() <- notification:

--- a/server/session_store.go
+++ b/server/session_store.go
@@ -1,0 +1,49 @@
+package server
+
+import "sync"
+
+// SessionStore defines an interface for overriding the in-process session
+// storage.
+type SessionStore interface {
+	Load(key string) (ClientSession, bool)
+	LoadAndDelete(key string) (ClientSession, bool)
+	LoadOrStore(string, ClientSession) (ClientSession, bool)
+	Range(f func(string, ClientSession) bool)
+}
+
+type localSessionStore struct {
+	sync.Map
+}
+
+func (store *localSessionStore) Load(key string) (ClientSession, bool) {
+	value, ok := store.Map.Load(key)
+	if !ok {
+		return nil, false
+	}
+
+	return value.(ClientSession), true
+}
+
+func (store *localSessionStore) LoadAndDelete(key string) (ClientSession, bool) {
+	value, loaded := store.Map.LoadAndDelete(key)
+	if !loaded {
+		return nil, false
+	}
+
+	return value.(ClientSession), true
+}
+
+func (store *localSessionStore) LoadOrStore(key string, value ClientSession) (ClientSession, bool) {
+	actual, loaded := store.Map.LoadOrStore(key, value)
+	if !loaded {
+		return value, false
+	}
+
+	return actual.(ClientSession), true
+}
+
+func (store *localSessionStore) Range(f func(string, ClientSession) bool) {
+	store.Map.Range(func(key any, value any) bool {
+		return f(key.(string), value.(ClientSession))
+	})
+}

--- a/server/sse.go
+++ b/server/sse.go
@@ -290,7 +290,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 			if session, ok := value.(*sseSession); ok {
 				close(session.done)
 			}
-			s.sessions.Delete(key)
+			s.sessions.LoadAndDelete(key)
 			return true
 		})
 
@@ -328,8 +328,8 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		notificationChannel: make(chan mcp.JSONRPCNotification, 100),
 	}
 
-	s.sessions.Store(sessionID, session)
-	defer s.sessions.Delete(sessionID)
+	s.sessions.LoadOrStore(sessionID, session)
+	defer s.sessions.LoadAndDelete(sessionID)
 
 	if err := s.server.RegisterSession(r.Context(), session); err != nil {
 		http.Error(w, fmt.Sprintf("Session registration failed: %v", err), http.StatusInternalServerError)


### PR DESCRIPTION
Right now, [`MCPServer`](https://pkg.go.dev/github.com/mark3labs/mcp-go@v0.25.0/server#MCPServer) and [`SSEServer`](https://pkg.go.dev/github.com/mark3labs/mcp-go@v0.25.0/server#SSEServer) define internal fields for storing sessions.

The default session storage is implemented with `sync.Map` which makes it hard to scale a back-end. With the SSE transport, message requests need to be received by the same process hosting the SSE connection. For this to happen, you need session affinity. Routing layers typically implement this through an HTTP cookie but I don't think available clients broadly honor `Set-Cookie` headers.

So, the session storage should probably be overridable to allow horizontally scaled deployments.

This pull request is not a complete solution but really a request for comments on how to do this. My first draft is narrowing how `sync.Map` is used to minimize the interface. A second step would then be accepting an option to pass in such an implementation.

(The session store will need to also be responsible for creating new sessions and provide a custom implementation of [the `ClientSession` interface](https://pkg.go.dev/github.com/mark3labs/mcp-go@v0.25.0/server#ClientSession).)

## Alternatives

The `OnRegisterSession` hook potentially allows tracking the session registration and then propagating the existence of this session to other nodes which would register them through [`(*MCPServer).RegisterSession`](https://pkg.go.dev/github.com/mark3labs/mcp-go@v0.25.0/server#MCPServer.RegisterSession). The problem is that every server then needs to keep track of every session and there would be a delay where a newly created session is not known to every node. That makes it a nonstarter.

Another approach would be to embed a node name into the session ID itself, intercept requests early and do sideways routing to the proper node. There's no technical blocker to doing this but it would lead to some amount of code duplication and unnecessary processing.