### PR TITLE
fix(Srv/stdio): risk of goroutine leaks and concurrent reads in `readNextLine()`

### DIFF
--- a/server/stdio.go
+++ b/server/stdio.go
@@ -171,7 +171,6 @@ func (s *StdioServer) readNextLine(ctx context.Context, reader *bufio.Reader) (s
 				select {
 				case errChan <- err:
 				case <-done:
-
 				}
 				return
 			}
@@ -179,6 +178,7 @@ func (s *StdioServer) readNextLine(ctx context.Context, reader *bufio.Reader) (s
 			case readChan <- line:
 			case <-done:
 			}
+			return
 		}
 	}()
 


### PR DESCRIPTION
# Problem Summary
&emsp;The original implementation of `readNextLine` spawns a goroutine to perform a `ReadString('\n')` call and deliver the result via `readChan` or `errChan`. However, this goroutine **did not return immediately** after writing to a channel, which introduces **two subtle concurrency issues** caused by incorrect assumptions about goroutine scheduling and lifecycle.
**[Problem]Data Loss or Goroutine Leak**
&emsp;If the outer `readNextLine` function exits due to context cancellation (e.g., `ctx.Done()`), but the inner goroutine is still blocked on `ReadString` or attempting to send to a now-unread `readChan`, the following may happen:
- The goroutine continues to read input and successfully captures a line,
- But `readChan` is never read again,
- Or the goroutine continues reading beyond its intended scope.

&emsp;➡️ Result: **The read data is lost,** and **the goroutine leaks**, causing silent memory and input channel pressure over time.

**[Problem] Concurrent Reads on `bufio.Reader`**:
&emsp;If the spawned goroutine successfully delivers a line to `readChan` but does not return immediately, it may remain alive and proceed to call `ReadString('\n')` again. This can happen if the Go scheduler delays the main thread’s consumption of the value, allowing the same goroutine to continue running.
&emsp;➡️ Result: **Multiple goroutines may perform concurrent reads on the shared `bufio.Reader`,** which is not safe for concurrent use. This can cause data corruption, misordered reads, or panics.

# Root Cause: Invalid Timing Assumption
The original logic assumes:
> That the `readChan` or `errChan` consumer will always read immediately after the line is sent, and that the goroutine will exit soon enough due to a closed `done` channel.

&emsp;This is **a scheduling-dependent assumption**, and does **not hold reliably in Go's concurrent model.** The race occurs in the tiny gap between delivering the line and reacting to `done`.
# Fix: Exit Goroutine Immediately After Attempting to Deliver
&emsp;We fix this by ensuring the goroutine **returns immediately after the `select` that attempts to deliver the line,**:
```Go
select {
case readChan <- line:
case <-done:
}
return
```
This ensures:
- Each goroutine performs **at most one read**,
- The goroutine always exits quickly after delivery or cancellation,
- All data is either consumed or explicitly dropped with awareness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when reading lines by ensuring background processes exit promptly after completing their task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->