### PR TITLE
ci: add check to verify generated code is up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,3 +15,21 @@ jobs:
       with:
         go-version-file: 'go.mod'
     - run: go test ./... -race
+
+  verify-codegen:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: 'go.mod'
+    - name: Run code generation
+      run: go generate ./...
+    - name: Check for uncommitted changes
+      run: |
+        if [[ -n $(git status --porcelain) ]]; then
+          echo "Error: Generated code is not up to date. Please run 'go generate ./...' and commit the changes."
+          git status
+          git diff
+          exit 1
+        fi


### PR DESCRIPTION
This commit adds a new CI job that runs code generation and verifies no  uncommitted changes exist. This prevents accidental manual edits to  autogenerated files by:

1. Running `go generate ./...` during CI
2. Failing the build when generated code differs from committed code
3. Providing clear error messages with instructions for developers



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow to allow manual runs and added a new job to verify code generation and detect uncommitted changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->