### PR TITLE
chore: replace `interface{}` with `any`

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -94,7 +94,7 @@ func (c *Client) OnNotification(
 func (c *Client) sendRequest(
 	ctx context.Context,
 	method string,
-	params interface{},
+	params any,
 ) (*json.RawMessage, error) {
 	if !c.initialized && method != "initialize" {
 		return nil, fmt.Errorf("client not initialized")

--- a/client/inprocess_test.go
+++ b/client/inprocess_test.go
@@ -196,7 +196,7 @@ func TestInProcessMCPClient(t *testing.T) {
 
 		request := mcp.CallToolRequest{}
 		request.Params.Name = "test-tool"
-		request.Params.Arguments = map[string]interface{}{
+		request.Params.Arguments = map[string]any{
 			"parameter-1": "value1",
 		}
 

--- a/client/sse_test.go
+++ b/client/sse_test.go
@@ -238,7 +238,7 @@ func TestSSEMCPClient(t *testing.T) {
 
 		request := mcp.CallToolRequest{}
 		request.Params.Name = "test-tool"
-		request.Params.Arguments = map[string]interface{}{
+		request.Params.Arguments = map[string]any{
 			"parameter-1": "value1",
 		}
 

--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -232,7 +232,7 @@ func TestStdioMCPClient(t *testing.T) {
 
 		request := mcp.CallToolRequest{}
 		request.Params.Name = "test-tool"
-		request.Params.Arguments = map[string]interface{}{
+		request.Params.Arguments = map[string]any{
 			"param1": "value1",
 		}
 

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -64,7 +64,7 @@ func startMockSSEEchoServer() (string, func()) {
 		}
 
 		// Parse incoming JSON-RPC request
-		var request map[string]interface{}
+		var request map[string]any
 		decoder := json.NewDecoder(r.Body)
 		if err := decoder.Decode(&request); err != nil {
 			http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
@@ -72,7 +72,7 @@ func startMockSSEEchoServer() (string, func()) {
 		}
 
 		// Echo back the request as the response result
-		response := map[string]interface{}{
+		response := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      request["id"],
 			"result":  request,
@@ -96,7 +96,7 @@ func startMockSSEEchoServer() (string, func()) {
 			mu.Unlock()
 		case "debug/echo_error_string":
 			data, _ := json.Marshal(request)
-			response["error"] = map[string]interface{}{
+			response["error"] = map[string]any{
 				"code":    -1,
 				"message": string(data),
 			}
@@ -153,9 +153,9 @@ func TestSSE(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		params := map[string]interface{}{
+		params := map[string]any{
 			"string": "hello world",
-			"array":  []interface{}{1, 2, 3},
+			"array":  []any{1, 2, 3},
 		}
 
 		request := JSONRPCRequest{
@@ -173,10 +173,10 @@ func TestSSE(t *testing.T) {
 
 		// Parse the result to verify echo
 		var result struct {
-			JSONRPC string                 `json:"jsonrpc"`
-			ID      int64                  `json:"id"`
-			Method  string                 `json:"method"`
-			Params  map[string]interface{} `json:"params"`
+			JSONRPC string         `json:"jsonrpc"`
+			ID      int64          `json:"id"`
+			Method  string         `json:"method"`
+			Params  map[string]any `json:"params"`
 		}
 
 		if err := json.Unmarshal(response.Result, &result); err != nil {
@@ -198,7 +198,7 @@ func TestSSE(t *testing.T) {
 			t.Errorf("Expected string 'hello world', got %v", result.Params["string"])
 		}
 
-		if arr, ok := result.Params["array"].([]interface{}); !ok || len(arr) != 3 {
+		if arr, ok := result.Params["array"].([]any); !ok || len(arr) != 3 {
 			t.Errorf("Expected array with 3 items, got %v", result.Params["array"])
 		}
 	})
@@ -244,7 +244,7 @@ func TestSSE(t *testing.T) {
 			Notification: mcp.Notification{
 				Method: "debug/echo_notification",
 				Params: mcp.NotificationParams{
-					AdditionalFields: map[string]interface{}{"test": "value"},
+					AdditionalFields: map[string]any{"test": "value"},
 				},
 			},
 		}
@@ -294,7 +294,7 @@ func TestSSE(t *testing.T) {
 					JSONRPC: "2.0",
 					ID:      int64(100 + idx),
 					Method:  "debug/echo",
-					Params: map[string]interface{}{
+					Params: map[string]any{
 						"requestIndex": idx,
 						"timestamp":    time.Now().UnixNano(),
 					},
@@ -324,10 +324,10 @@ func TestSSE(t *testing.T) {
 
 			// Parse the result to verify echo
 			var result struct {
-				JSONRPC string                 `json:"jsonrpc"`
-				ID      int64                  `json:"id"`
-				Method  string                 `json:"method"`
-				Params  map[string]interface{} `json:"params"`
+				JSONRPC string         `json:"jsonrpc"`
+				ID      int64          `json:"id"`
+				Method  string         `json:"method"`
+				Params  map[string]any `json:"params"`
 			}
 
 			if err := json.Unmarshal(responses[i].Result, &result); err != nil {

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -73,9 +73,9 @@ func TestStdio(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5000000000*time.Second)
 		defer cancel()
 
-		params := map[string]interface{}{
+		params := map[string]any{
 			"string": "hello world",
-			"array":  []interface{}{1, 2, 3},
+			"array":  []any{1, 2, 3},
 		}
 
 		request := JSONRPCRequest{
@@ -93,10 +93,10 @@ func TestStdio(t *testing.T) {
 
 		// Parse the result to verify echo
 		var result struct {
-			JSONRPC string                 `json:"jsonrpc"`
-			ID      int64                  `json:"id"`
-			Method  string                 `json:"method"`
-			Params  map[string]interface{} `json:"params"`
+			JSONRPC string         `json:"jsonrpc"`
+			ID      int64          `json:"id"`
+			Method  string         `json:"method"`
+			Params  map[string]any `json:"params"`
 		}
 
 		if err := json.Unmarshal(response.Result, &result); err != nil {
@@ -118,7 +118,7 @@ func TestStdio(t *testing.T) {
 			t.Errorf("Expected string 'hello world', got %v", result.Params["string"])
 		}
 
-		if arr, ok := result.Params["array"].([]interface{}); !ok || len(arr) != 3 {
+		if arr, ok := result.Params["array"].([]any); !ok || len(arr) != 3 {
 			t.Errorf("Expected array with 3 items, got %v", result.Params["array"])
 		}
 	})
@@ -164,7 +164,7 @@ func TestStdio(t *testing.T) {
 			Notification: mcp.Notification{
 				Method: "debug/echo_notification",
 				Params: mcp.NotificationParams{
-					AdditionalFields: map[string]interface{}{"test": "value"},
+					AdditionalFields: map[string]any{"test": "value"},
 				},
 			},
 		}
@@ -213,7 +213,7 @@ func TestStdio(t *testing.T) {
 					JSONRPC: "2.0",
 					ID:      int64(100 + idx),
 					Method:  "debug/echo",
-					Params: map[string]interface{}{
+					Params: map[string]any{
 						"requestIndex": idx,
 						"timestamp":    time.Now().UnixNano(),
 					},
@@ -243,10 +243,10 @@ func TestStdio(t *testing.T) {
 
 			// Parse the result to verify echo
 			var result struct {
-				JSONRPC string                 `json:"jsonrpc"`
-				ID      int64                  `json:"id"`
-				Method  string                 `json:"method"`
-				Params  map[string]interface{} `json:"params"`
+				JSONRPC string         `json:"jsonrpc"`
+				ID      int64          `json:"id"`
+				Method  string         `json:"method"`
+				Params  map[string]any `json:"params"`
 			}
 
 			if err := json.Unmarshal(responses[i].Result, &result); err != nil {

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -46,7 +46,7 @@ func startMockStreamableHTTPServer() (string, func()) {
 			w.Header().Set("Mcp-Session-Id", sessionID)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      request["id"],
 				"result":  "initialized",
@@ -62,7 +62,7 @@ func startMockStreamableHTTPServer() (string, func()) {
 			// Echo back the request as the response result
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      request["id"],
 				"result":  request,
@@ -104,10 +104,10 @@ func startMockStreamableHTTPServer() (string, func()) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			data, _ := json.Marshal(request)
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			json.NewEncoder(w).Encode(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      request["id"],
-				"error": map[string]interface{}{
+				"error": map[string]any{
 					"code":    -1,
 					"message": string(data),
 				},
@@ -152,9 +152,9 @@ func TestStreamableHTTP(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
 
-		params := map[string]interface{}{
+		params := map[string]any{
 			"string": "hello world",
-			"array":  []interface{}{1, 2, 3},
+			"array":  []any{1, 2, 3},
 		}
 
 		request := JSONRPCRequest{
@@ -172,10 +172,10 @@ func TestStreamableHTTP(t *testing.T) {
 
 		// Parse the result to verify echo
 		var result struct {
-			JSONRPC string                 `json:"jsonrpc"`
-			ID      int64                  `json:"id"`
-			Method  string                 `json:"method"`
-			Params  map[string]interface{} `json:"params"`
+			JSONRPC string         `json:"jsonrpc"`
+			ID      int64          `json:"id"`
+			Method  string         `json:"method"`
+			Params  map[string]any `json:"params"`
 		}
 
 		if err := json.Unmarshal(response.Result, &result); err != nil {
@@ -197,7 +197,7 @@ func TestStreamableHTTP(t *testing.T) {
 			t.Errorf("Expected string 'hello world', got %v", result.Params["string"])
 		}
 
-		if arr, ok := result.Params["array"].([]interface{}); !ok || len(arr) != 3 {
+		if arr, ok := result.Params["array"].([]any); !ok || len(arr) != 3 {
 			t.Errorf("Expected array with 3 items, got %v", result.Params["array"])
 		}
 	})
@@ -295,7 +295,7 @@ func TestStreamableHTTP(t *testing.T) {
 					JSONRPC: "2.0",
 					ID:      int64(100 + idx),
 					Method:  "debug/echo",
-					Params: map[string]interface{}{
+					Params: map[string]any{
 						"requestIndex": idx,
 						"timestamp":    time.Now().UnixNano(),
 					},
@@ -325,10 +325,10 @@ func TestStreamableHTTP(t *testing.T) {
 
 			// Parse the result to verify echo
 			var result struct {
-				JSONRPC string                 `json:"jsonrpc"`
-				ID      int64                  `json:"id"`
-				Method  string                 `json:"method"`
-				Params  map[string]interface{} `json:"params"`
+				JSONRPC string         `json:"jsonrpc"`
+				ID      int64          `json:"id"`
+				Method  string         `json:"method"`
+				Params  map[string]any `json:"params"`
 			}
 
 			if err := json.Unmarshal(responses[i].Result, &result); err != nil {

--- a/examples/custom_context/main.go
+++ b/examples/custom_context/main.go
@@ -44,8 +44,8 @@ func tokenFromContext(ctx context.Context) (string, error) {
 }
 
 type response struct {
-	Args    map[string]interface{} `json:"args"`
-	Headers map[string]string      `json:"headers"`
+	Args    map[string]any    `json:"args"`
+	Headers map[string]string `json:"headers"`
 }
 
 // makeRequest makes a request to httpbin.org including the auth token in the request

--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -137,12 +137,12 @@ func NewMCPServer() *server.MCPServer {
 	// 	Description: "Samples from an LLM using MCP's sampling feature",
 	// 	InputSchema: mcp.ToolInputSchema{
 	// 		Type: "object",
-	// 		Properties: map[string]interface{}{
-	// 			"prompt": map[string]interface{}{
+	// 		Properties: map[string]any{
+	// 			"prompt": map[string]any{
 	// 				"type":        "string",
 	// 				"description": "The prompt to send to the LLM",
 	// 			},
-	// 			"maxTokens": map[string]interface{}{
+	// 			"maxTokens": map[string]any{
 	// 				"type":        "number",
 	// 				"description": "Maximum number of tokens to generate",
 	// 				"default":     100,
@@ -190,9 +190,9 @@ func runUpdateInterval() {
 	// 				Notification: mcp.Notification{
 	// 					Method: "resources/updated",
 	// 					Params: struct {
-	// 						Meta map[string]interface{} `json:"_meta,omitempty"`
+	// 						Meta map[string]any `json:"_meta,omitempty"`
 	// 					}{
-	// 						Meta: map[string]interface{}{"uri": uri},
+	// 						Meta: map[string]any{"uri": uri},
 	// 					},
 	// 				},
 	// 			},
@@ -333,7 +333,7 @@ func handleSendNotification(
 	err := server.SendNotificationToClient(
 		ctx,
 		"notifications/progress",
-		map[string]interface{}{
+		map[string]any{
 			"progress":      10,
 			"total":         10,
 			"progressToken": 0,
@@ -370,7 +370,7 @@ func handleLongRunningOperationTool(
 			server.SendNotificationToClient(
 				ctx,
 				"notifications/progress",
-				map[string]interface{}{
+				map[string]any{
 					"progress":      i,
 					"total":         int(steps),
 					"progressToken": progressToken,
@@ -394,7 +394,7 @@ func handleLongRunningOperationTool(
 	}, nil
 }
 
-// func (s *MCPServer) handleSampleLLMTool(arguments map[string]interface{}) (*mcp.CallToolResult, error) {
+// func (s *MCPServer) handleSampleLLMTool(arguments map[string]any) (*mcp.CallToolResult, error) {
 // 	prompt, _ := arguments["prompt"].(string)
 // 	maxTokens, _ := arguments["maxTokens"].(float64)
 
@@ -406,7 +406,7 @@ func handleLongRunningOperationTool(
 // 	)
 
 // 	return &mcp.CallToolResult{
-// 		Content: []interface{}{
+// 		Content: []any{
 // 			mcp.TextContent{
 // 				Type: "text",
 // 				Text: fmt.Sprintf("LLM sampling result: %s", result),

--- a/examples/filesystem_stdio_client/main.go
+++ b/examples/filesystem_stdio_client/main.go
@@ -79,7 +79,7 @@ func main() {
 	fmt.Println("Listing /tmp directory...")
 	listTmpRequest := mcp.CallToolRequest{}
 	listTmpRequest.Params.Name = "list_directory"
-	listTmpRequest.Params.Arguments = map[string]interface{}{
+	listTmpRequest.Params.Arguments = map[string]any{
 		"path": "/tmp",
 	}
 
@@ -94,7 +94,7 @@ func main() {
 	fmt.Println("Creating /tmp/mcp directory...")
 	createDirRequest := mcp.CallToolRequest{}
 	createDirRequest.Params.Name = "create_directory"
-	createDirRequest.Params.Arguments = map[string]interface{}{
+	createDirRequest.Params.Arguments = map[string]any{
 		"path": "/tmp/mcp",
 	}
 
@@ -109,7 +109,7 @@ func main() {
 	fmt.Println("Creating /tmp/mcp/hello.txt...")
 	writeFileRequest := mcp.CallToolRequest{}
 	writeFileRequest.Params.Name = "write_file"
-	writeFileRequest.Params.Arguments = map[string]interface{}{
+	writeFileRequest.Params.Arguments = map[string]any{
 		"path":    "/tmp/mcp/hello.txt",
 		"content": "Hello World",
 	}
@@ -125,7 +125,7 @@ func main() {
 	fmt.Println("Reading /tmp/mcp/hello.txt...")
 	readFileRequest := mcp.CallToolRequest{}
 	readFileRequest.Params.Name = "read_file"
-	readFileRequest.Params.Arguments = map[string]interface{}{
+	readFileRequest.Params.Arguments = map[string]any{
 		"path": "/tmp/mcp/hello.txt",
 	}
 
@@ -139,7 +139,7 @@ func main() {
 	fmt.Println("Getting info for /tmp/mcp/hello.txt...")
 	fileInfoRequest := mcp.CallToolRequest{}
 	fileInfoRequest.Params.Name = "get_file_info"
-	fileInfoRequest.Params.Arguments = map[string]interface{}{
+	fileInfoRequest.Params.Arguments = map[string]any{
 		"path": "/tmp/mcp/hello.txt",
 	}
 

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -44,8 +44,8 @@ type CallToolResult struct {
 type CallToolRequest struct {
 	Request
 	Params struct {
-		Name      string                 `json:"name"`
-		Arguments map[string]interface{} `json:"arguments,omitempty"`
+		Name      string         `json:"name"`
+		Arguments map[string]any `json:"arguments,omitempty"`
 		Meta      *struct {
 			// If specified, the caller is requesting out-of-band progress
 			// notifications for this request (as represented by
@@ -83,7 +83,7 @@ type Tool struct {
 // It handles marshaling either InputSchema or RawInputSchema based on which is set.
 func (t Tool) MarshalJSON() ([]byte, error) {
 	// Create a map to build the JSON structure
-	m := make(map[string]interface{}, 3)
+	m := make(map[string]any, 3)
 
 	// Add the name and description
 	m["name"] = t.Name
@@ -108,14 +108,14 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 }
 
 type ToolInputSchema struct {
-	Type       string                 `json:"type"`
-	Properties map[string]interface{} `json:"properties,omitempty"`
-	Required   []string               `json:"required,omitempty"`
+	Type       string         `json:"type"`
+	Properties map[string]any `json:"properties,omitempty"`
+	Required   []string       `json:"required,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface for ToolInputSchema.
 func (tis ToolInputSchema) MarshalJSON() ([]byte, error) {
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 	m["type"] = tis.Type
 
 	// Marshal Properties to '{}' rather than `nil` when its length equals zero
@@ -149,7 +149,7 @@ type ToolOption func(*Tool)
 
 // PropertyOption is a function that configures a property in a Tool's input schema.
 // It allows for flexible configuration of JSON Schema properties using the functional options pattern.
-type PropertyOption func(map[string]interface{})
+type PropertyOption func(map[string]any)
 
 //
 // Core Tool Functions
@@ -163,7 +163,7 @@ func NewTool(name string, opts ...ToolOption) Tool {
 		Name: name,
 		InputSchema: ToolInputSchema{
 			Type:       "object",
-			Properties: make(map[string]interface{}),
+			Properties: make(map[string]any),
 			Required:   nil, // Will be omitted from JSON if empty
 		},
 		Annotations: ToolAnnotation{
@@ -220,7 +220,7 @@ func WithToolAnnotation(annotation ToolAnnotation) ToolOption {
 // Description adds a description to a property in the JSON Schema.
 // The description should explain the purpose and expected values of the property.
 func Description(desc string) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["description"] = desc
 	}
 }
@@ -228,7 +228,7 @@ func Description(desc string) PropertyOption {
 // Required marks a property as required in the tool's input schema.
 // Required properties must be provided when using the tool.
 func Required() PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["required"] = true
 	}
 }
@@ -236,7 +236,7 @@ func Required() PropertyOption {
 // Title adds a display-friendly title to a property in the JSON Schema.
 // This title can be used by UI components to show a more readable property name.
 func Title(title string) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["title"] = title
 	}
 }
@@ -248,7 +248,7 @@ func Title(title string) PropertyOption {
 // DefaultString sets the default value for a string property.
 // This value will be used if the property is not explicitly provided.
 func DefaultString(value string) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["default"] = value
 	}
 }
@@ -256,7 +256,7 @@ func DefaultString(value string) PropertyOption {
 // Enum specifies a list of allowed values for a string property.
 // The property value must be one of the specified enum values.
 func Enum(values ...string) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["enum"] = values
 	}
 }
@@ -264,7 +264,7 @@ func Enum(values ...string) PropertyOption {
 // MaxLength sets the maximum length for a string property.
 // The string value must not exceed this length.
 func MaxLength(max int) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["maxLength"] = max
 	}
 }
@@ -272,7 +272,7 @@ func MaxLength(max int) PropertyOption {
 // MinLength sets the minimum length for a string property.
 // The string value must be at least this length.
 func MinLength(min int) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["minLength"] = min
 	}
 }
@@ -280,7 +280,7 @@ func MinLength(min int) PropertyOption {
 // Pattern sets a regex pattern that a string property must match.
 // The string value must conform to the specified regular expression.
 func Pattern(pattern string) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["pattern"] = pattern
 	}
 }
@@ -292,7 +292,7 @@ func Pattern(pattern string) PropertyOption {
 // DefaultNumber sets the default value for a number property.
 // This value will be used if the property is not explicitly provided.
 func DefaultNumber(value float64) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["default"] = value
 	}
 }
@@ -300,7 +300,7 @@ func DefaultNumber(value float64) PropertyOption {
 // Max sets the maximum value for a number property.
 // The number value must not exceed this maximum.
 func Max(max float64) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["maximum"] = max
 	}
 }
@@ -308,7 +308,7 @@ func Max(max float64) PropertyOption {
 // Min sets the minimum value for a number property.
 // The number value must not be less than this minimum.
 func Min(min float64) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["minimum"] = min
 	}
 }
@@ -316,7 +316,7 @@ func Min(min float64) PropertyOption {
 // MultipleOf specifies that a number must be a multiple of the given value.
 // The number value must be divisible by this value.
 func MultipleOf(value float64) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["multipleOf"] = value
 	}
 }
@@ -328,7 +328,7 @@ func MultipleOf(value float64) PropertyOption {
 // DefaultBool sets the default value for a boolean property.
 // This value will be used if the property is not explicitly provided.
 func DefaultBool(value bool) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["default"] = value
 	}
 }
@@ -340,7 +340,7 @@ func DefaultBool(value bool) PropertyOption {
 // DefaultArray sets the default value for an array property.
 // This value will be used if the property is not explicitly provided.
 func DefaultArray[T any](value []T) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["default"] = value
 	}
 }
@@ -353,7 +353,7 @@ func DefaultArray[T any](value []T) PropertyOption {
 // It accepts property options to configure the boolean property's behavior and constraints.
 func WithBoolean(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
-		schema := map[string]interface{}{
+		schema := map[string]any{
 			"type": "boolean",
 		}
 
@@ -375,7 +375,7 @@ func WithBoolean(name string, opts ...PropertyOption) ToolOption {
 // It accepts property options to configure the number property's behavior and constraints.
 func WithNumber(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
-		schema := map[string]interface{}{
+		schema := map[string]any{
 			"type": "number",
 		}
 
@@ -397,7 +397,7 @@ func WithNumber(name string, opts ...PropertyOption) ToolOption {
 // It accepts property options to configure the string property's behavior and constraints.
 func WithString(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
-		schema := map[string]interface{}{
+		schema := map[string]any{
 			"type": "string",
 		}
 
@@ -419,9 +419,9 @@ func WithString(name string, opts ...PropertyOption) ToolOption {
 // It accepts property options to configure the object property's behavior and constraints.
 func WithObject(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
-		schema := map[string]interface{}{
+		schema := map[string]any{
 			"type":       "object",
-			"properties": map[string]interface{}{},
+			"properties": map[string]any{},
 		}
 
 		for _, opt := range opts {
@@ -442,7 +442,7 @@ func WithObject(name string, opts ...PropertyOption) ToolOption {
 // It accepts property options to configure the array property's behavior and constraints.
 func WithArray(name string, opts ...PropertyOption) ToolOption {
 	return func(t *Tool) {
-		schema := map[string]interface{}{
+		schema := map[string]any{
 			"type": "array",
 		}
 
@@ -461,65 +461,65 @@ func WithArray(name string, opts ...PropertyOption) ToolOption {
 }
 
 // Properties defines the properties for an object schema
-func Properties(props map[string]interface{}) PropertyOption {
-	return func(schema map[string]interface{}) {
+func Properties(props map[string]any) PropertyOption {
+	return func(schema map[string]any) {
 		schema["properties"] = props
 	}
 }
 
 // AdditionalProperties specifies whether additional properties are allowed in the object
 // or defines a schema for additional properties
-func AdditionalProperties(schema interface{}) PropertyOption {
-	return func(schemaMap map[string]interface{}) {
+func AdditionalProperties(schema any) PropertyOption {
+	return func(schemaMap map[string]any) {
 		schemaMap["additionalProperties"] = schema
 	}
 }
 
 // MinProperties sets the minimum number of properties for an object
 func MinProperties(min int) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["minProperties"] = min
 	}
 }
 
 // MaxProperties sets the maximum number of properties for an object
 func MaxProperties(max int) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["maxProperties"] = max
 	}
 }
 
 // PropertyNames defines a schema for property names in an object
-func PropertyNames(schema map[string]interface{}) PropertyOption {
-	return func(schemaMap map[string]interface{}) {
+func PropertyNames(schema map[string]any) PropertyOption {
+	return func(schemaMap map[string]any) {
 		schemaMap["propertyNames"] = schema
 	}
 }
 
 // Items defines the schema for array items
-func Items(schema interface{}) PropertyOption {
-	return func(schemaMap map[string]interface{}) {
+func Items(schema any) PropertyOption {
+	return func(schemaMap map[string]any) {
 		schemaMap["items"] = schema
 	}
 }
 
 // MinItems sets the minimum number of items for an array
 func MinItems(min int) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["minItems"] = min
 	}
 }
 
 // MaxItems sets the maximum number of items for an array
 func MaxItems(max int) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["maxItems"] = max
 	}
 }
 
 // UniqueItems specifies whether array items must be unique
 func UniqueItems(unique bool) PropertyOption {
-	return func(schema map[string]interface{}) {
+	return func(schema map[string]any) {
 		schema["uniqueItems"] = unique
 	}
 }

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -50,7 +50,7 @@ func TestToolWithRawSchema(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Unmarshal to verify the structure
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(data, &result)
 	assert.NoError(t, err)
 
@@ -59,18 +59,18 @@ func TestToolWithRawSchema(t *testing.T) {
 	assert.Equal(t, "Search API", result["description"])
 
 	// Verify schema was properly included
-	schema, ok := result["inputSchema"].(map[string]interface{})
+	schema, ok := result["inputSchema"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "object", schema["type"])
 
-	properties, ok := schema["properties"].(map[string]interface{})
+	properties, ok := schema["properties"].(map[string]any)
 	assert.True(t, ok)
 
-	query, ok := properties["query"].(map[string]interface{})
+	query, ok := properties["query"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "string", query["type"])
 
-	required, ok := schema["required"].([]interface{})
+	required, ok := schema["required"].([]any)
 	assert.True(t, ok)
 	assert.Contains(t, required, "query")
 }
@@ -105,12 +105,12 @@ func TestUnmarshalToolWithRawSchema(t *testing.T) {
 	// Verify schema was properly included
 	assert.Equal(t, "object", toolUnmarshalled.InputSchema.Type)
 	assert.Contains(t, toolUnmarshalled.InputSchema.Properties, "query")
-	assert.Subset(t, toolUnmarshalled.InputSchema.Properties["query"], map[string]interface{}{
+	assert.Subset(t, toolUnmarshalled.InputSchema.Properties["query"], map[string]any{
 		"type":        "string",
 		"description": "Search query",
 	})
 	assert.Contains(t, toolUnmarshalled.InputSchema.Properties, "limit")
-	assert.Subset(t, toolUnmarshalled.InputSchema.Properties["limit"], map[string]interface{}{
+	assert.Subset(t, toolUnmarshalled.InputSchema.Properties["limit"], map[string]any{
 		"type":    "integer",
 		"minimum": 1.0,
 		"maximum": 50.0,
@@ -136,7 +136,7 @@ func TestUnmarshalToolWithoutRawSchema(t *testing.T) {
 	// Verify tool properties
 	assert.Equal(t, tool.Name, toolUnmarshalled.Name)
 	assert.Equal(t, tool.Description, toolUnmarshalled.Description)
-	assert.Subset(t, toolUnmarshalled.InputSchema.Properties["input"], map[string]interface{}{
+	assert.Subset(t, toolUnmarshalled.InputSchema.Properties["input"], map[string]any{
 		"type":        "string",
 		"description": "Test input",
 	})
@@ -150,13 +150,13 @@ func TestToolWithObjectAndArray(t *testing.T) {
 		WithDescription("A tool for managing reading lists"),
 		WithObject("preferences",
 			Description("User preferences for the reading list"),
-			Properties(map[string]interface{}{
-				"theme": map[string]interface{}{
+			Properties(map[string]any{
+				"theme": map[string]any{
 					"type":        "string",
 					"description": "UI theme preference",
 					"enum":        []string{"light", "dark"},
 				},
-				"maxItems": map[string]interface{}{
+				"maxItems": map[string]any{
 					"type":        "number",
 					"description": "Maximum number of items in the list",
 					"minimum":     1,
@@ -166,19 +166,19 @@ func TestToolWithObjectAndArray(t *testing.T) {
 		WithArray("books",
 			Description("List of books to read"),
 			Required(),
-			Items(map[string]interface{}{
+			Items(map[string]any{
 				"type": "object",
-				"properties": map[string]interface{}{
-					"title": map[string]interface{}{
+				"properties": map[string]any{
+					"title": map[string]any{
 						"type":        "string",
 						"description": "Book title",
 						"required":    true,
 					},
-					"author": map[string]interface{}{
+					"author": map[string]any{
 						"type":        "string",
 						"description": "Book author",
 					},
-					"year": map[string]interface{}{
+					"year": map[string]any{
 						"type":        "number",
 						"description": "Publication year",
 						"minimum":     1000,
@@ -191,7 +191,7 @@ func TestToolWithObjectAndArray(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Unmarshal to verify the structure
-	var result map[string]interface{}
+	var result map[string]any
 	err = json.Unmarshal(data, &result)
 	assert.NoError(t, err)
 
@@ -200,44 +200,44 @@ func TestToolWithObjectAndArray(t *testing.T) {
 	assert.Equal(t, "A tool for managing reading lists", result["description"])
 
 	// Verify schema was properly included
-	schema, ok := result["inputSchema"].(map[string]interface{})
+	schema, ok := result["inputSchema"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "object", schema["type"])
 
 	// Verify properties
-	properties, ok := schema["properties"].(map[string]interface{})
+	properties, ok := schema["properties"].(map[string]any)
 	assert.True(t, ok)
 
 	// Verify preferences object
-	preferences, ok := properties["preferences"].(map[string]interface{})
+	preferences, ok := properties["preferences"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "object", preferences["type"])
 	assert.Equal(t, "User preferences for the reading list", preferences["description"])
 
-	prefProps, ok := preferences["properties"].(map[string]interface{})
+	prefProps, ok := preferences["properties"].(map[string]any)
 	assert.True(t, ok)
 	assert.Contains(t, prefProps, "theme")
 	assert.Contains(t, prefProps, "maxItems")
 
 	// Verify books array
-	books, ok := properties["books"].(map[string]interface{})
+	books, ok := properties["books"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "array", books["type"])
 	assert.Equal(t, "List of books to read", books["description"])
 
 	// Verify array items schema
-	items, ok := books["items"].(map[string]interface{})
+	items, ok := books["items"].(map[string]any)
 	assert.True(t, ok)
 	assert.Equal(t, "object", items["type"])
 
-	itemProps, ok := items["properties"].(map[string]interface{})
+	itemProps, ok := items["properties"].(map[string]any)
 	assert.True(t, ok)
 	assert.Contains(t, itemProps, "title")
 	assert.Contains(t, itemProps, "author")
 	assert.Contains(t, itemProps, "year")
 
 	// Verify required fields
-	required, ok := schema["required"].([]interface{})
+	required, ok := schema["required"].([]any)
 	assert.True(t, ok)
 	assert.Contains(t, required, "books")
 }
@@ -245,7 +245,7 @@ func TestToolWithObjectAndArray(t *testing.T) {
 func TestParseToolCallToolRequest(t *testing.T) {
 	request := CallToolRequest{}
 	request.Params.Name = "test-tool"
-	request.Params.Arguments = map[string]interface{}{
+	request.Params.Arguments = map[string]any{
 		"bool_value":    "true",
 		"int64_value":   "123456789",
 		"int32_value":   "123456789",

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -86,7 +86,7 @@ func (t *URITemplate) UnmarshalJSON(data []byte) error {
 /* JSON-RPC types */
 
 // JSONRPCMessage represents either a JSONRPCRequest, JSONRPCNotification, JSONRPCResponse, or JSONRPCError
-type JSONRPCMessage interface{}
+type JSONRPCMessage any
 
 // LATEST_PROTOCOL_VERSION is the most recent version of the MCP protocol.
 const LATEST_PROTOCOL_VERSION = "2024-11-05"
@@ -95,7 +95,7 @@ const LATEST_PROTOCOL_VERSION = "2024-11-05"
 const JSONRPC_VERSION = "2.0"
 
 // ProgressToken is used to associate progress notifications with the original request.
-type ProgressToken interface{}
+type ProgressToken any
 
 // Cursor is an opaque token used to represent a cursor for pagination.
 type Cursor string
@@ -115,7 +115,7 @@ type Request struct {
 	} `json:"params,omitempty"`
 }
 
-type Params map[string]interface{}
+type Params map[string]any
 
 type Notification struct {
 	Method string             `json:"method"`
@@ -125,16 +125,16 @@ type Notification struct {
 type NotificationParams struct {
 	// This parameter name is reserved by MCP to allow clients and
 	// servers to attach additional metadata to their notifications.
-	Meta map[string]interface{} `json:"_meta,omitempty"`
+	Meta map[string]any `json:"_meta,omitempty"`
 
 	// Additional fields can be added to this map
-	AdditionalFields map[string]interface{} `json:"-"`
+	AdditionalFields map[string]any `json:"-"`
 }
 
 // MarshalJSON implements custom JSON marshaling
 func (p NotificationParams) MarshalJSON() ([]byte, error) {
 	// Create a map to hold all fields
-	m := make(map[string]interface{})
+	m := make(map[string]any)
 
 	// Add Meta if it exists
 	if p.Meta != nil {
@@ -155,24 +155,24 @@ func (p NotificationParams) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON implements custom JSON unmarshaling
 func (p *NotificationParams) UnmarshalJSON(data []byte) error {
 	// Create a map to hold all fields
-	var m map[string]interface{}
+	var m map[string]any
 	if err := json.Unmarshal(data, &m); err != nil {
 		return err
 	}
 
 	// Initialize maps if they're nil
 	if p.Meta == nil {
-		p.Meta = make(map[string]interface{})
+		p.Meta = make(map[string]any)
 	}
 	if p.AdditionalFields == nil {
-		p.AdditionalFields = make(map[string]interface{})
+		p.AdditionalFields = make(map[string]any)
 	}
 
 	// Process all fields
 	for k, v := range m {
 		if k == "_meta" {
 			// Handle Meta field
-			if meta, ok := v.(map[string]interface{}); ok {
+			if meta, ok := v.(map[string]any); ok {
 				p.Meta = meta
 			}
 		} else {
@@ -187,18 +187,18 @@ func (p *NotificationParams) UnmarshalJSON(data []byte) error {
 type Result struct {
 	// This result property is reserved by the protocol to allow clients and
 	// servers to attach additional metadata to their responses.
-	Meta map[string]interface{} `json:"_meta,omitempty"`
+	Meta map[string]any `json:"_meta,omitempty"`
 }
 
 // RequestId is a uniquely identifying ID for a request in JSON-RPC.
 // It can be any JSON-serializable value, typically a number or string.
-type RequestId interface{}
+type RequestId any
 
 // JSONRPCRequest represents a request that expects a response.
 type JSONRPCRequest struct {
-	JSONRPC string      `json:"jsonrpc"`
-	ID      RequestId   `json:"id"`
-	Params  interface{} `json:"params,omitempty"`
+	JSONRPC string    `json:"jsonrpc"`
+	ID      RequestId `json:"id"`
+	Params  any       `json:"params,omitempty"`
 	Request
 }
 
@@ -210,9 +210,9 @@ type JSONRPCNotification struct {
 
 // JSONRPCResponse represents a successful (non-error) response to a request.
 type JSONRPCResponse struct {
-	JSONRPC string      `json:"jsonrpc"`
-	ID      RequestId   `json:"id"`
-	Result  interface{} `json:"result"`
+	JSONRPC string    `json:"jsonrpc"`
+	ID      RequestId `json:"id"`
+	Result  any       `json:"result"`
 }
 
 // JSONRPCError represents a non-successful (error) response to a request.
@@ -227,7 +227,7 @@ type JSONRPCError struct {
 		Message string `json:"message"`
 		// Additional information about the error. The value of this member
 		// is defined by the sender (e.g. detailed error information, nested errors etc.).
-		Data interface{} `json:"data,omitempty"`
+		Data any `json:"data,omitempty"`
 	} `json:"error"`
 }
 
@@ -322,7 +322,7 @@ type InitializedNotification struct {
 // client can define its own, additional capabilities.
 type ClientCapabilities struct {
 	// Experimental, non-standard capabilities that the client supports.
-	Experimental map[string]interface{} `json:"experimental,omitempty"`
+	Experimental map[string]any `json:"experimental,omitempty"`
 	// Present if the client supports listing roots.
 	Roots *struct {
 		// Whether the client supports notifications for changes to the roots list.
@@ -337,7 +337,7 @@ type ClientCapabilities struct {
 // server can define its own, additional capabilities.
 type ServerCapabilities struct {
 	// Experimental, non-standard capabilities that the server supports.
-	Experimental map[string]interface{} `json:"experimental,omitempty"`
+	Experimental map[string]any `json:"experimental,omitempty"`
 	// Present if the server supports sending log messages to the client.
 	Logging *struct{} `json:"logging,omitempty"`
 	// Present if the server offers any prompt templates.
@@ -452,7 +452,7 @@ type ReadResourceRequest struct {
 		// to the server how to interpret it.
 		URI string `json:"uri"`
 		// Arguments to pass to the resource handler
-		Arguments map[string]interface{} `json:"arguments,omitempty"`
+		Arguments map[string]any `json:"arguments,omitempty"`
 	} `json:"params"`
 }
 
@@ -599,7 +599,7 @@ type LoggingMessageNotification struct {
 		Logger string `json:"logger,omitempty"`
 		// The data to be logged, such as a string message or an object. Any JSON
 		// serializable type is allowed here.
-		Data interface{} `json:"data"`
+		Data any `json:"data"`
 	} `json:"params"`
 }
 
@@ -636,7 +636,7 @@ type CreateMessageRequest struct {
 		Temperature      float64           `json:"temperature,omitempty"`
 		MaxTokens        int               `json:"maxTokens"`
 		StopSequences    []string          `json:"stopSequences,omitempty"`
-		Metadata         interface{}       `json:"metadata,omitempty"`
+		Metadata         any               `json:"metadata,omitempty"`
 	} `json:"params"`
 }
 
@@ -655,8 +655,8 @@ type CreateMessageResult struct {
 
 // SamplingMessage describes a message issued to or received from an LLM API.
 type SamplingMessage struct {
-	Role    Role        `json:"role"`
-	Content interface{} `json:"content"` // Can be TextContent, ImageContent or AudioContent
+	Role    Role `json:"role"`
+	Content any  `json:"content"` // Can be TextContent, ImageContent or AudioContent
 }
 
 type Annotations struct {
@@ -796,7 +796,7 @@ type ModelHint struct {
 type CompleteRequest struct {
 	Request
 	Params struct {
-		Ref      interface{} `json:"ref"` // Can be PromptReference or ResourceReference
+		Ref      any `json:"ref"` // Can be PromptReference or ResourceReference
 		Argument struct {
 			// The name of the argument
 			Name string `json:"name"`
@@ -877,19 +877,19 @@ type RootsListChangedNotification struct {
 }
 
 // ClientRequest represents any request that can be sent from client to server.
-type ClientRequest interface{}
+type ClientRequest any
 
 // ClientNotification represents any notification that can be sent from client to server.
-type ClientNotification interface{}
+type ClientNotification any
 
 // ClientResult represents any result that can be sent from client to server.
-type ClientResult interface{}
+type ClientResult any
 
 // ServerRequest represents any request that can be sent from server to client.
-type ServerRequest interface{}
+type ServerRequest any
 
 // ServerNotification represents any notification that can be sent from server to client.
-type ServerNotification interface{}
+type ServerNotification any
 
 // ServerResult represents any result that can be sent from server to client.
-type ServerResult interface{}
+type ServerResult any

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -60,7 +60,7 @@ var _ ServerResult = &ListToolsResult{}
 // Helper functions for type assertions
 
 // asType attempts to cast the given interface to the given type
-func asType[T any](content interface{}) (*T, bool) {
+func asType[T any](content any) (*T, bool) {
 	tc, ok := content.(T)
 	if !ok {
 		return nil, false
@@ -69,32 +69,32 @@ func asType[T any](content interface{}) (*T, bool) {
 }
 
 // AsTextContent attempts to cast the given interface to TextContent
-func AsTextContent(content interface{}) (*TextContent, bool) {
+func AsTextContent(content any) (*TextContent, bool) {
 	return asType[TextContent](content)
 }
 
 // AsImageContent attempts to cast the given interface to ImageContent
-func AsImageContent(content interface{}) (*ImageContent, bool) {
+func AsImageContent(content any) (*ImageContent, bool) {
 	return asType[ImageContent](content)
 }
 
 // AsAudioContent attempts to cast the given interface to AudioContent
-func AsAudioContent(content interface{}) (*AudioContent, bool) {
+func AsAudioContent(content any) (*AudioContent, bool) {
 	return asType[AudioContent](content)
 }
 
 // AsEmbeddedResource attempts to cast the given interface to EmbeddedResource
-func AsEmbeddedResource(content interface{}) (*EmbeddedResource, bool) {
+func AsEmbeddedResource(content any) (*EmbeddedResource, bool) {
 	return asType[EmbeddedResource](content)
 }
 
 // AsTextResourceContents attempts to cast the given interface to TextResourceContents
-func AsTextResourceContents(content interface{}) (*TextResourceContents, bool) {
+func AsTextResourceContents(content any) (*TextResourceContents, bool) {
 	return asType[TextResourceContents](content)
 }
 
 // AsBlobResourceContents attempts to cast the given interface to BlobResourceContents
-func AsBlobResourceContents(content interface{}) (*BlobResourceContents, bool) {
+func AsBlobResourceContents(content any) (*BlobResourceContents, bool) {
 	return asType[BlobResourceContents](content)
 }
 
@@ -114,15 +114,15 @@ func NewJSONRPCError(
 	id RequestId,
 	code int,
 	message string,
-	data interface{},
+	data any,
 ) JSONRPCError {
 	return JSONRPCError{
 		JSONRPC: JSONRPC_VERSION,
 		ID:      id,
 		Error: struct {
-			Code    int         `json:"code"`
-			Message string      `json:"message"`
-			Data    interface{} `json:"data,omitempty"`
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    any    `json:"data,omitempty"`
 		}{
 			Code:    code,
 			Message: message,
@@ -167,7 +167,7 @@ func NewProgressNotification(
 func NewLoggingMessageNotification(
 	level LoggingLevel,
 	logger string,
-	data interface{},
+	data any,
 ) LoggingMessageNotification {
 	return LoggingMessageNotification{
 		Notification: Notification{
@@ -176,7 +176,7 @@ func NewLoggingMessageNotification(
 		Params: struct {
 			Level  LoggingLevel `json:"level"`
 			Logger string       `json:"logger,omitempty"`
-			Data   interface{}  `json:"data"`
+			Data   any          `json:"data"`
 		}{
 			Level:  level,
 			Logger: logger,

--- a/server/server.go
+++ b/server/server.go
@@ -472,7 +472,7 @@ func (s *MCPServer) AddNotificationHandler(
 
 func (s *MCPServer) handleInitialize(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.InitializeRequest,
 ) (*mcp.InitializeResult, *requestError) {
 	capabilities := mcp.ServerCapabilities{}
@@ -528,7 +528,7 @@ func (s *MCPServer) handleInitialize(
 
 func (s *MCPServer) handlePing(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.PingRequest,
 ) (*mcp.EmptyResult, *requestError) {
 	return &mcp.EmptyResult{}, nil
@@ -572,7 +572,7 @@ func listByPagination[T any](
 
 func (s *MCPServer) handleListResources(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.ListResourcesRequest,
 ) (*mcp.ListResourcesResult, *requestError) {
 	s.resourcesMu.RLock()
@@ -605,7 +605,7 @@ func (s *MCPServer) handleListResources(
 
 func (s *MCPServer) handleListResourceTemplates(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.ListResourceTemplatesRequest,
 ) (*mcp.ListResourceTemplatesResult, *requestError) {
 	s.resourcesMu.RLock()
@@ -636,7 +636,7 @@ func (s *MCPServer) handleListResourceTemplates(
 
 func (s *MCPServer) handleReadResource(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, *requestError) {
 	s.resourcesMu.RLock()
@@ -665,7 +665,7 @@ func (s *MCPServer) handleReadResource(
 			matched = true
 			matchedVars := template.URITemplate.Match(request.Params.URI)
 			// Convert matched variables to a map
-			request.Params.Arguments = make(map[string]interface{}, len(matchedVars))
+			request.Params.Arguments = make(map[string]any, len(matchedVars))
 			for name, value := range matchedVars {
 				request.Params.Arguments[name] = value.V
 			}
@@ -700,7 +700,7 @@ func matchesTemplate(uri string, template *mcp.URITemplate) bool {
 
 func (s *MCPServer) handleListPrompts(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.ListPromptsRequest,
 ) (*mcp.ListPromptsResult, *requestError) {
 	s.promptsMu.RLock()
@@ -733,7 +733,7 @@ func (s *MCPServer) handleListPrompts(
 
 func (s *MCPServer) handleGetPrompt(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, *requestError) {
 	s.promptsMu.RLock()
@@ -762,7 +762,7 @@ func (s *MCPServer) handleGetPrompt(
 
 func (s *MCPServer) handleListTools(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.ListToolsRequest,
 ) (*mcp.ListToolsResult, *requestError) {
 	// Get the base tools from the server
@@ -847,7 +847,7 @@ func (s *MCPServer) handleListTools(
 
 func (s *MCPServer) handleToolCall(
 	ctx context.Context,
-	id interface{},
+	id any,
 	request mcp.CallToolRequest,
 ) (*mcp.CallToolResult, *requestError) {
 	// First check session-specific tools
@@ -919,7 +919,7 @@ func (s *MCPServer) handleNotification(
 	return nil
 }
 
-func createResponse(id interface{}, result interface{}) mcp.JSONRPCMessage {
+func createResponse(id any, result any) mcp.JSONRPCMessage {
 	return mcp.JSONRPCResponse{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      id,
@@ -928,7 +928,7 @@ func createResponse(id interface{}, result interface{}) mcp.JSONRPCMessage {
 }
 
 func createErrorResponse(
-	id interface{},
+	id any,
 	code int,
 	message string,
 ) mcp.JSONRPCMessage {
@@ -936,9 +936,9 @@ func createErrorResponse(
 		JSONRPC: mcp.JSONRPC_VERSION,
 		ID:      id,
 		Error: struct {
-			Code    int         `json:"code"`
-			Message string      `json:"message"`
-			Data    interface{} `json:"data,omitempty"`
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+			Data    any    `json:"data,omitempty"`
 		}{
 			Code:    code,
 			Message: message,

--- a/server/server_race_test.go
+++ b/server/server_race_test.go
@@ -98,7 +98,7 @@ func TestRaceConditions(t *testing.T) {
 	runConcurrentOperation(&wg, testDuration, "call-tools", func() {
 		req := mcp.CallToolRequest{}
 		req.Params.Name = "persistent-tool"
-		req.Params.Arguments = map[string]interface{}{"param": "test"}
+		req.Params.Arguments = map[string]any{"param": "test"}
 		result, reqErr := srv.handleToolCall(ctx, "123", req)
 		require.Nil(t, reqErr, "Tool call operation should not return an error")
 		require.NotNil(t, result, "Tool call result should not be nil")

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -351,7 +351,7 @@ func TestMCPServer_HandleValidMessages(t *testing.T) {
 
 	tests := []struct {
 		name     string
-		message  interface{}
+		message  any
 		validate func(t *testing.T, response mcp.JSONRPCMessage)
 	}{
 		{
@@ -866,7 +866,7 @@ func TestMCPServer_HandleUndefinedHandlers(t *testing.T) {
 		Description: "Test tool",
 		InputSchema: mcp.ToolInputSchema{
 			Type:       "object",
-			Properties: map[string]interface{}{},
+			Properties: map[string]any{},
 		},
 		Annotations: mcp.ToolAnnotation{
 			Title:           "test-tool",

--- a/server/session.go
+++ b/server/session.go
@@ -105,7 +105,7 @@ func (s *MCPServer) SendNotificationToAllClients(
 					go func(sessionID string, hooks *Hooks) {
 						ctx := context.Background()
 						// Use the error hook to report the blocked channel
-						hooks.onError(ctx, nil, "notification", map[string]interface{}{
+						hooks.onError(ctx, nil, "notification", map[string]any{
 							"method":    method,
 							"sessionID": sessionID,
 						}, fmt.Errorf("notification channel blocked for session %s: %w", sessionID, err))
@@ -149,7 +149,7 @@ func (s *MCPServer) SendNotificationToClient(
 			hooks := s.hooks
 			go func(sessionID string, hooks *Hooks) {
 				// Use the error hook to report the blocked channel
-				hooks.onError(ctx, nil, "notification", map[string]interface{}{
+				hooks.onError(ctx, nil, "notification", map[string]any{
 					"method":    method,
 					"sessionID": sessionID,
 				}, fmt.Errorf("notification channel blocked for session %s: %w", sessionID, err))
@@ -197,7 +197,7 @@ func (s *MCPServer) SendNotificationToSpecificClient(
 			hooks := s.hooks
 			go func(sID string, hooks *Hooks) {
 				// Use the error hook to report the blocked channel
-				hooks.onError(ctx, nil, "notification", map[string]interface{}{
+				hooks.onError(ctx, nil, "notification", map[string]any{
 					"method":    method,
 					"sessionID": sID,
 				}, fmt.Errorf("notification channel blocked for session %s: %w", sID, err))
@@ -253,7 +253,7 @@ func (s *MCPServer) AddSessionTools(sessionID string, tools ...ServerTool) error
 			hooks := s.hooks
 			go func(sID string, hooks *Hooks) {
 				ctx := context.Background()
-				hooks.onError(ctx, nil, "notification", map[string]interface{}{
+				hooks.onError(ctx, nil, "notification", map[string]any{
 					"method":    "notifications/tools/list_changed",
 					"sessionID": sID,
 				}, fmt.Errorf("failed to send notification after adding tools: %w", err))
@@ -306,7 +306,7 @@ func (s *MCPServer) DeleteSessionTools(sessionID string, names ...string) error 
 			hooks := s.hooks
 			go func(sID string, hooks *Hooks) {
 				ctx := context.Background()
-				hooks.onError(ctx, nil, "notification", map[string]interface{}{
+				hooks.onError(ctx, nil, "notification", map[string]any{
 					"method":    "notifications/tools/list_changed",
 					"sessionID": sID,
 				}, fmt.Errorf("failed to send notification after deleting tools: %w", err))

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -130,7 +130,7 @@ func TestSessionWithTools_Integration(t *testing.T) {
 	// Test that we can access the session-specific tool
 	testReq := mcp.CallToolRequest{}
 	testReq.Params.Name = "session-tool"
-	testReq.Params.Arguments = map[string]interface{}{}
+	testReq.Params.Arguments = map[string]any{}
 
 	// Call using session context
 	sessionCtx := server.WithContext(context.Background(), session)
@@ -328,11 +328,11 @@ func TestMCPServer_CallSessionTool(t *testing.T) {
 
 	// Call the tool using session context
 	sessionCtx := server.WithContext(context.Background(), session)
-	toolRequest := map[string]interface{}{
+	toolRequest := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
 		"method":  "tools/call",
-		"params": map[string]interface{}{
+		"params": map[string]any{
 			"name": "test_tool",
 		},
 	}
@@ -545,7 +545,7 @@ func TestMCPServer_NotificationChannelBlocked(t *testing.T) {
 
 		errorCaptured = true
 		// Extract session ID and method from the error message metadata
-		if msgMap, ok := message.(map[string]interface{}); ok {
+		if msgMap, ok := message.(map[string]any); ok {
 			if sid, ok := msgMap["sessionID"].(string); ok {
 				errorSessionID = sid
 			}

--- a/server/sse.go
+++ b/server/sse.go
@@ -54,7 +54,7 @@ func (s *sseSession) Initialized() bool {
 
 func (s *sseSession) GetSessionTools() map[string]ServerTool {
 	tools := make(map[string]ServerTool)
-	s.tools.Range(func(key, value interface{}) bool {
+	s.tools.Range(func(key, value any) bool {
 		if tool, ok := value.(ServerTool); ok {
 			tools[key.(string)] = tool
 		}
@@ -65,7 +65,7 @@ func (s *sseSession) GetSessionTools() map[string]ServerTool {
 
 func (s *sseSession) SetSessionTools(tools map[string]ServerTool) {
 	// Clear existing tools
-	s.tools.Range(func(key, _ interface{}) bool {
+	s.tools.Range(func(key, _ any) bool {
 		s.tools.Delete(key)
 		return true
 	})
@@ -251,7 +251,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 	s.mu.RUnlock()
 
 	if srv != nil {
-		s.sessions.Range(func(key, value interface{}) bool {
+		s.sessions.Range(func(key, value any) bool {
 			if session, ok := value.(*sseSession); ok {
 				close(session.done)
 			}
@@ -473,7 +473,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 // writeJSONRPCError writes a JSON-RPC error response with the given error details.
 func (s *SSEServer) writeJSONRPCError(
 	w http.ResponseWriter,
-	id interface{},
+	id any,
 	code int,
 	message string,
 ) {
@@ -487,7 +487,7 @@ func (s *SSEServer) writeJSONRPCError(
 // Returns an error if the session is not found or closed.
 func (s *SSEServer) SendEventToSession(
 	sessionID string,
-	event interface{},
+	event any,
 ) error {
 	sessionI, ok := s.sessions.Load(sessionID)
 	if !ok {

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -76,13 +76,13 @@ func TestSSEServer(t *testing.T) {
 		)
 
 		// Send initialize request
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -154,13 +154,13 @@ func TestSSEServer(t *testing.T) {
 				)
 
 				// Send initialize request
-				initRequest := map[string]interface{}{
+				initRequest := map[string]any{
 					"jsonrpc": "2.0",
 					"id":      sessionNum,
 					"method":  "initialize",
-					"params": map[string]interface{}{
+					"params": map[string]any{
 						"protocolVersion": "2024-11-05",
-						"clientInfo": map[string]interface{}{
+						"clientInfo": map[string]any{
 							"name": fmt.Sprintf(
 								"test-client-%d",
 								sessionNum,
@@ -203,7 +203,7 @@ func TestSSEServer(t *testing.T) {
 					strings.Split(strings.Split(endpointEvent, "data: ")[1], "\n")[0],
 				)
 
-				var response map[string]interface{}
+				var response map[string]any
 				if err := json.NewDecoder(strings.NewReader(respFromSee)).Decode(&response); err != nil {
 					t.Errorf(
 						"Session %d: Failed to decode response: %v",
@@ -385,13 +385,13 @@ func TestSSEServer(t *testing.T) {
 
 		// The messageURL should already be correct since we set the baseURL correctly
 		// Test message endpoint
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -468,13 +468,13 @@ func TestSSEServer(t *testing.T) {
 
 		// The messageURL should already be correct since we set the baseURL correctly
 		// Test message endpoint
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -598,13 +598,13 @@ func TestSSEServer(t *testing.T) {
 		)
 
 		// Send initialize request
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -639,7 +639,7 @@ func TestSSEServer(t *testing.T) {
 			strings.Split(strings.Split(endpointEvent, "data: ")[1], "\n")[0],
 		)
 
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.NewDecoder(strings.NewReader(respFromSSE)).Decode(&response); err != nil {
 			t.Fatalf("Failed to decode response: %v", err)
 		}
@@ -652,11 +652,11 @@ func TestSSEServer(t *testing.T) {
 		}
 
 		// Call the tool.
-		toolRequest := map[string]interface{}{
+		toolRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      2,
 			"method":  "tools/call",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"name": "test_tool",
 			},
 		}
@@ -688,7 +688,7 @@ func TestSSEServer(t *testing.T) {
 			strings.Split(strings.Split(endpointEvent, "data: ")[1], "\n")[0],
 		)
 
-		response = make(map[string]interface{})
+		response = make(map[string]any)
 		if err := json.NewDecoder(strings.NewReader(respFromSSE)).Decode(&response); err != nil {
 			t.Fatalf("Failed to decode response: %v", err)
 		}
@@ -699,7 +699,7 @@ func TestSSEServer(t *testing.T) {
 		if response["id"].(float64) != 2 {
 			t.Errorf("Expected id 2, got %v", response["id"])
 		}
-		if response["result"].(map[string]interface{})["content"].([]interface{})[0].(map[string]interface{})["text"] != "test_value" {
+		if response["result"].(map[string]any)["content"].([]any)[0].(map[string]any)["text"] != "test_value" {
 			t.Errorf("Expected result 'test_value', got %v", response["result"])
 		}
 		if response["error"] != nil {
@@ -922,13 +922,13 @@ func TestSSEServer(t *testing.T) {
 		}
 
 		// Optionally, test sending a message to the message endpoint
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -971,7 +971,7 @@ func TestSSEServer(t *testing.T) {
 
 		// Extract and parse the response data
 		respData := strings.TrimSpace(strings.Split(strings.Split(initResponseStr, "data: ")[1], "\n")[0])
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.NewDecoder(strings.NewReader(respData)).Decode(&response); err != nil {
 			t.Fatalf("Failed to decode response: %v", err)
 		}
@@ -1246,7 +1246,7 @@ func TestSSEServer(t *testing.T) {
 			WithHooks(&Hooks{
 				OnAfterInitialize: []OnAfterInitializeFunc{
 					func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
-						result.Result.Meta = map[string]interface{}{"invalid": func() {}} // marshal will fail
+						result.Result.Meta = map[string]any{"invalid": func() {}} // marshal will fail
 					},
 				},
 			}),
@@ -1276,13 +1276,13 @@ func TestSSEServer(t *testing.T) {
 		)
 
 		// Send initialize request
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -1359,13 +1359,13 @@ func TestSSEServer(t *testing.T) {
 			strings.Split(strings.Split(endpointEvent, "data: ")[1], "\n")[0],
 		)
 
-		messageRequest := map[string]interface{}{
+		messageRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "tools/call",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"name":       "slowMethod",
-				"parameters": map[string]interface{}{},
+				"parameters": map[string]any{},
 			},
 		}
 

--- a/server/stdio_test.go
+++ b/server/stdio_test.go
@@ -54,13 +54,13 @@ func TestStdioServer(t *testing.T) {
 		}()
 
 		// Create test message
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -84,7 +84,7 @@ func TestStdioServer(t *testing.T) {
 		}
 		responseBytes := scanner.Bytes()
 
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.Unmarshal(responseBytes, &response); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
 		}
@@ -166,13 +166,13 @@ func TestStdioServer(t *testing.T) {
 		}()
 
 		// Create test message
-		initRequest := map[string]interface{}{
+		initRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      1,
 			"method":  "initialize",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"protocolVersion": "2024-11-05",
-				"clientInfo": map[string]interface{}{
+				"clientInfo": map[string]any{
 					"name":    "test-client",
 					"version": "1.0.0",
 				},
@@ -196,7 +196,7 @@ func TestStdioServer(t *testing.T) {
 		}
 		responseBytes := scanner.Bytes()
 
-		var response map[string]interface{}
+		var response map[string]any
 		if err := json.Unmarshal(responseBytes, &response); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
 		}
@@ -216,11 +216,11 @@ func TestStdioServer(t *testing.T) {
 		}
 
 		// Call the tool.
-		toolRequest := map[string]interface{}{
+		toolRequest := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      2,
 			"method":  "tools/call",
-			"params": map[string]interface{}{
+			"params": map[string]any{
 				"name": "test_tool",
 			},
 		}
@@ -239,7 +239,7 @@ func TestStdioServer(t *testing.T) {
 		}
 		responseBytes = scanner.Bytes()
 
-		response = map[string]interface{}{}
+		response = map[string]any{}
 		if err := json.Unmarshal(responseBytes, &response); err != nil {
 			t.Fatalf("failed to unmarshal response: %v", err)
 		}
@@ -250,7 +250,7 @@ func TestStdioServer(t *testing.T) {
 		if response["id"].(float64) != 2 {
 			t.Errorf("Expected id 2, got %v", response["id"])
 		}
-		if response["result"].(map[string]interface{})["content"].([]interface{})[0].(map[string]interface{})["text"] != "test_value" {
+		if response["result"].(map[string]any)["content"].([]any)[0].(map[string]any)["text"] != "test_value" {
 			t.Errorf("Expected result 'test_value', got %v", response["result"])
 		}
 		if response["error"] != nil {

--- a/testdata/mockstdio_server.go
+++ b/testdata/mockstdio_server.go
@@ -16,9 +16,9 @@ type JSONRPCRequest struct {
 }
 
 type JSONRPCResponse struct {
-	JSONRPC string      `json:"jsonrpc"`
-	ID      *int64      `json:"id,omitempty"`
-	Result  interface{} `json:"result,omitempty"`
+	JSONRPC string `json:"jsonrpc"`
+	ID      *int64 `json:"id,omitempty"`
+	Result  any    `json:"result,omitempty"`
 	Error   *struct {
 		Code    int    `json:"code"`
 		Message string `json:"message"`
@@ -49,21 +49,21 @@ func handleRequest(request JSONRPCRequest) JSONRPCResponse {
 
 	switch request.Method {
 	case "initialize":
-		response.Result = map[string]interface{}{
+		response.Result = map[string]any{
 			"protocolVersion": "1.0",
-			"serverInfo": map[string]interface{}{
+			"serverInfo": map[string]any{
 				"name":    "mock-server",
 				"version": "1.0.0",
 			},
-			"capabilities": map[string]interface{}{
-				"prompts": map[string]interface{}{
+			"capabilities": map[string]any{
+				"prompts": map[string]any{
 					"listChanged": true,
 				},
-				"resources": map[string]interface{}{
+				"resources": map[string]any{
 					"listChanged": true,
 					"subscribe":   true,
 				},
-				"tools": map[string]interface{}{
+				"tools": map[string]any{
 					"listChanged": true,
 				},
 			},
@@ -71,8 +71,8 @@ func handleRequest(request JSONRPCRequest) JSONRPCResponse {
 	case "ping":
 		response.Result = struct{}{}
 	case "resources/list":
-		response.Result = map[string]interface{}{
-			"resources": []map[string]interface{}{
+		response.Result = map[string]any{
+			"resources": []map[string]any{
 				{
 					"name": "test-resource",
 					"uri":  "test://resource",
@@ -80,8 +80,8 @@ func handleRequest(request JSONRPCRequest) JSONRPCResponse {
 			},
 		}
 	case "resources/read":
-		response.Result = map[string]interface{}{
-			"contents": []map[string]interface{}{
+		response.Result = map[string]any{
+			"contents": []map[string]any{
 				{
 					"text": "test content",
 					"uri":  "test://resource",
@@ -91,19 +91,19 @@ func handleRequest(request JSONRPCRequest) JSONRPCResponse {
 	case "resources/subscribe", "resources/unsubscribe":
 		response.Result = struct{}{}
 	case "prompts/list":
-		response.Result = map[string]interface{}{
-			"prompts": []map[string]interface{}{
+		response.Result = map[string]any{
+			"prompts": []map[string]any{
 				{
 					"name": "test-prompt",
 				},
 			},
 		}
 	case "prompts/get":
-		response.Result = map[string]interface{}{
-			"messages": []map[string]interface{}{
+		response.Result = map[string]any{
+			"messages": []map[string]any{
 				{
 					"role": "assistant",
-					"content": map[string]interface{}{
+					"content": map[string]any{
 						"type": "text",
 						"text": "test message",
 					},
@@ -111,19 +111,19 @@ func handleRequest(request JSONRPCRequest) JSONRPCResponse {
 			},
 		}
 	case "tools/list":
-		response.Result = map[string]interface{}{
-			"tools": []map[string]interface{}{
+		response.Result = map[string]any{
+			"tools": []map[string]any{
 				{
 					"name": "test-tool",
-					"inputSchema": map[string]interface{}{
+					"inputSchema": map[string]any{
 						"type": "object",
 					},
 				},
 			},
 		}
 	case "tools/call":
-		response.Result = map[string]interface{}{
-			"content": []map[string]interface{}{
+		response.Result = map[string]any{
+			"content": []map[string]any{
 				{
 					"type": "text",
 					"text": "tool result",
@@ -133,8 +133,8 @@ func handleRequest(request JSONRPCRequest) JSONRPCResponse {
 	case "logging/setLevel":
 		response.Result = struct{}{}
 	case "completion/complete":
-		response.Result = map[string]interface{}{
-			"completion": map[string]interface{}{
+		response.Result = map[string]any{
+			"completion": map[string]any{
 				"values": []string{"test completion"},
 			},
 		}


### PR DESCRIPTION
Using `any` instead of `interface{}` is much cleaner and is followed by new Go projects.

There isn't any functional change. The change is only semantic.

We can also add linters to the CI in the future to make the coding style consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all code and tests to use the modern Go type alias `any` instead of `interface{}` for generic values, maps, and slices. This change improves code clarity and aligns with current Go best practices. There are no changes to application behavior or logic.
- **Documentation**
  - Updated type signatures and struct field types in public-facing data structures and APIs to use `any` for better readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->