### PR TITLE
fix(MCPServer): correct notification method in func `RemoveResource()`

### DIFF
--- a/server/resource_test.go
+++ b/server/resource_test.go
@@ -84,7 +84,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 			expectedNotifications: 1,
 			validate: func(t *testing.T, notifications []mcp.JSONRPCNotification, resourcesList mcp.JSONRPCMessage) {
 				// Check that we received a list_changed notification
-				assert.Equal(t, "resources/list_changed", notifications[0].Method)
+				assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notifications[0].Method)
 
 				// Verify we now have only one resource
 				resp, ok := resourcesList.(mcp.JSONRPCResponse)
@@ -133,7 +133,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 			expectedNotifications: 1, // Still sends a notification
 			validate: func(t *testing.T, notifications []mcp.JSONRPCNotification, resourcesList mcp.JSONRPCMessage) {
 				// Check that we received a list_changed notification
-				assert.Equal(t, "resources/list_changed", notifications[0].Method)
+				assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notifications[0].Method)
 
 				// The original resource should still be there
 				resp, ok := resourcesList.(mcp.JSONRPCResponse)

--- a/server/server.go
+++ b/server/server.go
@@ -341,7 +341,7 @@ func (s *MCPServer) RemoveResource(uri string) {
 
 	// Send notification to all initialized sessions if listChanged capability is enabled
 	if s.capabilities.resources != nil && s.capabilities.resources.listChanged {
-		s.SendNotificationToAllClients("resources/list_changed", nil)
+		s.SendNotificationToAllClients(mcp.MethodNotificationResourcesListChanged, nil)
 	}
 }
 


### PR DESCRIPTION
&emsp; This PR corrects the notification's method  from `"resources/list_changed"` to  `"notifications/resources/list_changed"` when we remove Resource from MCPServer  for  consistency with the  [specification](https://modelcontextprotocol.io/specification/2025-03-26/server/resources#list-changed-notification):
> When the list of available resources changes, servers that declared the listChanged capability SHOULD send a notification:
{
  "jsonrpc": "2.0",
  "method": "notifications/resources/list_changed"
}

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved consistency in notification handling by standardizing the notification method name using a predefined constant. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->