### PR TITLE
feat(MCPServer): avoid unnecessary notifications when Resource/Tool not exists

### DIFF
--- a/server/resource_test.go
+++ b/server/resource_test.go
@@ -98,7 +98,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 			},
 		},
 		{
-			name: "RemoveResource with non-existent resource does nothing",
+			name: "RemoveResource with non-existent resource does nothing and not receives notifications from MCPServer",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
 				// Add a test resource
 				server.AddResource(
@@ -130,10 +130,11 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 				// Remove a non-existent resource
 				server.RemoveResource("test://nonexistent")
 			},
-			expectedNotifications: 1, // Still sends a notification
+			expectedNotifications: 0, // No notifications expected
 			validate: func(t *testing.T, notifications []mcp.JSONRPCNotification, resourcesList mcp.JSONRPCMessage) {
-				// Check that we received a list_changed notification
-				assert.Equal(t, mcp.MethodNotificationResourcesListChanged, notifications[0].Method)
+				// verify that no notifications were sent
+				assert.Empty(t, notifications)
+
 
 				// The original resource should still be there
 				resp, ok := resourcesList.(mcp.JSONRPCResponse)


### PR DESCRIPTION
# Motivation
&emsp; While working on an MCPClient, I unintentionally sent `DeleteResource` request twice with the same URI. I observed that the MCPServer responded with two `resources/list_changed` notifications, even though the second deletion had no actual effect (the resource had already been removed).
&emsp; As a result, the client’s `NotificationHandler` was triggered twice, leading to redundant processing.
&emsp; This behavior highlighted that the server does not currently check whether a resource or tool actually exists before broadcasting a `list_changed` event.
# Problem
&emsp; In the original implementation of `RemoveResource` (and similarly `DeleteTools`), the server always sends a `list_changed` notification, **regardless of whether the deletion modified the internal state**.
&emsp; Although safe from a language standpoint (Go’s delete is a no-op for nonexistent keys), this can lead to:
- **Unnecessary client-side handling** of notifications,
- **Inaccurate signaling** about state changes,
- **Potential for abuse** by triggering repeated fake deletions to flood notifications.

&emsp; Also, from the [specification](https://modelcontextprotocol.io/specification/2025-03-26/server/resources#list-changed-notification):
> When the list of available resources changes, servers that declared the listChanged capability SHOULD send a notification. Sending a `DeleteResource` request with non-existing resource URI actually incurs no changes to the list of available resource/tools

&emsp;  I think it could be better for MCPServer to send notifications to MCPClients when the ResourceList/ToolsList   actually changes. 
# What This PR Changes
&emsp;This PR updates `RemoveResource` and `DeleteTools` to:
- Check whether the resource/tool actually existed before removal,
- Only send a `list_changed` notification **if the internal state was modified.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of resource and tool deletions to ensure notifications are only sent when actual changes occur.
	- Prevented unnecessary notifications when attempting to remove non-existent resources or tools.

- **Tests**
	- Updated existing tests to verify that no notifications are sent when removing non-existent resources.
	- Added a new test to confirm correct behavior when deleting non-existent tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->