### PR TITLE
fix: fix some obvious simplifications

### DIFF
--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -159,47 +159,47 @@ func NewMCPServer() *server.MCPServer {
 	return mcpServer
 }
 
-func generateResources() []mcp.Resource {
-	resources := make([]mcp.Resource, 100)
-	for i := 0; i < 100; i++ {
-		uri := fmt.Sprintf("test://static/resource/%d", i+1)
-		if i%2 == 0 {
-			resources[i] = mcp.Resource{
-				URI:      uri,
-				Name:     fmt.Sprintf("Resource %d", i+1),
-				MIMEType: "text/plain",
-			}
-		} else {
-			resources[i] = mcp.Resource{
-				URI:      uri,
-				Name:     fmt.Sprintf("Resource %d", i+1),
-				MIMEType: "application/octet-stream",
-			}
-		}
-	}
-	return resources
-}
+// func generateResources() []mcp.Resource {
+// 	resources := make([]mcp.Resource, 100)
+// 	for i := 0; i < 100; i++ {
+// 		uri := fmt.Sprintf("test://static/resource/%d", i+1)
+// 		if i%2 == 0 {
+// 			resources[i] = mcp.Resource{
+// 				URI:      uri,
+// 				Name:     fmt.Sprintf("Resource %d", i+1),
+// 				MIMEType: "text/plain",
+// 			}
+// 		} else {
+// 			resources[i] = mcp.Resource{
+// 				URI:      uri,
+// 				Name:     fmt.Sprintf("Resource %d", i+1),
+// 				MIMEType: "application/octet-stream",
+// 			}
+// 		}
+// 	}
+// 	return resources
+// }
 
-func runUpdateInterval() {
-	// for range s.updateTicker.C {
-	// 	for uri := range s.subscriptions {
-	// 		s.server.HandleMessage(
-	// 			context.Background(),
-	// 			mcp.JSONRPCNotification{
-	// 				JSONRPC: mcp.JSONRPC_VERSION,
-	// 				Notification: mcp.Notification{
-	// 					Method: "resources/updated",
-	// 					Params: struct {
-	// 						Meta map[string]interface{} `json:"_meta,omitempty"`
-	// 					}{
-	// 						Meta: map[string]interface{}{"uri": uri},
-	// 					},
-	// 				},
-	// 			},
-	// 		)
-	// 	}
-	// }
-}
+// func runUpdateInterval() {
+// 	for range s.updateTicker.C {
+// 		for uri := range s.subscriptions {
+// 			s.server.HandleMessage(
+// 				context.Background(),
+// 				mcp.JSONRPCNotification{
+// 					JSONRPC: mcp.JSONRPC_VERSION,
+// 					Notification: mcp.Notification{
+// 						Method: "resources/updated",
+// 						Params: struct {
+// 							Meta map[string]interface{} `json:"_meta,omitempty"`
+// 						}{
+// 							Meta: map[string]interface{}{"uri": uri},
+// 						},
+// 					},
+// 				},
+// 			)
+// 		}
+// 	}
+// }
 
 func handleReadResource(
 	ctx context.Context,

--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -189,27 +189,6 @@ func generateResources() []mcp.Resource {
 	return resources
 }
 
-// func runUpdateInterval() {
-// 	for range s.updateTicker.C {
-// 		for uri := range s.subscriptions {
-// 			s.server.HandleMessage(
-// 				context.Background(),
-// 				mcp.JSONRPCNotification{
-// 					JSONRPC: mcp.JSONRPC_VERSION,
-// 					Notification: mcp.Notification{
-// 						Method: "resources/updated",
-// 						Params: struct {
-// 							Meta map[string]interface{} `json:"_meta,omitempty"`
-// 						}{
-// 							Meta: map[string]interface{}{"uri": uri},
-// 						},
-// 					},
-// 				},
-// 			)
-// 		}
-// 	}
-// }
-
 func handleReadResource(
 	ctx context.Context,
 	request mcp.ReadResourceRequest,

--- a/server/session.go
+++ b/server/session.go
@@ -231,10 +231,8 @@ func (s *MCPServer) AddSessionTools(sessionID string, tools ...ServerTool) error
 	newSessionTools := make(map[string]ServerTool, len(sessionTools)+len(tools))
 
 	// Copy existing tools
-	if sessionTools != nil {
-		for k, v := range sessionTools {
-			newSessionTools[k] = v
-		}
+	for k, v := range sessionTools {
+		newSessionTools[k] = v
 	}
 
 	// Add new tools

--- a/server/sse.go
+++ b/server/sse.go
@@ -451,7 +451,7 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 			if eventData, err := json.Marshal(response); err != nil {
 				// If there is an error marshalling the response, send a generic error response
 				log.Printf("failed to marshal response: %v", err)
-				message = fmt.Sprintf("event: message\ndata: {\"error\": \"internal error\",\"jsonrpc\": \"2.0\", \"id\": null}\n\n")
+				message = "event: message\ndata: {\"error\": \"internal error\",\"jsonrpc\": \"2.0\", \"id\": null}\n\n"
 			} else {
 				message = fmt.Sprintf("event: message\ndata: %s\n\n", eventData)
 			}

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -197,7 +197,8 @@ func TestSSEServer(t *testing.T) {
 
 				endpointEvent, err = readSSEEvent(sseResp)
 				if err != nil {
-					t.Fatalf("Failed to read SSE response: %v", err)
+					t.Errorf("Failed to read SSE response: %v", err)
+					return
 				}
 				respFromSee := strings.TrimSpace(
 					strings.Split(strings.Split(endpointEvent, "data: ")[1], "\n")[0],


### PR DESCRIPTION
I found these issues while I was going through the codebase from my linter and thought they could be definitely fixed.

1. Comment out unused code in the examples properly.
2. Remove unnecessary nil check around a range. If it is nil, it won't do anything.
3. Unnecessary fmt.Sprintf

It would be good if add a linter to the CI. I can add it to the existing workflow if everyone think that would help.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tool capabilities in the MCP server.
  - Introduced 100 new generated resources with alternating text and binary content.
- **Refactor**
  - Simplified error message handling for server-sent events.
  - Streamlined session tool management by removing redundant checks.
  - Improved test robustness by enhancing error handling in SSE session tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->