### PR TITLE
docs: make code examples in the README correct as per spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Discuss the SDK on [Discord](https://discord.gg/RqSS2NQVsY)
 
 </div>
 
+
 ```go
 package main
 
@@ -31,10 +32,11 @@ import (
 )
 
 func main() {
-    // Create MCP server
+    // Create a new MCP server
     s := server.NewMCPServer(
         "Demo 🚀",
         "1.0.0",
+        server.WithToolCapabilities(false),
     )
 
     // Add tool
@@ -116,7 +118,6 @@ package main
 
 import (
     "context"
-    "errors"
     "fmt"
 
     "github.com/mark3labs/mcp-go/mcp"
@@ -128,8 +129,7 @@ func main() {
     s := server.NewMCPServer(
         "Calculator Demo",
         "1.0.0",
-        server.WithResourceCapabilities(true, true),
-        server.WithLogging(),
+        server.WithToolCapabilities(false),
         server.WithRecovery(),
     )
 
@@ -181,6 +181,7 @@ func main() {
     }
 }
 ```
+
 ## What is MCP?
 
 The [Model Context Protocol (MCP)](https://modelcontextprotocol.io) lets you build servers that expose data and functionality to LLM applications in a secure, standardized way. Think of it like a web API, but specifically designed for LLM interactions. MCP servers can:


### PR DESCRIPTION
Improved the code examples in the README to follow the MCP spec. See the review for details on why I made specific changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated example code snippets in the README to use the latest server options and improved formatting.
  - Removed unused imports from the Quickstart example for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->