### PR TITLE
feat(MCPServer): support `logging/setlevel` request

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -47,6 +47,10 @@ const (
 	// https://modelcontextprotocol.io/specification/2024-11-05/server/tools/
 	MethodToolsCall MCPMethod = "tools/call"
 
+	// MethodSetLogLevel configures the minimum log level for client
+	// https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging
+	MethodSetLogLevel MCPMethod = "logging/setLevel"
+
 	// MethodNotificationResourcesListChanged notifies when the list of available resources changes.
 	// https://modelcontextprotocol.io/specification/2025-03-26/server/resources#list-changed-notification
 	MethodNotificationResourcesListChanged = "notifications/resources/list_changed"

--- a/server/errors.go
+++ b/server/errors.go
@@ -13,10 +13,11 @@ var (
 	ErrToolNotFound     = errors.New("tool not found")
 
 	// Session-related errors
-	ErrSessionNotFound            = errors.New("session not found")
-	ErrSessionExists              = errors.New("session already exists")
-	ErrSessionNotInitialized      = errors.New("session not properly initialized")
-	ErrSessionDoesNotSupportTools = errors.New("session does not support per-session tools")
+	ErrSessionNotFound            	= errors.New("session not found")
+	ErrSessionExists              	= errors.New("session already exists")
+	ErrSessionNotInitialized      	= errors.New("session not properly initialized")
+	ErrSessionDoesNotSupportTools 	= errors.New("session does not support per-session tools")
+	ErrSessionDoesNotSupportLogging = errors.New("session does not support setting logging level")
 
 	// Notification-related errors
 	ErrNotificationNotInitialized = errors.New("notification channel not initialized")

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -67,6 +67,9 @@ type OnAfterInitializeFunc func(ctx context.Context, id any, message *mcp.Initia
 type OnBeforePingFunc func(ctx context.Context, id any, message *mcp.PingRequest)
 type OnAfterPingFunc func(ctx context.Context, id any, message *mcp.PingRequest, result *mcp.EmptyResult)
 
+type OnBeforeSetLevelFunc func(ctx context.Context, id any, message *mcp.SetLevelRequest)
+type OnAfterSetLevelFunc func(ctx context.Context, id any, message *mcp.SetLevelRequest, result *mcp.EmptyResult)
+
 type OnBeforeListResourcesFunc func(ctx context.Context, id any, message *mcp.ListResourcesRequest)
 type OnAfterListResourcesFunc func(ctx context.Context, id any, message *mcp.ListResourcesRequest, result *mcp.ListResourcesResult)
 
@@ -99,6 +102,8 @@ type Hooks struct {
 	OnAfterInitialize             []OnAfterInitializeFunc
 	OnBeforePing                  []OnBeforePingFunc
 	OnAfterPing                   []OnAfterPingFunc
+	OnBeforeSetLevel              []OnBeforeSetLevelFunc
+	OnAfterSetLevel               []OnAfterSetLevelFunc
 	OnBeforeListResources         []OnBeforeListResourcesFunc
 	OnAfterListResources          []OnAfterListResourcesFunc
 	OnBeforeListResourceTemplates []OnBeforeListResourceTemplatesFunc
@@ -282,6 +287,7 @@ func (c *Hooks) afterInitialize(ctx context.Context, id any, message *mcp.Initia
 		hook(ctx, id, message, result)
 	}
 }
+
 func (c *Hooks) AddBeforePing(hook OnBeforePingFunc) {
 	c.OnBeforePing = append(c.OnBeforePing, hook)
 }
@@ -309,6 +315,35 @@ func (c *Hooks) afterPing(ctx context.Context, id any, message *mcp.PingRequest,
 		hook(ctx, id, message, result)
 	}
 }
+
+func (c *Hooks) AddBeforeSetLevel(hook OnBeforeSetLevelFunc) {
+	c.OnBeforeSetLevel = append(c.OnBeforeSetLevel, hook)
+}
+
+func (c *Hooks) AddAfterSetLevel(hook OnAfterSetLevelFunc) {
+	c.OnAfterSetLevel = append(c.OnAfterSetLevel, hook)
+}
+
+func (c *Hooks) beforeSetLevel(ctx context.Context, id any, message *mcp.SetLevelRequest) {
+	c.beforeAny(ctx, id, mcp.MethodSetLogLevel, message)
+	if c == nil {
+		return
+	}
+	for _, hook := range c.OnBeforeSetLevel {
+		hook(ctx, id, message)
+	}
+}
+
+func (c *Hooks) afterSetLevel(ctx context.Context, id any, message *mcp.SetLevelRequest, result *mcp.EmptyResult) {
+	c.onSuccess(ctx, id, mcp.MethodSetLogLevel, message, result)
+	if c == nil {
+		return
+	}
+	for _, hook := range c.OnAfterSetLevel {
+		hook(ctx, id, message, result)
+	}
+}
+
 func (c *Hooks) AddBeforeListResources(hook OnBeforeListResourcesFunc) {
 	c.OnBeforeListResources = append(c.OnBeforeListResources, hook)
 }

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -110,6 +110,31 @@ func (s *MCPServer) HandleMessage(
 		}
 		s.hooks.afterPing(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
+	case mcp.MethodSetLogLevel:
+		var request mcp.SetLevelRequest
+		var result *mcp.EmptyResult
+		if s.capabilities.logging == false {
+			err = &requestError{
+				id:   baseMessage.ID,
+				code: mcp.METHOD_NOT_FOUND,
+				err:  fmt.Errorf("logging %w", ErrUnsupported),
+			}
+		} else if unmarshalErr := json.Unmarshal(message, &request); unmarshalErr != nil {
+			err = &requestError{
+				id:   baseMessage.ID,
+				code: mcp.INVALID_REQUEST,
+				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
+			}
+		} else {
+			s.hooks.beforeSetLevel(ctx, baseMessage.ID, &request)
+			result, err = s.handleSetLevel(ctx, baseMessage.ID, request)
+		}
+		if err != nil {
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
+			return err.ToJSONRPCError()
+		}
+		s.hooks.afterSetLevel(ctx, baseMessage.ID, &request, result)
+		return createResponse(baseMessage.ID, *result)
 	case mcp.MethodResourcesList:
 		var request mcp.ListResourcesRequest
 		var result *mcp.ListResourcesResult

--- a/server/server.go
+++ b/server/server.go
@@ -540,6 +540,34 @@ func (s *MCPServer) handlePing(
 	return &mcp.EmptyResult{}, nil
 }
 
+func (s *MCPServer) handleSetLevel(
+	ctx context.Context,
+	id any,
+	request mcp.SetLevelRequest,
+) (*mcp.EmptyResult, *requestError) {
+	clientSession := ClientSessionFromContext(ctx)
+	if clientSession == nil || !clientSession.Initialized() {
+		return nil, &requestError{
+			id: 	id,
+			code: 	mcp.INTERNAL_ERROR,
+			err: 	ErrSessionNotInitialized,
+		}
+	}
+
+	sessionLogging, ok := clientSession.(SessionWithLogging)
+	if !ok {
+		return nil, &requestError{
+			id: 	id,
+			code: 	mcp.INTERNAL_ERROR,
+			err: 	ErrSessionDoesNotSupportLogging,
+		}
+	}
+
+	sessionLogging.SetLogLevel(request.Params.Level)
+
+	return &mcp.EmptyResult{}, nil
+}
+
 func listByPagination[T mcp.Named](
 	ctx context.Context,
 	s *MCPServer,

--- a/server/session.go
+++ b/server/session.go
@@ -19,6 +19,15 @@ type ClientSession interface {
 	SessionID() string
 }
 
+// SessionWithLogging is an extension of ClientSession that can receive log message notifications and set log level
+type SessionWithLogging interface {
+	ClientSession
+	// SetLogLevel sets the minimum log level
+	SetLogLevel(level mcp.LoggingLevel)
+	// GetLogLevel retrieves the minimum log level
+	GetLogLevel() mcp.LoggingLevel
+}
+
 // SessionWithTools is an extension of ClientSession that can store session-specific tool data
 type SessionWithTools interface {
 	ClientSession

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -98,9 +99,47 @@ func (f *sessionTestClientWithTools) SetSessionTools(tools map[string]ServerTool
 	f.sessionTools = toolsCopy
 }
 
-// Verify that both implementations satisfy their respective interfaces
-var _ ClientSession = &sessionTestClient{}
-var _ SessionWithTools = &sessionTestClientWithTools{}
+// sessionTestClientWithTools implements the SessionWithLogging interface for testing
+type sessionTestClientWithLogging struct {
+	sessionID           string
+	notificationChannel chan mcp.JSONRPCNotification
+	initialized         bool
+	loggingLevel 		atomic.Value
+}
+
+func (f *sessionTestClientWithLogging) SessionID() string {
+	return f.sessionID
+}
+
+func (f *sessionTestClientWithLogging) NotificationChannel() chan<- mcp.JSONRPCNotification {
+	return f.notificationChannel
+}
+
+func (f *sessionTestClientWithLogging) Initialize() {
+	// set default logging level
+	f.loggingLevel.Store(mcp.LoggingLevelError)
+	f.initialized = true
+}
+
+func (f *sessionTestClientWithLogging) Initialized() bool {
+	return f.initialized
+}
+
+func (f *sessionTestClientWithLogging) SetLogLevel(level mcp.LoggingLevel) {
+	f.loggingLevel.Store(level)
+}
+
+func (f *sessionTestClientWithLogging) GetLogLevel() mcp.LoggingLevel {
+	level := f.loggingLevel.Load()
+	return level.(mcp.LoggingLevel)
+}
+
+// Verify that all implementations satisfy their respective interfaces
+var (
+	_ ClientSession 			= (*sessionTestClient)(nil)
+	_ SessionWithTools 			= (*sessionTestClientWithTools)(nil)
+	_ SessionWithLogging		= (*sessionTestClientWithLogging)(nil)
+)
 
 func TestSessionWithTools_Integration(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithToolCapabilities(true))
@@ -618,4 +657,52 @@ func TestMCPServer_NotificationChannelBlocked(t *testing.T) {
 	assert.True(t, localErrorCaptured, "Error hook should have been called for broadcast")
 	assert.Equal(t, "blocked-session", localErrorSessionID, "Session ID should be captured in the error hook")
 	assert.Equal(t, "broadcast-message", localErrorMethod, "Method should be captured in the error hook")
+}
+
+func TestMCPServer_SetLevel(t *testing.T) {
+	server := NewMCPServer("test-server", "1.0.0", WithLogging())
+
+	// Create and initicalize a session
+	sessionChan := make(chan mcp.JSONRPCNotification, 10)
+	session := &sessionTestClientWithLogging{
+		sessionID:           "session-1",
+		notificationChannel: sessionChan,
+	}
+	session.Initialize()
+
+	// Check default logging level
+	if session.GetLogLevel() != mcp.LoggingLevelError {
+		t.Errorf("Expected error level, got %v", session.GetLogLevel())
+	}
+
+	// Register the session
+	err := server.RegisterSession(context.Background(), session)
+	require.NoError(t, err)
+
+	// Set Logging level to critical
+	sessionCtx := server.WithContext(context.Background(), session)
+	setRequest := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "logging/setLevel",
+		"params": map[string]any{
+			"level": mcp.LoggingLevelCritical,
+		},
+	}
+	requestBytes, err := json.Marshal(setRequest)
+	if err != nil {
+		t.Fatalf("Failed to marshal tool request: %v", err)
+	}
+
+	response := server.HandleMessage(sessionCtx, requestBytes)
+	resp, ok := response.(mcp.JSONRPCResponse)
+	assert.True(t, ok)
+
+	_, ok = resp.Result.(mcp.EmptyResult)
+	assert.True(t, ok)
+
+	// Check logging level
+	if session.GetLogLevel() != mcp.LoggingLevelCritical {
+		t.Errorf("Expected critical level, got %v", session.GetLogLevel())
+	}
 }

--- a/server/sse.go
+++ b/server/sse.go
@@ -28,6 +28,7 @@ type sseSession struct {
 	requestID           atomic.Int64
 	notificationChannel chan mcp.JSONRPCNotification
 	initialized         atomic.Bool
+	loggingLevel		atomic.Value
 	tools               sync.Map // stores session-specific tools
 }
 
@@ -45,11 +46,22 @@ func (s *sseSession) NotificationChannel() chan<- mcp.JSONRPCNotification {
 }
 
 func (s *sseSession) Initialize() {
+	// set default logging level
+	s.loggingLevel.Store(mcp.LoggingLevelError)
 	s.initialized.Store(true)
 }
 
 func (s *sseSession) Initialized() bool {
 	return s.initialized.Load()
+}
+
+func(s *sseSession) SetLogLevel(level mcp.LoggingLevel) {
+	s.loggingLevel.Store(level)
+}
+
+func(s *sseSession) GetLogLevel() mcp.LoggingLevel {
+	level := s.loggingLevel.Load()
+	return level.(mcp.LoggingLevel)
 }
 
 func (s *sseSession) GetSessionTools() map[string]ServerTool {
@@ -77,8 +89,9 @@ func (s *sseSession) SetSessionTools(tools map[string]ServerTool) {
 }
 
 var (
-	_ ClientSession    = (*sseSession)(nil)
-	_ SessionWithTools = (*sseSession)(nil)
+	_ ClientSession    		= (*sseSession)(nil)
+	_ SessionWithTools 		= (*sseSession)(nil)
+	_ SessionWithLogging	= (*sseSession)(nil)
 )
 
 // SSEServer implements a Server-Sent Events (SSE) based MCP server.

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -51,8 +51,9 @@ func WithStdioContextFunc(fn StdioContextFunc) StdioOption {
 
 // stdioSession is a static client session, since stdio has only one client.
 type stdioSession struct {
-	notifications chan mcp.JSONRPCNotification
-	initialized   atomic.Bool
+	notifications 	chan mcp.JSONRPCNotification
+	initialized   	atomic.Bool
+	loggingLevel	atomic.Value
 }
 
 func (s *stdioSession) SessionID() string {
@@ -64,6 +65,8 @@ func (s *stdioSession) NotificationChannel() chan<- mcp.JSONRPCNotification {
 }
 
 func (s *stdioSession) Initialize() {
+	// set default logging level
+	s.loggingLevel.Store(mcp.LoggingLevelError)
 	s.initialized.Store(true)
 }
 
@@ -71,7 +74,19 @@ func (s *stdioSession) Initialized() bool {
 	return s.initialized.Load()
 }
 
-var _ ClientSession = (*stdioSession)(nil)
+func(s *stdioSession) SetLogLevel(level mcp.LoggingLevel) {
+	s.loggingLevel.Store(level)
+}
+
+func(s *stdioSession) GetLogLevel() mcp.LoggingLevel {
+	level := s.loggingLevel.Load()
+	return level.(mcp.LoggingLevel)
+}
+
+var (
+	_ ClientSession			= (*stdioSession)(nil)
+	_ SessionWithLogging 	= (*stdioSession)(nil)
+)
 
 var stdioSessionInstance = stdioSession{
 	notifications: make(chan mcp.JSONRPCNotification, 100),


### PR DESCRIPTION
&emsp; This PR supports `logging/setlevel` functionality according to the [specification](https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#setting-log-level):
<img width="370" alt="workflow" src="https://github.com/user-attachments/assets/97f22012-20b8-4fbe-97df-7eab7d2dbb22" />
