### PR TITLE
fix: proper deprecation messaging for WithHTTPContextFunc

### DIFF
--- a/examples/custom_context/main.go
+++ b/examples/custom_context/main.go
@@ -125,7 +125,7 @@ func NewMCPServer() *MCPServer {
 func (s *MCPServer) ServeSSE(addr string) *server.SSEServer {
 	return server.NewSSEServer(s.server,
 		server.WithBaseURL(fmt.Sprintf("http://%s", addr)),
-		server.WithSSEContextFunc(authFromRequest),
+		server.WithHTTPContextFunc(authFromRequest),
 	)
 }
 

--- a/server/sse.go
+++ b/server/sse.go
@@ -185,7 +185,7 @@ func WithSSEEndpoint(endpoint string) SSEOption {
 // WithSSEContextFunc sets a function that will be called to customise the context
 // to the server using the incoming request.
 //
-// Deprecated: Use WithContextFunc instead. This will be removed in a future version.
+// Deprecated: Use WithHTTPContextFunc instead. This will be removed in a future version.
 //
 //go:deprecated
 func WithSSEContextFunc(fn SSEContextFunc) SSEOption {

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -579,7 +579,7 @@ func TestSSEServer(t *testing.T) {
 			return mcp.NewToolResultText(testVal), nil
 		})
 
-		testServer := NewTestServer(mcpServer, WithSSEContextFunc(setTestValFromRequest))
+		testServer := NewTestServer(mcpServer, WithHTTPContextFunc(setTestValFromRequest))
 		defer testServer.Close()
 
 		// Connect to SSE endpoint


### PR DESCRIPTION
1. Proper deprecation messaging
2. use `WithHTTPContextFunc` in testing code