### PR TITLE
chore: add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Report an issue or unexpected behavior
+title: 'bug: '
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug, including what happened and what you expected to happen.
+
+## Code Sample
+
+```go
+// Minimum code snippet to reproduce the issue
+// Remove if not applicable
+```
+
+## Logs or Error Messages
+
+```text
+If applicable, include any error messages, stack traces, or logs. Remove if not applicable.
+```
+
+## Environment
+
+ - Go version (see `go.mod`): [e.g. 1.23]
+ - mcp-go version (see `go.mod`): [e.g. 0.27.0]
+ - Any other relevant environment details (OS, architecture, etc.)
+
+## Additional Context
+
+Add any other context about the problem here.
+
+## Possible Solution
+
+If you have a suggestion for fixing the issue, please describe it here.

--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Ask a Question
+    url: https://github.com/mark3labs/mcp-go/discussions/categories/q-a
+    about: Ask any question about the project.
+  - name: Join the Community
+    url: https://discord.gg/RqSS2NQVsY
+    about: Join the community on Discord.

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -1,0 +1,15 @@
+---
+name: Documentation improvement
+about: Suggestion improvements to the documentation
+title: 'docs: '
+labels: documentation
+assignees: ''
+---
+
+## Documentation Issue
+
+Describe what's unclear, incorrect, or missing in the current documentation.
+
+## Location
+
+Provide a link or description of where this documentation issue exists or should exist (README, code comments, examples, etc.).

--- a/.github/ISSUE_TEMPLATE/documentation-improvement.md
+++ b/.github/ISSUE_TEMPLATE/documentation-improvement.md
@@ -1,6 +1,6 @@
 ---
 name: Documentation improvement
-about: Suggestion improvements to the documentation
+about: Suggest improvements to the documentation
 title: 'docs: '
 labels: documentation
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,32 @@
+---
+name: Feature request
+about: Suggest a new feature or enhancement
+title: 'feature: '
+labels: enhancement
+assignees: ''
+---
+
+## Problem Statement
+
+A clear and concise description of what the problem is. For example, "I'm always frustrated when [...]"
+
+## Proposed Solution
+
+A clear and concise description of what you want to happen. Include any API design or implementation details you have in mind.
+
+## MCP Spec Reference
+
+If this feature is described in the MCP specification, please provide a link to the relevant section with a brief explanation of how it relates to your request.
+
+Remove this section if not applicable.
+
+## Example Usage
+
+```go
+// If applicable, provide sample code showing how the proposed feature would be used.
+// Remove if not applicable
+```
+
+## Alternatives/Workarounds Considered
+
+A clear and concise description of any alternative solutions, workarounds, or features you've considered.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,37 @@
+## Description
+<!-- Provide a concise description of the changes in this PR -->
+
+Fixes #<issue_number> (if applicable)
+
+## Type of Change
+<!-- Please select all the relevant options by replacing [ ] with [x] -->
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] MCP spec compatibility implementation
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Code refactoring (no functional changes)
+- [ ] Performance improvement
+- [ ] Tests only (no functional changes)
+- [ ] Other (please describe):
+
+## Checklist
+<!-- Please select all that apply by replacing [ ] with [x] -->
+
+- [ ] My code follows the code style of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] I have updated the documentation accordingly
+
+## MCP Spec Compliance
+<!-- If this PR implements a feature from the MCP specification, please answer the following -->
+<!-- If not applicable, remove this section -->
+
+- [ ] This PR implements a feature defined in the MCP specification
+- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
+- [ ] Implementation follows the specification exactly
+
+## Additional Information
+<!-- Any additional information that might be useful for reviewers -->
+<!-- If not applicable, remove this section -->


### PR DESCRIPTION
Adds three issue templates:

1. For reporting bugs
2. For suggesting doc improvements
3. for requesting features, including:
	1. Enhancements to the SDK APIs
	2. Improving compatibility with the MCP spec
	3. and anything else without having separate templates for each feature area.

Subcategories of issues can be separated using more specific labels, which will be added soon.

Also adds a PR template with checklists to ensure contributors think through before opening PRs. Reduces the chances of not updating the docs or adding tests, etc.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added standardized GitHub issue templates for bug reports, feature requests, and documentation improvements to streamline user submissions.
  - Introduced a pull request template to guide contributors in providing clear and complete PR descriptions.
  - Enabled blank issues and added contact links for community support and Q&A via GitHub Discussions and Discord.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->