### PR TITLE
ci: add golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,23 @@
+name: golangci-lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v8
+        with:
+          version: v2.1

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,5 @@
+version: "2"
+linters:
+  exclusions:
+    presets:
+      - std-error-handling

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,3 +3,4 @@ linters:
   exclusions:
     presets:
       - std-error-handling
+

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -46,11 +46,14 @@ func startMockStreamableHTTPServer() (string, func()) {
 			w.Header().Set("Mcp-Session-Id", sessionID)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusAccepted)
-			json.NewEncoder(w).Encode(map[string]any{
+			if err := json.NewEncoder(w).Encode(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      request["id"],
 				"result":  "initialized",
-			})
+			}); err != nil {
+				http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+				return
+			}
 
 		case "debug/echo":
 			// Check session ID
@@ -62,11 +65,14 @@ func startMockStreamableHTTPServer() (string, func()) {
 			// Echo back the request as the response result
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			json.NewEncoder(w).Encode(map[string]any{
+			if err := json.NewEncoder(w).Encode(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      request["id"],
 				"result":  request,
-			})
+			}); err != nil {
+				http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+				return
+			}
 
 		case "debug/echo_notification":
 			// Check session ID
@@ -104,14 +110,17 @@ func startMockStreamableHTTPServer() (string, func()) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			data, _ := json.Marshal(request)
-			json.NewEncoder(w).Encode(map[string]any{
+			if err := json.NewEncoder(w).Encode(map[string]any{
 				"jsonrpc": "2.0",
 				"id":      request["id"],
 				"error": map[string]any{
 					"code":    -1,
 					"message": string(data),
 				},
-			})
+			}); err != nil {
+				http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+				return
+			}
 		}
 	})
 

--- a/examples/custom_context/main.go
+++ b/examples/custom_context/main.go
@@ -125,7 +125,7 @@ func NewMCPServer() *MCPServer {
 func (s *MCPServer) ServeSSE(addr string) *server.SSEServer {
 	return server.NewSSEServer(s.server,
 		server.WithBaseURL(fmt.Sprintf("http://%s", addr)),
-		server.WithSSEContextFunc(authFromRequest),
+		server.WithHTTPContextFunc(authFromRequest),
 	)
 }
 

--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -392,7 +392,7 @@ func handleLongRunningOperationTool(
 	for i := 1; i < int(steps)+1; i++ {
 		time.Sleep(time.Duration(stepDuration * float64(time.Second)))
 		if progressToken != nil {
-			server.SendNotificationToClient(
+			err := server.SendNotificationToClient(
 				ctx,
 				"notifications/progress",
 				map[string]any{
@@ -402,6 +402,9 @@ func handleLongRunningOperationTool(
 					"message":       fmt.Sprintf("Server progress %v%%", int(float64(i)*100/steps)),
 				},
 			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to send notification: %w", err)
+			}
 		}
 	}
 

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -67,7 +67,7 @@ type URITemplate struct {
 }
 
 func (t *URITemplate) MarshalJSON() ([]byte, error) {
-	return json.Marshal(t.Template.Raw())
+	return json.Marshal(t.Raw())
 }
 
 func (t *URITemplate) UnmarshalJSON(data []byte) error {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -368,7 +368,7 @@ func TestMCPServer_Tools(t *testing.T) {
 				"id": 1,
 				"method": "tools/list"
 			}`))
-			tt.validate(t, notifications, toolsList.(mcp.JSONRPCMessage))
+			tt.validate(t, notifications, toolsList)
 		})
 	}
 }

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -573,7 +573,8 @@ func TestMCPServer_NotificationChannelBlocked(t *testing.T) {
 	require.NoError(t, err)
 
 	// Fill the buffer first to ensure it gets blocked
-	server.SendNotificationToSpecificClient(session.SessionID(), "first-message", nil)
+	err = server.SendNotificationToSpecificClient(session.SessionID(), "first-message", nil)
+	require.NoError(t, err)
 
 	// This will cause the buffer to block
 	err = server.SendNotificationToSpecificClient(session.SessionID(), "blocked-message", nil)

--- a/server/sse.go
+++ b/server/sse.go
@@ -185,7 +185,7 @@ func WithSSEEndpoint(endpoint string) SSEOption {
 // WithSSEContextFunc sets a function that will be called to customise the context
 // to the server using the incoming request.
 //
-// Deprecated: Use WithContextFunc instead. This will be removed in a future version.
+// Deprecated: Use WithHTTPContextFunc instead. This will be removed in a future version.
 //
 //go:deprecated
 func WithSSEContextFunc(fn SSEContextFunc) SSEOption {
@@ -297,7 +297,11 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	defer s.sessions.Delete(sessionID)
 
 	if err := s.server.RegisterSession(r.Context(), session); err != nil {
-		http.Error(w, fmt.Sprintf("Session registration failed: %v", err), http.StatusInternalServerError)
+		http.Error(
+			w,
+			fmt.Sprintf("Session registration failed: %v", err),
+			http.StatusInternalServerError,
+		)
 		return
 	}
 	defer s.server.UnregisterSession(r.Context(), sessionID)
@@ -621,7 +625,11 @@ func (s *SSEServer) MessageHandler() http.Handler {
 // ServeHTTP implements the http.Handler interface.
 func (s *SSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.dynamicBasePathFunc != nil {
-		http.Error(w, (&ErrDynamicPathConfig{Method: "ServeHTTP"}).Error(), http.StatusInternalServerError)
+		http.Error(
+			w,
+			(&ErrDynamicPathConfig{Method: "ServeHTTP"}).Error(),
+			http.StatusInternalServerError,
+		)
 		return
 	}
 	path := r.URL.Path

--- a/server/sse.go
+++ b/server/sse.go
@@ -484,7 +484,14 @@ func (s *SSEServer) writeJSONRPCError(
 	response := createErrorResponse(id, code, message)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusBadRequest)
-	json.NewEncoder(w).Encode(response)
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(
+			w,
+			fmt.Sprintf("Failed to encode response: %v", err),
+			http.StatusInternalServerError,
+		)
+		return
+	}
 }
 
 // SendEventToSession sends an event to a specific SSE session identified by sessionID.

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -29,6 +29,7 @@ func TestSSEServer(t *testing.T) {
 
 		if sseServer == nil {
 			t.Error("SSEServer should not be nil")
+			return
 		}
 		if sseServer.server == nil {
 			t.Error("MCPServer should not be nil")
@@ -1247,7 +1248,7 @@ func TestSSEServer(t *testing.T) {
 			WithHooks(&Hooks{
 				OnAfterInitialize: []OnAfterInitializeFunc{
 					func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
-						result.Result.Meta = map[string]any{"invalid": func() {}} // marshal will fail
+						result.Meta = map[string]any{"invalid": func() {}} // marshal will fail
 					},
 				},
 			}),


### PR DESCRIPTION
Add golangci-lint to the CI.

Fix the errors reported by golangci-lint.

See this workflow run for all the errors reported by golangci-lint before they were fixed: https://github.com/mark3labs/mcp-go/actions/runs/14992236103/job/42118080591?pr=282

Only the default linters are enabled now. We can enable more in the future as needed unless anyone has strong opinions on enabling any of the other linters now. See: https://golangci-lint.run/usage/linters/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added automated code linting for Go projects using golangci-lint on pushes to main and pull requests.
	- Improved server error handling readability and updated deprecation guidance.
	- Enhanced error handling in mock HTTP server responses and notification sending.
	- Fixed test stability by correcting error handling and assignment in server tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->