### PR TITLE
fix(session): Don't send tool changed notifications if session not initialized yet

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -243,19 +243,24 @@ func (s *MCPServer) AddSessionTools(sessionID string, tools ...ServerTool) error
 	// Set the tools (this should be thread-safe)
 	session.SetSessionTools(newSessionTools)
 
-	// Send notification only to this session
-	if err := s.SendNotificationToSpecificClient(sessionID, "notifications/tools/list_changed", nil); err != nil {
-		// Log the error but don't fail the operation
-		// The tools were successfully added, but notification failed
-		if s.hooks != nil && len(s.hooks.OnError) > 0 {
-			hooks := s.hooks
-			go func(sID string, hooks *Hooks) {
-				ctx := context.Background()
-				hooks.onError(ctx, nil, "notification", map[string]any{
-					"method":    "notifications/tools/list_changed",
-					"sessionID": sID,
-				}, fmt.Errorf("failed to send notification after adding tools: %w", err))
-			}(sessionID, hooks)
+	// It only makes sense to send tool notifications to initialized sessions --
+	// if we're not initialized yet the client can't possibly have sent their
+	// initial tools/list message
+	if session.Initialized() {
+		// Send notification only to this session
+		if err := s.SendNotificationToSpecificClient(sessionID, "notifications/tools/list_changed", nil); err != nil {
+			// Log the error but don't fail the operation
+			// The tools were successfully added, but notification failed
+			if s.hooks != nil && len(s.hooks.OnError) > 0 {
+				hooks := s.hooks
+				go func(sID string, hooks *Hooks) {
+					ctx := context.Background()
+					hooks.onError(ctx, nil, "notification", map[string]any{
+						"method":    "notifications/tools/list_changed",
+						"sessionID": sID,
+					}, fmt.Errorf("failed to send notification after adding tools: %w", err))
+				}(sessionID, hooks)
+			}
 		}
 	}
 
@@ -296,19 +301,24 @@ func (s *MCPServer) DeleteSessionTools(sessionID string, names ...string) error 
 	// Set the tools (this should be thread-safe)
 	session.SetSessionTools(newSessionTools)
 
-	// Send notification only to this session
-	if err := s.SendNotificationToSpecificClient(sessionID, "notifications/tools/list_changed", nil); err != nil {
-		// Log the error but don't fail the operation
-		// The tools were successfully deleted, but notification failed
-		if s.hooks != nil && len(s.hooks.OnError) > 0 {
-			hooks := s.hooks
-			go func(sID string, hooks *Hooks) {
-				ctx := context.Background()
-				hooks.onError(ctx, nil, "notification", map[string]any{
-					"method":    "notifications/tools/list_changed",
-					"sessionID": sID,
-				}, fmt.Errorf("failed to send notification after deleting tools: %w", err))
-			}(sessionID, hooks)
+	// It only makes sense to send tool notifications to initialized sessions --
+	// if we're not initialized yet the client can't possibly have sent their
+	// initial tools/list message
+	if session.Initialized() {
+		// Send notification only to this session
+		if err := s.SendNotificationToSpecificClient(sessionID, "notifications/tools/list_changed", nil); err != nil {
+			// Log the error but don't fail the operation
+			// The tools were successfully deleted, but notification failed
+			if s.hooks != nil && len(s.hooks.OnError) > 0 {
+				hooks := s.hooks
+				go func(sID string, hooks *Hooks) {
+					ctx := context.Background()
+					hooks.onError(ctx, nil, "notification", map[string]any{
+						"method":    "notifications/tools/list_changed",
+						"sessionID": sID,
+					}, fmt.Errorf("failed to send notification after deleting tools: %w", err))
+				}(sessionID, hooks)
+			}
 		}
 	}
 


### PR DESCRIPTION

## Description
<!-- Provide a concise description of the changes in this PR -->
AddSessionTools and DeleteSessionTools can be called before the session is registered, in particular in the RegisterSession hook.

They should not attempt to send `notifications/tools/list_changed` notifications in this case as it will only generate errors.


## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Notifications about tool list changes are now only sent after a session has been initialized, preventing premature notifications.  
- **Tests**
  - Added tests to ensure tool addition and deletion during uninitialized sessions do not trigger notifications or errors, and that notifications are properly sent after initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->