### PR TITLE
    fix: Gate notifications on capabilities

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -247,8 +247,12 @@ func (s *MCPServer) AddSessionTools(sessionID string, tools ...ServerTool) error
 
 	// It only makes sense to send tool notifications to initialized sessions --
 	// if we're not initialized yet the client can't possibly have sent their
-	// initial tools/list message
-	if session.Initialized() {
+	// initial tools/list message.
+	//
+	// For initialized sessions, honor tools.listChanged, which is specifically
+	// about whether notifications will be sent or not.
+	// see <https://modelcontextprotocol.io/specification/2025-03-26/server/tools#capabilities>
+	if session.Initialized() && s.capabilities.tools != nil && s.capabilities.tools.listChanged {
 		// Send notification only to this session
 		if err := s.SendNotificationToSpecificClient(sessionID, "notifications/tools/list_changed", nil); err != nil {
 			// Log the error but don't fail the operation
@@ -305,8 +309,12 @@ func (s *MCPServer) DeleteSessionTools(sessionID string, names ...string) error 
 
 	// It only makes sense to send tool notifications to initialized sessions --
 	// if we're not initialized yet the client can't possibly have sent their
-	// initial tools/list message
-	if session.Initialized() {
+	// initial tools/list message.
+	//
+	// For initialized sessions, honor tools.listChanged, which is specifically
+	// about whether notifications will be sent or not.
+	// see <https://modelcontextprotocol.io/specification/2025-03-26/server/tools#capabilities>
+	if session.Initialized() && s.capabilities.tools != nil && s.capabilities.tools.listChanged {
 		// Send notification only to this session
 		if err := s.SendNotificationToSpecificClient(sessionID, "notifications/tools/list_changed", nil); err != nil {
 			// Log the error but don't fail the operation


### PR DESCRIPTION
## Description

Servers may report their [tools.listChanged][] capability as false, in which case they indicate that they will not send notifications when available tools change.

Honor the spec by not sending notifications/tools/list_changed notifications when capabilities.tools.listChanged is false.

[tools.listChanged]: https://modelcontextprotocol.io/specification/2025-03-26/server/tools#capabilities


This PR is downstream of #289.
<!-- Provide a concise description of the changes in this PR -->


## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [MCP spec: server/tools#capabilities](https://modelcontextprotocol.io/specification/2025-03-26/server/tools#capabilities)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved notification logic so that "tools list changed" notifications are only sent when the server supports this feature and notifications are enabled.

- **Tests**
	- Added a test to ensure that when tool capabilities are disabled, tools can still be managed without triggering notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->