### PR TITLE
feat(tools): implicitly register capabilities

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -224,6 +224,8 @@ func (s *MCPServer) AddSessionTools(sessionID string, tools ...ServerTool) error
 		return ErrSessionDoesNotSupportTools
 	}
 
+	s.implicitlyRegisterToolCapabilities()
+
 	// Get existing tools (this should return a thread-safe copy)
 	sessionTools := session.GetSessionTools()
 


### PR DESCRIPTION

## Description
<!-- Provide a concise description of the changes in this PR -->
When users add tools via AddTool or AddSessionTool, implicitly set the tools capability.  If the user has not already called WithToolCapabilities, then default listChanged to true, but honor any existing value.

This mimics the behavior of the official typescript sdk, which registers `tools.listChanged: true` when the user adds a tool to the MCP server.

See the [discussion](https://github.com/mark3labs/mcp-go/pull/290#issuecomment-2881507484) in #290 for more context.

Fixes #<issue_number> (if applicable)

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when adding tools or session tools by ensuring tool capabilities are always properly initialized.
- **Tests**
	- Added new tests to verify correct initialization and behavior of tool capabilities under different server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->