### PR TITLE
feat(protocol): allow additional fields in meta

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -46,15 +46,7 @@ type CallToolRequest struct {
 	Params struct {
 		Name      string         `json:"name"`
 		Arguments map[string]any `json:"arguments,omitempty"`
-		Meta      *struct {
-			// If specified, the caller is requesting out-of-band progress
-			// notifications for this request (as represented by
-			// notifications/progress). The value of this parameter is an
-			// opaque token that will be attached to any subsequent
-			// notifications. The receiver is not obligated to provide these
-			// notifications.
-			ProgressToken ProgressToken `json:"progressToken,omitempty"`
-		} `json:"_meta,omitempty"`
+		Meta      *Meta          `json:"_meta,omitempty"`
 	} `json:"params"`
 }
 

--- a/mcp/types_test.go
+++ b/mcp/types_test.go
@@ -1,0 +1,70 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMetaMarshalling(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		meta    *Meta
+		expMeta *Meta
+	}{
+		{
+			name:    "empty",
+			json:    "{}",
+			meta:    &Meta{},
+			expMeta: &Meta{AdditionalFields: map[string]any{}},
+		},
+		{
+			name:    "empty additional fields",
+			json:    "{}",
+			meta:    &Meta{AdditionalFields: map[string]any{}},
+			expMeta: &Meta{AdditionalFields: map[string]any{}},
+		},
+		{
+			name:    "string token only",
+			json:    `{"progressToken":"123"}`,
+			meta:    &Meta{ProgressToken: "123"},
+			expMeta: &Meta{ProgressToken: "123", AdditionalFields: map[string]any{}},
+		},
+		{
+			name:    "string token only, empty additional fields",
+			json:    `{"progressToken":"123"}`,
+			meta:    &Meta{ProgressToken: "123", AdditionalFields: map[string]any{}},
+			expMeta: &Meta{ProgressToken: "123", AdditionalFields: map[string]any{}},
+		},
+		{
+			name: "additional fields only",
+			json: `{"a":2,"b":"1"}`,
+			meta: &Meta{AdditionalFields: map[string]any{"a": 2, "b": "1"}},
+			// For untyped map, numbers are always float64
+			expMeta: &Meta{AdditionalFields: map[string]any{"a": float64(2), "b": "1"}},
+		},
+		{
+			name: "progress token and additional fields",
+			json: `{"a":2,"b":"1","progressToken":"123"}`,
+			meta: &Meta{ProgressToken: "123", AdditionalFields: map[string]any{"a": 2, "b": "1"}},
+			// For untyped map, numbers are always float64
+			expMeta: &Meta{ProgressToken: "123", AdditionalFields: map[string]any{"a": float64(2), "b": "1"}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := json.Marshal(tc.meta)
+			require.NoError(t, err)
+			assert.Equal(t, tc.json, string(data))
+
+			meta := &Meta{}
+			err = json.Unmarshal([]byte(tc.json), meta)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expMeta, meta)
+		})
+	}
+}


### PR DESCRIPTION
## Description

Replaces anonymous struct type with real type for `Meta` on request params with custom JSON marshalling logic to allow fields in addition to progress token to be marshalled. 

Technically, it seems all types in a JSON-RPC protocol like MCP should be open to other fields and MCP's python/JS SDKs do allow this in most types. In practice, `_meta` is being used in several instrumentation frameworks for propagating trace context

https://github.com/modelcontextprotocol/modelcontextprotocol/issues/246

Defining a type with custom marshalling allows doing similar with mcp-go. As the structure of the existing anonymous struct is preserved, I believe this is a backwards compatible change.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [X] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

Actually I couldn't find text in the specification itself but convention in the SDKs along with guidance in the attached issue. I think it is in principal spec compliance.

https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/types.py#L25
https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/types.py#L51
https://github.com/modelcontextprotocol/typescript-sdk/blob/main/src/types.ts#L30 (`.passthrough()`)

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
