### PR TITLE
feat(MCPServer): send log message notifications to specific client

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -67,6 +67,10 @@ const (
 	// MethodNotificationToolsListChanged notifies when the list of available tools changes.
 	// https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/list_changed/
 	MethodNotificationToolsListChanged = "notifications/tools/list_changed"
+
+	// MethodNotificationMessage notifies when severs send log messages.
+	// https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#log-message-notifications
+	MethodNotificationMessage MCPMethod = "notifications/message"
 )
 
 type URITemplate struct {
@@ -733,6 +737,30 @@ const (
 	LoggingLevelAlert     LoggingLevel = "alert"
 	LoggingLevelEmergency LoggingLevel = "emergency"
 )
+
+var (
+	// Map logging level constants to numerical codes as specified in RFC-5424
+	levelToSeverity = func() map[LoggingLevel]int {
+		return map[LoggingLevel]int {
+			LoggingLevelEmergency:	0,
+			LoggingLevelAlert:		1,
+			LoggingLevelCritical:	2,
+			LoggingLevelError:		3,
+			LoggingLevelWarning:	4,
+			LoggingLevelNotice:		5,
+			LoggingLevelInfo:		6,
+			LoggingLevelDebug:		7,
+		}
+	}()
+)
+
+// Allows is a helper function that decides a message could be sent to client or not according to the logging level
+func (subscribedLevel LoggingLevel) Allows(currentLevel LoggingLevel) (bool, error) {
+    if _, ok := levelToSeverity[currentLevel]; !ok {
+		return false, fmt.Errorf("illegal message logging level:%s", currentLevel)
+	}
+	return levelToSeverity[subscribedLevel] >= levelToSeverity[currentLevel], nil
+}
 
 /* Sampling */
 

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -171,7 +171,7 @@ func NewLoggingMessageNotification(
 ) LoggingMessageNotification {
 	return LoggingMessageNotification{
 		Notification: Notification{
-			Method: "notifications/message",
+			Method: string(MethodNotificationMessage),
 		},
 		Params: struct {
 			Level  LoggingLevel `json:"level"`


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->
&emsp;This PR enables MCPServer to send log message notifications to specific client according to the [specification](https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#log-message-notifications)



## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/logging#log-message-notifications)
- [x] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
