### PR TITLE
fix: handle the situation where the channel is closed

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -310,8 +310,11 @@ func (c *SSE) SendRequest(
 	case <-ctx.Done():
 		deleteResponseChan()
 		return nil, ctx.Err()
-	case response := <-responseChan:
-		return response, nil
+	case response, ok := <-responseChan:
+		if ok {
+			return response, nil
+		}
+		return nil, fmt.Errorf("connection has been closed")
 	}
 }
 


### PR DESCRIPTION
## Description
This PR fix handle the situation where the channel is closed.

When using mcp-go as the mcp client, sometimes it is necessary to use ping to keep the server alive. A goroutine will be started to send pings at intervals. When an error is detected in the ping return, the client will be shut down. At this point, if other goroutines are using this client, a crash will occur. The reason is that the response is nil, which will be in the code:

```go
// mcp-go code
if response.Error ! = nil {   // panic occurred, because response is nil
    return nil, errors.New(response.Error.Message)
}
```


```go
// my code
go func() {
......
for {
	select {
	case <-ticker.C:
		err := c.Ping(ctx)
		if err != nil {
			cli.c.Close()
			return
		}
	}
}
}()
```

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
