### PR TITLE
chore(Srv/stdio): duplicated setting of ErrorLogger

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -78,10 +78,7 @@ func (s *sseSession) GetSessionTools() map[string]ServerTool {
 
 func (s *sseSession) SetSessionTools(tools map[string]ServerTool) {
 	// Clear existing tools
-	s.tools.Range(func(key, _ any) bool {
-		s.tools.Delete(key)
-		return true
-	})
+	s.tools.Clear()
 
 	// Set new tools
 	for name, tool := range tools {

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -289,7 +289,6 @@ func (s *StdioServer) writeResponse(
 // Returns an error if the server encounters any issues during operation.
 func ServeStdio(server *MCPServer, opts ...StdioOption) error {
 	s := NewStdioServer(server)
-	s.SetErrorLogger(log.New(os.Stderr, "", log.LstdFlags))
 
 	for _, opt := range opts {
 		opt(s)


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->
1. remove duplicated setting of `StdioServer.errLogger` in func `ServeStdio()` since we have set a same `errorLogger` in func `NewStdioServer()`:
```Go
func NewStdioServer(server *MCPServer) *StdioServer {
	return &StdioServer{
		server: server,
		errLogger: log.New(
			os.Stderr,
			"",
			log.LstdFlags,
		), // Default to discarding logs
	}
}
```
2. use `sync.Map.Clear()` ([link text](https://pkg.go.dev/sync@go1.24.3#Map.Clear) )to directly clear `sseSession.tools` that was introduced in go1.23.0. [SAFE to use since the version for mcp-go is set to 1.23 now in file `go.mod`]

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling for session tool management to simplify logic.
  - Removed redundant error logger initialization for standard input/output server to streamline code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->