### PR TITLE
feat(server): persist client info in sessions

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -492,7 +492,7 @@ func (s *MCPServer) AddNotificationHandler(
 func (s *MCPServer) handleInitialize(
 	ctx context.Context,
 	_ any,
-	_ mcp.InitializeRequest,
+	request mcp.InitializeRequest,
 ) (*mcp.InitializeResult, *requestError) {
 	capabilities := mcp.ServerCapabilities{}
 

--- a/server/server.go
+++ b/server/server.go
@@ -537,6 +537,11 @@ func (s *MCPServer) handleInitialize(
 
 	if session := ClientSessionFromContext(ctx); session != nil {
 		session.Initialize()
+
+		// Store client info if the session supports it
+		if sessionWithClientInfo, ok := session.(SessionWithClientInfo); ok {
+			sessionWithClientInfo.SetClientInfo(request.Params.ClientInfo)
+		}
 	}
 	return &result, nil
 }

--- a/server/session.go
+++ b/server/session.go
@@ -39,7 +39,7 @@ type SessionWithTools interface {
 	SetSessionTools(tools map[string]ServerTool)
 }
 
-// SessionWithClientInfo is an extension of ClientSession that can store client implementation info
+// SessionWithClientInfo is an extension of ClientSession that can store client info
 type SessionWithClientInfo interface {
 	ClientSession
 	// GetClientInfo returns the client information for this session

--- a/server/session.go
+++ b/server/session.go
@@ -30,6 +30,15 @@ type SessionWithTools interface {
 	SetSessionTools(tools map[string]ServerTool)
 }
 
+// SessionWithClientInfo is an extension of ClientSession that can store client implementation info
+type SessionWithClientInfo interface {
+	ClientSession
+	// GetClientInfo returns the client information for this session
+	GetClientInfo() mcp.Implementation
+	// SetClientInfo sets the client information for this session
+	SetClientInfo(clientInfo mcp.Implementation)
+}
+
 // clientSessionKey is the context key for storing current client notification channel.
 type clientSessionKey struct{}
 

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -8,9 +8,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // sessionTestClient implements the basic ClientSession interface for testing
@@ -98,9 +99,47 @@ func (f *sessionTestClientWithTools) SetSessionTools(tools map[string]ServerTool
 	f.sessionTools = toolsCopy
 }
 
-// Verify that both implementations satisfy their respective interfaces
+// sessionTestClientWithClientInfo implements the SessionWithClientInfo interface for testing
+type sessionTestClientWithClientInfo struct {
+	sessionID           string
+	notificationChannel chan mcp.JSONRPCNotification
+	initialized         bool
+	clientInfoMu        sync.RWMutex
+	clientInfo          mcp.Implementation
+}
+
+func (f *sessionTestClientWithClientInfo) SessionID() string {
+	return f.sessionID
+}
+
+func (f *sessionTestClientWithClientInfo) NotificationChannel() chan<- mcp.JSONRPCNotification {
+	return f.notificationChannel
+}
+
+func (f *sessionTestClientWithClientInfo) Initialize() {
+	f.initialized = true
+}
+
+func (f *sessionTestClientWithClientInfo) Initialized() bool {
+	return f.initialized
+}
+
+func (f *sessionTestClientWithClientInfo) GetClientInfo() mcp.Implementation {
+	f.clientInfoMu.RLock()
+	defer f.clientInfoMu.RUnlock()
+	return f.clientInfo
+}
+
+func (f *sessionTestClientWithClientInfo) SetClientInfo(clientInfo mcp.Implementation) {
+	f.clientInfoMu.Lock()
+	defer f.clientInfoMu.Unlock()
+	f.clientInfo = clientInfo
+}
+
+// Verify that all implementations satisfy their respective interfaces
 var _ ClientSession = &sessionTestClient{}
 var _ SessionWithTools = &sessionTestClientWithTools{}
+var _ SessionWithClientInfo = &sessionTestClientWithClientInfo{}
 
 func TestSessionWithTools_Integration(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithToolCapabilities(true))
@@ -916,4 +955,49 @@ func TestMCPServer_ToolNotificationsDisabled(t *testing.T) {
 
 	// Verify tool was deleted from session
 	assert.Len(t, session.GetSessionTools(), 0)
+}
+
+func TestSessionWithClientInfo_Integration(t *testing.T) {
+	server := NewMCPServer("test-server", "1.0.0")
+
+	session := &sessionTestClientWithClientInfo{
+		sessionID:           "session-1",
+		notificationChannel: make(chan mcp.JSONRPCNotification, 10),
+		initialized:         false,
+	}
+
+	err := server.RegisterSession(context.Background(), session)
+	require.NoError(t, err)
+
+	clientInfo := mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0.0",
+	}
+
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ClientInfo = clientInfo
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.Capabilities = mcp.ClientCapabilities{}
+
+	sessionCtx := server.WithContext(context.Background(), session)
+
+	// Retrieve the session from context
+	retrievedSession := ClientSessionFromContext(sessionCtx)
+	require.NotNil(t, retrievedSession, "Session should be available from context")
+	assert.Equal(t, session.SessionID(), retrievedSession.SessionID(), "Session ID should match")
+
+	// Check if the session can be cast to SessionWithClientInfo
+	sessionWithClientInfo, ok := retrievedSession.(SessionWithClientInfo)
+	require.True(t, ok, "Session should implement SessionWithClientInfo")
+
+	result, reqErr := server.handleInitialize(sessionCtx, 1, initRequest)
+	require.Nil(t, reqErr)
+	require.NotNil(t, result)
+
+	assert.True(t, sessionWithClientInfo.Initialized(), "Session should be initialized")
+
+	storedClientInfo := sessionWithClientInfo.GetClientInfo()
+
+	assert.Equal(t, clientInfo.Name, storedClientInfo.Name, "Client name should match")
+	assert.Equal(t, clientInfo.Version, storedClientInfo.Version, "Client version should match")
 }

--- a/server/sse.go
+++ b/server/sse.go
@@ -28,9 +28,8 @@ type sseSession struct {
 	notificationChannel chan mcp.JSONRPCNotification
 	initialized         atomic.Bool
 	loggingLevel        atomic.Value
-	tools               sync.Map // stores session-specific tools
-	mu                  sync.RWMutex
-	clientInfo          mcp.Implementation
+	tools               sync.Map     // stores session-specific tools
+	clientInfo          atomic.Value // stores session-specific client info
 }
 
 // SSEContextFunc is a function that takes an existing context and the current
@@ -90,21 +89,22 @@ func (s *sseSession) SetSessionTools(tools map[string]ServerTool) {
 }
 
 func (s *sseSession) GetClientInfo() mcp.Implementation {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	return s.clientInfo
+	if value := s.clientInfo.Load(); value != nil {
+		if clientInfo, ok := value.(mcp.Implementation); ok {
+			return clientInfo
+		}
+	}
+	return mcp.Implementation{}
 }
 
 func (s *sseSession) SetClientInfo(clientInfo mcp.Implementation) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.clientInfo = clientInfo
+	s.clientInfo.Store(clientInfo)
 }
 
 var (
-	_ ClientSession      = (*sseSession)(nil)
-	_ SessionWithTools   = (*sseSession)(nil)
-	_ SessionWithLogging = (*sseSession)(nil)
+	_ ClientSession         = (*sseSession)(nil)
+	_ SessionWithTools      = (*sseSession)(nil)
+	_ SessionWithLogging    = (*sseSession)(nil)
 	_ SessionWithClientInfo = (*sseSession)(nil)
 )
 

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -108,7 +108,6 @@ var (
 
 var stdioSessionInstance = stdioSession{
 	notifications: make(chan mcp.JSONRPCNotification, 100),
-	clientInfo:    atomic.Value{},
 }
 
 // NewStdioServer creates a new stdio server wrapper around an MCPServer.


### PR DESCRIPTION
## Description
This PR adds the ability to persist client information in MCP sessions. 

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional Information
This PR introduces a new interface SessionWithClientInfo that extends the ClientSession interface to provide the ability to store and retrieve client information. 

## Usage example
```
retrievedSession := mcpServer.ClientSessionFromContext(ctx)
sessionWithClientInfo, _ := retrievedSession.(mcpServer.SessionWithClientInfo)
clientName := sessionWithClientInfo.GetClientInfo().Name
```
