### PR TITLE
docs(examples): correct use of `GetArguments`

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ func main() {
 }
 
 func helloHandler(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-    name, ok := request.Params.Arguments["name"].(string)
+    name, ok := request.GetArguments()["name"].(string)
     if !ok {
         return nil, errors.New("name must be a string")
     }


### PR DESCRIPTION
As part of 28c9cc310fed16014107a4e4c970b1d440066b4a we made
`Params.Arguments` return an `any`.

We'd updated almost all the documentation, aside from this case.

This doesn't impact the Prompt examples, as they're still using the old
method.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the internal method for accessing request arguments to enhance code clarity and maintainability. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->