### PR TITLE
fix(server): Implement MCP version negotiation.

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -98,6 +98,12 @@ type JSONRPCMessage any
 // LATEST_PROTOCOL_VERSION is the most recent version of the MCP protocol.
 const LATEST_PROTOCOL_VERSION = "2025-03-26"
 
+// ValidProtocolVersions lists all known valid MCP protocol versions.
+var ValidProtocolVersions = []string{
+	"2024-11-05",
+	LATEST_PROTOCOL_VERSION,
+}
+
 // JSONRPC_VERSION is the version of JSON-RPC used by MCP.
 const JSONRPC_VERSION = "2.0"
 

--- a/server/server.go
+++ b/server/server.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"sort"
 	"sync"
 
@@ -550,7 +551,7 @@ func (s *MCPServer) handleInitialize(
 	}
 
 	result := mcp.InitializeResult{
-		ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+		ProtocolVersion: s.protocolVersion(request.Params.ProtocolVersion),
 		ServerInfo: mcp.Implementation{
 			Name:    s.name,
 			Version: s.version,
@@ -568,6 +569,14 @@ func (s *MCPServer) handleInitialize(
 		}
 	}
 	return &result, nil
+}
+
+func (s *MCPServer) protocolVersion(clientVersion string) string {
+	if slices.Contains(mcp.ValidProtocolVersions, clientVersion) {
+		return clientVersion
+	}
+
+	return mcp.LATEST_PROTOCOL_VERSION
 }
 
 func (s *MCPServer) handlePing(


### PR DESCRIPTION
## Description

Fix protocol version negotiation to comply with MCP specification

### Problem

The current server implementation violates the [MCP protocol specification for version negotiation](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#version-negotiation). It always responds with `LATEST_PROTOCOL_VERSION` regardless of client capabilities, causing some clients (e.g. Claude Desktop) to disconnect.

### Root Cause

According to the MCP spec:
> "If the server supports the requested protocol version, it MUST respond with the same version. Otherwise, the server MUST respond with another protocol version it supports."

Our server was not implementing this negotiation correctly, leading to Claude Desktop to terminate the MCP server immediately.

### Solution

Implement protocol version negotiation per MCP specification:

- If server supports client's requested version → respond with same version  
- If server doesn't support client's version → respond with server's preferred version

This fixes compatibility issues with clients like Claude Desktop that expect proper version negotiation.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [X] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [X] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Version Negotiation](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle#version-negotiation)
- [X] Implementation follows the specification exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved protocol version negotiation during initialization, allowing the server to recognize and respond to supported client protocol versions.
- **Tests**
	- Added tests to verify correct server behavior when handling various client protocol version requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->