### PR TITLE
Add option to StreamableHTTPServer to allow custom http server instance

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -227,7 +227,9 @@ func WithSSEEndpoint(endpoint string) SSEOption {
 	}
 }
 
-// WithHTTPServer sets the HTTP server instance
+// WithHTTPServer sets the HTTP server instance.
+// NOTE: When providing a custom HTTP server, you must handle routing yourself
+// If routing is not set up, the server will start but won't handle any MCP requests.
 func WithHTTPServer(srv *http.Server) SSEOption {
 	return func(s *SSEServer) {
 		s.srv = srv

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -73,7 +73,9 @@ func WithHTTPContextFunc(fn HTTPContextFunc) StreamableHTTPOption {
 	}
 }
 
-// WithStreamableHTTPServer sets the HTTP server instance for StreamableHTTPServer
+// WithStreamableHTTPServer sets the HTTP server instance for StreamableHTTPServer.
+// NOTE: When providing a custom HTTP server, you must handle routing yourself
+// If routing is not set up, the server will start but won't handle any MCP requests.
 func WithStreamableHTTPServer(srv *http.Server) StreamableHTTPOption {
 	return func(s *StreamableHTTPServer) {
 		s.httpServer = srv


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved server configuration flexibility by allowing the use of a custom HTTP server instance, including detection of address conflicts.
- **Tests**
  - Added tests to verify custom server injection, address conflict handling, and option consistency.
- **Documentation**
  - Added guidance on routing requirements when using a custom HTTP server to ensure proper request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->