### PR TITLE
fix: ignore session IDs in stateless mode instead of rejecting them

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -608,9 +608,7 @@ func (s *StatelessSessionIdManager) Generate() string {
 	return ""
 }
 func (s *StatelessSessionIdManager) Validate(sessionID string) (isTerminated bool, err error) {
-	if sessionID != "" {
-		return false, fmt.Errorf("session id is not allowed to be set when stateless")
-	}
+	// In stateless mode, ignore session IDs completely - don't validate or reject them
 	return false, nil
 }
 func (s *StatelessSessionIdManager) Terminate(sessionID string) (isNotAllowed bool, err error) {


### PR DESCRIPTION
## Summary
- Fixed StatelessSessionIdManager to ignore session IDs completely instead of rejecting them with an error
- Updated tests to verify that requests with session IDs succeed in stateless mode
- Added specific test for the tools/list scenario mentioned in the issue

## Test plan
- [x] Updated existing test "Invalid session id" to verify session IDs are ignored in stateless mode
- [x] Added new test "tools/list with session id in stateless mode" to test the specific scenario from the issue
- [x] All existing tests continue to pass
- [x] Verified that both requests with and without session IDs work in stateless mode

🤖 Generated with opencode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session IDs are now ignored in stateless mode, allowing requests with session ID headers to succeed as expected.

- **Tests**
  - Updated and added tests to confirm that session ID headers do not affect request handling in stateless mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->