### PR TITLE
fix: SSE parser now correctly handles events without event field

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -194,7 +194,11 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 		if err != nil {
 			if err == io.EOF {
 				// Process any pending event before exit
-				if event != "" && data != "" {
+				if data != "" {
+					// If no event type is specified, use empty string (default event type)
+					if event == "" {
+						event = "message"
+					}
 					c.handleSSEEvent(event, data)
 				}
 				break
@@ -209,7 +213,11 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 		line = strings.TrimRight(line, "\r\n")
 		if line == "" {
 			// Empty line means end of event
-			if event != "" && data != "" {
+			if data != "" {
+				// If no event type is specified, use empty string (default event type)
+				if event == "" {
+					event = "message"
+				}
 				c.handleSSEEvent(event, data)
 				event = ""
 				data = ""

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -380,7 +380,11 @@ func (c *StreamableHTTP) readSSE(ctx context.Context, reader io.ReadCloser, hand
 			if err != nil {
 				if err == io.EOF {
 					// Process any pending event before exit
-					if event != "" && data != "" {
+					if data != "" {
+						// If no event type is specified, use empty string (default event type)
+						if event == "" {
+							event = "message"
+						}
 						handler(event, data)
 					}
 					return
@@ -398,7 +402,11 @@ func (c *StreamableHTTP) readSSE(ctx context.Context, reader io.ReadCloser, hand
 			line = strings.TrimRight(line, "\r\n")
 			if line == "" {
 				// Empty line means end of event
-				if event != "" && data != "" {
+				if data != "" {
+					// If no event type is specified, use empty string (default event type)
+					if event == "" {
+						event = "message"
+					}
 					handler(event, data)
 					event = ""
 					data = ""


### PR DESCRIPTION
## Summary
- Fixed SSE parser to correctly handle events with only `data:` field (no `event:` field)
- According to W3C SSE specification, the `event:` field is optional and should default to "message"
- Added comprehensive test to verify the fix works correctly

## Test plan
- [x] Added new test `SSEEventWithoutEventField` that specifically tests SSE events without event field
- [x] All existing SSE tests continue to pass
- [x] Full test suite passes

🤖 Generated with opencode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of Server-Sent Events (SSE) to correctly process events without an explicit event type as "message" events.

- **Tests**
  - Added tests to verify that SSE events containing only data (without an event field) are handled properly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->