### PR TITLE
fix(server): Fix the logic of the WithStateLess function

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -40,7 +40,9 @@ func WithEndpointPath(endpointPath string) StreamableHTTPOption {
 // to StatelessSessionIdManager.
 func WithStateLess(stateLess bool) StreamableHTTPOption {
 	return func(s *StreamableHTTPServer) {
-		s.sessionIdManager = &StatelessSessionIdManager{}
+		if stateLess {
+			s.sessionIdManager = &StatelessSessionIdManager{}
+		}
 	}
 }
 


### PR DESCRIPTION
## Description

Added a check logic for the stateLess parameter in the WithStateLess function: Only when stateLess is true, set the sessionIdManager to StatelessSessionIdManager. This modification ensures that the function behaves as expected and improves the robustness of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved internal handling of session management to better respect stateless configuration settings. No changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->