### PR TITLE
fix(client/transport/stream): check for nil pointer

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -103,7 +103,9 @@ func NewStreamableHTTP(serverURL string, options ...StreamableHTTPCOption) (*Str
 	smc.sessionID.Store("") // set initial value to simplify later usage
 
 	for _, opt := range options {
-		opt(smc)
+		if opt != nil {
+			opt(smc)
+		}
 	}
 
 	// If OAuth is configured, set the base URL for metadata discovery


### PR DESCRIPTION
## Description
I noticed when you create a StreamableHTTP and pass empty options, there is the possibility for the application to crash due to a nil pointer on the empty option.

Fixes #<issue_number> (if applicable)

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
If you would like to replicate the issue, you can try this: 

```golang
var httpOptions mcpTransport.StreamableHTTPCOption

// Create MCP streamable HTTP transport
transport, err := mcpTransport.NewStreamableHTTP(<MCP_SERVER_URL>, httpOptions)
```

