### PR TITLE
feat(client): add session persistence and restoration support

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,79 @@
+package client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestStateRestoration(t *testing.T) {
+	mcpServer := server.NewMCPServer(
+		"test-server",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	// First client lifecycle
+	client1, err := NewInProcessClient(mcpServer)
+	if err != nil {
+		t.Fatalf("Failed to create first client: %v", err)
+	}
+
+	ctx := context.Background()
+
+	if err := client1.Start(ctx); err != nil {
+		t.Fatalf("Failed to start first client: %v", err)
+	}
+
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0.0",
+	}
+
+	if _, err := client1.Initialize(ctx, initRequest); err != nil {
+		t.Fatalf("Failed to initialize first client: %v", err)
+	}
+
+	if err := client1.Ping(ctx); err != nil {
+		t.Fatalf("Ping on first client failed: %v", err)
+	}
+
+	exportedState := client1.ExportState()
+
+	if err := client1.Close(); err != nil {
+		t.Fatalf("Failed to close first client: %v", err)
+	}
+
+	// Second client lifecycle (state restoration)
+	client2, err := NewInProcessClient(mcpServer)
+	if err != nil {
+		t.Fatalf("Failed to create second client: %v", err)
+	}
+	defer client2.Close()
+
+	if err := client2.Start(ctx); err != nil {
+		t.Fatalf("Failed to start second client: %v", err)
+	}
+
+	if err := client2.ImportState(ctx, exportedState); err != nil {
+		t.Fatalf("Failed to import state into second client: %v", err)
+	}
+
+	if err := client2.Ping(ctx); err != nil {
+		t.Fatalf("Ping on restored client failed: %v", err)
+	}
+
+	restoredState := client2.ExportState()
+
+	if !restoredState.Initialized {
+		t.Errorf("Expected restored client to be initialized")
+	}
+
+	if restoredState.RequestID <= exportedState.RequestID {
+		t.Errorf("Expected request ID to increase after restoration; before=%d, after=%d", exportedState.RequestID, restoredState.RequestID)
+	}
+}

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -513,3 +513,8 @@ func (c *StreamableHTTP) GetOAuthHandler() *OAuthHandler {
 func (c *StreamableHTTP) IsOAuthEnabled() bool {
 	return c.oauthHandler != nil
 }
+
+// SetSessionId sets the session ID for the transport
+func (c *StreamableHTTP) SetSessionId(sessionID string) {
+	c.sessionID.Store(sessionID)
+}

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1042,3 +1042,21 @@ type ServerResult any
 type Named interface {
 	GetName() string
 }
+
+// ClientState represents the resumable state of an MCP client
+type ClientState struct {
+	// Initialized indicates whether the client has been initialized
+	Initialized bool `json:"initialized"`
+
+	// RequestID is the last used request ID
+	RequestID int64 `json:"requestId"`
+
+	// ClientCapabilities represents the client's capabilities
+	ClientCapabilities ClientCapabilities `json:"clientCapabilities"`
+
+	// ServerCapabilities represents the server's capabilities
+	ServerCapabilities ServerCapabilities `json:"serverCapabilities"`
+
+	// SessionID is the session ID from the transport (if any)
+	SessionID string `json:"sessionId,omitempty"`
+}

--- a/www/docs/pages/clients/basics.mdx
+++ b/www/docs/pages/clients/basics.mdx
@@ -297,6 +297,41 @@ func (mc *ManagedClient) Close() error {
 }
 ```
 
+### Persisting & Restoring Client State
+
+MCP-Go lets you snapshot a running client and resume it later — even in a new
+process — with `ExportState()` and `ImportState()`.
+
+```go
+// Save state before shutting down
+state := client.ExportState()
+if err := client.Close(); err != nil {
+    log.Printf("close failed: %v", err)
+}
+
+// Later, or in another process
+restoredClient, _ := client.NewStreamableHttpClient(baseURL)
+_ = restoredClient.Start(ctx)          // transport must be running
+if err := restoredClient.ImportState(ctx, state); err != nil {
+    log.Fatal(err)
+}
+
+// Continue exactly where you left off
+if err := restoredClient.Ping(ctx); err != nil {
+    log.Fatal(err)
+}
+```
+
+`ExportState()` captures:
+
+* initialization status  
+* last JSON-RPC request ID (so IDs continue monotonically)  
+* negotiated client / server capabilities  
+* HTTP session ID (for StreamableHTTP transports)
+
+`ImportState()` re-hydrates those values.  After a successful call the
+restored client can immediately issue normal requests without re-initializing.
+
 ## Error Handling
 
 Proper error handling is essential for robust client applications.


### PR DESCRIPTION
## Description
This feature adds client session persistence and restoration support, which is useful for environments where entire client instances cannot be persisted, such as within Temporal activities.

Key points:
* `ExportState()` and `ImportState()` methods on `client.Client`
* New `mcp.ClientState` type
* `SetSessionId()` helper on Streamable HTTP transport
* Unit test `TestStateRestoration`
* Documentation section “Persisting & Restoring Client State” added to **Client Basics**

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information
This was created to address the requirement of restoring the session ID for Playwright MCP, which necessitates the same session ID for uninterrupted access to the same browser instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to export and import client state, enabling seamless resumption of client sessions, including initialization status, request ID, capabilities, and session ID.
- **Documentation**
  - Introduced a new section explaining how to persist and restore client state, with example usage for end-users.
- **Tests**
  - Added tests to verify correct export and import of client state across client lifecycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->