### PR TITLE
feat: autocompletion for prompt args and resource template URI args

### DIFF
--- a/mcp/prompts.go
+++ b/mcp/prompts.go
@@ -68,6 +68,8 @@ type PromptArgument struct {
 	// Whether this argument must be provided.
 	// If true, clients must include this argument when calling prompts/get.
 	Required bool `json:"required,omitempty"`
+	// Optional CompletionHandlerFunc for autocompleting the argument value.
+	CompletionHandler *CompletionHandlerFunc `json:"completionHandler,omitempty"`
 }
 
 // Role represents the sender or recipient of messages and data in a
@@ -166,5 +168,12 @@ func ArgumentDescription(desc string) ArgumentOption {
 func RequiredArgument() ArgumentOption {
 	return func(arg *PromptArgument) {
 		arg.Required = true
+	}
+}
+
+// ArgumentCompletion configures an autocomplete handler for the argument.
+func ArgumentCompletion(handler CompletionHandlerFunc) ArgumentOption {
+	return func(arg *PromptArgument) {
+		arg.CompletionHandler = &handler
 	}
 }

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -97,3 +97,14 @@ func WithTemplateAnnotations(audience []Role, priority float64) ResourceTemplate
 		t.Annotations.Priority = priority
 	}
 }
+
+// WithTemplateArgumentCompletion adds an autocomplete handler for the specified argument of ResourceTemplate.
+// The argument should be one of the variables referenced by the URI template.
+func WithTemplateArgumentCompletion(argument string, handler CompletionHandlerFunc) ResourceTemplateOption {
+	return func(t *ResourceTemplate) {
+		if t.URITemplate.ArgumentCompletionHandlers == nil {
+			t.URITemplate.ArgumentCompletionHandlers = make(map[string]CompletionHandlerFunc)
+		}
+		t.URITemplate.ArgumentCompletionHandlers[argument] = handler
+	}
+}

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -514,6 +514,35 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 	return nil, fmt.Errorf("unsupported content type: %s", contentType)
 }
 
+func ParseCompletionReference(req CompleteRequest) (*PromptReference, *ResourceReference, error) {
+	ref, ok := req.Params.Ref.(map[string]interface{})
+	if !ok {
+		return nil, nil, fmt.Errorf("params.ref must be a mapping")
+	}
+
+	refType, ok := ref["type"].(string)
+	if !ok {
+		return nil, nil, fmt.Errorf("params.ref.type must be a string")
+	}
+
+	switch RefType(refType) {
+	case RefTypeResource:
+		if uri, ok := ref["uri"].(string); !ok {
+			return nil, nil, fmt.Errorf("params.ref.uri must be a string")
+		} else {
+			return nil, &ResourceReference{Type: RefType(refType), URI: uri}, nil
+		}
+	case RefTypePrompt:
+		if name, ok := ref["name"].(string); !ok {
+			return nil, nil, fmt.Errorf("params.ref.name must be a string")
+		} else {
+			return &PromptReference{Type: RefType(refType), Name: name}, nil, nil
+		}
+	default:
+		return nil, nil, fmt.Errorf("unexpected value for params.ref.type: %s", refType)
+	}
+}
+
 func ParseGetPromptResult(rawMessage *json.RawMessage) (*GetPromptResult, error) {
 	if rawMessage == nil {
 		return nil, fmt.Errorf("response is nil")

--- a/server/hooks.go
+++ b/server/hooks.go
@@ -91,6 +91,9 @@ type OnAfterListToolsFunc func(ctx context.Context, id any, message *mcp.ListToo
 type OnBeforeCallToolFunc func(ctx context.Context, id any, message *mcp.CallToolRequest)
 type OnAfterCallToolFunc func(ctx context.Context, id any, message *mcp.CallToolRequest, result *mcp.CallToolResult)
 
+type OnBeforeCompleteFunc func(ctx context.Context, id any, message *mcp.CompleteRequest)
+type OnAfterCompleteFunc func(ctx context.Context, id any, message *mcp.CompleteRequest, result *mcp.CompleteResult)
+
 type Hooks struct {
 	OnRegisterSession             []OnRegisterSessionHookFunc
 	OnUnregisterSession           []OnUnregisterSessionHookFunc
@@ -118,6 +121,8 @@ type Hooks struct {
 	OnAfterListTools              []OnAfterListToolsFunc
 	OnBeforeCallTool              []OnBeforeCallToolFunc
 	OnAfterCallTool               []OnAfterCallToolFunc
+	OnBeforeComplete              []OnBeforeCompleteFunc
+	OnAfterComplete               []OnAfterCompleteFunc
 }
 
 func (c *Hooks) AddBeforeAny(hook BeforeAnyHookFunc) {
@@ -527,6 +532,33 @@ func (c *Hooks) afterCallTool(ctx context.Context, id any, message *mcp.CallTool
 		return
 	}
 	for _, hook := range c.OnAfterCallTool {
+		hook(ctx, id, message, result)
+	}
+}
+func (c *Hooks) AddBeforeComplete(hook OnBeforeCompleteFunc) {
+	c.OnBeforeComplete = append(c.OnBeforeComplete, hook)
+}
+
+func (c *Hooks) AddAfterComplete(hook OnAfterCompleteFunc) {
+	c.OnAfterComplete = append(c.OnAfterComplete, hook)
+}
+
+func (c *Hooks) beforeComplete(ctx context.Context, id any, message *mcp.CompleteRequest) {
+	c.beforeAny(ctx, id, mcp.MethodCompletion, message)
+	if c == nil {
+		return
+	}
+	for _, hook := range c.OnBeforeComplete {
+		hook(ctx, id, message)
+	}
+}
+
+func (c *Hooks) afterComplete(ctx context.Context, id any, message *mcp.CompleteRequest, result *mcp.CompleteResult) {
+	c.onSuccess(ctx, id, mcp.MethodCompletion, message, result)
+	if c == nil {
+		return
+	}
+	for _, hook := range c.OnAfterComplete {
 		hook(ctx, id, message, result)
 	}
 }

--- a/server/internal/gen/data.go
+++ b/server/internal/gen/data.go
@@ -107,5 +107,15 @@ var MCPRequestTypes = []MCPRequestType{
 		HookName:       "CallTool",
 		UnmarshalError: "invalid call tool request",
 		HandlerFunc:    "handleToolCall",
+	}, {
+		MethodName:     "MethodCompletion",
+		ParamType:      "CompleteRequest",
+		ResultType:     "CompleteResult",
+		Group:          "completions",
+		GroupName:      "Completions",
+		GroupHookName:  "Completion",
+		HookName:       "Complete",
+		UnmarshalError: "invalid completion request",
+		HandlerFunc:    "handleCompletion",
 	},
 }

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -310,6 +310,31 @@ func (s *MCPServer) HandleMessage(
 		}
 		s.hooks.afterCallTool(ctx, baseMessage.ID, &request, result)
 		return createResponse(baseMessage.ID, *result)
+	case mcp.MethodCompletion:
+		var request mcp.CompleteRequest
+		var result *mcp.CompleteResult
+		if s.capabilities.completions == nil {
+			err = &requestError{
+				id:   baseMessage.ID,
+				code: mcp.METHOD_NOT_FOUND,
+				err:  fmt.Errorf("completions %w", ErrUnsupported),
+			}
+		} else if unmarshalErr := json.Unmarshal(message, &request); unmarshalErr != nil {
+			err = &requestError{
+				id:   baseMessage.ID,
+				code: mcp.INVALID_REQUEST,
+				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
+			}
+		} else {
+			s.hooks.beforeComplete(ctx, baseMessage.ID, &request)
+			result, err = s.handleCompletion(ctx, baseMessage.ID, request)
+		}
+		if err != nil {
+			s.hooks.onError(ctx, baseMessage.ID, baseMessage.Method, &request, err)
+			return err.ToJSONRPCError()
+		}
+		s.hooks.afterComplete(ctx, baseMessage.ID, &request, result)
+		return createResponse(baseMessage.ID, *result)
 	default:
 		return createErrorResponse(
 			baseMessage.ID,


### PR DESCRIPTION
## Description

- Handle the method `compeltion/complete`
- Add the `Context` field to the `CompleteRequest` struct (references previously completed/selected arguments for the same prompt/resouce reference, which implementations can use to narrow down or steer the autocomplete suggestions)
- Allows server developers to configure autocomplete handlers for prompt argumens and arguments of resource template URIs

Example usage:
```go
s := server.NewMCPServer(...)

// Usage with ResourceTemplate
s.AddResourceTemplate(
  mcp.NewResourceTemplate(
    "postgresql://{userName}@host:5432/{databaseName}", // URI template
    "Database", // Resource name
    mcp.WithTemplateArgumentCompletion(
      "databaseName",
      func(_ context.Context, request mcp.CompleteRequest) (*mcp.CompleteResult, error) {
        input := request.Params.Argument.Value
        user := request.Params.Context.Arguments["user"]
        // TODO: check available databases for user, fuzzy match against input, return matches
      }
    ),
  ),
  resourceTemplateHandler
)

// Usage with Prompt
mcpServer.AddPrompt(
  mcp.NewPrompt(
    "Tell me a {adjective} joke about {subject}",
    mcp.WithArgument(
      "adjective",
      mcp.ArgumentCompletion(func(ctx context.Context, request mcp.CompleteRequest) (*mcp.CompleteResult, error) {
        input := request.Params.Argument.Value
        // TODO: Check dictionary for adjectives, fuzzy match against input, return suggestions
      }),
    ),
  ),
  func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
    return nil, nil
  },
)
```

## Type of Change
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
- [x] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Completion](https://modelcontextprotocol.io/specification/2025-03-26/server/utilities/completion)
- [x] Implementation follows the specification exactly

## Additional Information
- It was necessary to declare `CompletionHandlerFunc` in the `mcp` package instead of the `server` package to avoid a circular import. Any suggestions on how to solve this with a cleaner approach are welcome.