### PR TITLE
feat(tools): 添加 GetAnySlice 和 RequireAnySlice 方法

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -233,6 +233,32 @@ func (r CallToolRequest) RequireBool(key string) (bool, error) {
 	return false, fmt.Errorf("required argument %q not found", key)
 }
 
+// GetAnySlice returns a []any slice argument by key, or the default value if not found
+func (r CallToolRequest) GetAnySlice(key string, defaultValue []any) []any {
+	args := r.GetArguments()
+	if val, ok := args[key]; ok {
+		switch v := val.(type) {
+		case []any:
+			return v
+		}
+	}
+	return defaultValue
+}
+
+// RequireAnySlice returns a []any slice argument by key, or an error if not found or not convertible to []any slice
+func (r CallToolRequest) RequireAnySlice(key string) ([]any, error) {
+	args := r.GetArguments()
+	if val, ok := args[key]; ok {
+		switch v := val.(type) {
+		case []any:
+			return v, nil
+		default:
+			return nil, fmt.Errorf("argument %q is not an any slice", key)
+		}
+	}
+	return nil, fmt.Errorf("required argument %q not found", key)
+}
+
 // GetStringSlice returns a string slice argument by key, or the default value if not found
 func (r CallToolRequest) GetStringSlice(key string, defaultValue []string) []string {
 	args := r.GetArguments()

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -394,6 +394,19 @@ func TestCallToolRequestHelperFunctions(t *testing.T) {
 	_, err = req.RequireBool("missing_val")
 	assert.Error(t, err)
 
+	// Test GetAnySlice
+	assert.Equal(t, []any{"one", "two", "three"}, req.GetAnySlice("string_slice_val", nil))
+	assert.Equal(t, []any{1, 2, 3}, req.GetAnySlice("int_slice_val", nil))
+	assert.Equal(t, []any{1.1, 2.2, 3.3}, req.GetAnySlice("float_slice_val", nil))
+
+	// Test RequireAnySlice
+	as, err := req.RequireAnySlice("string_slice_val")
+	assert.NoError(t, err)
+	assert.Equal(t, []any{"one", "two", "three"}, as)
+	_, err = req.RequireAnySlice("missing_val")
+	assert.Error(t, err)
+	assert.Equal(t, []any{true, false, true}, req.GetAnySlice("bool_slice_val", nil))
+
 	// Test GetStringSlice
 	assert.Equal(t, []string{"one", "two", "three"}, req.GetStringSlice("string_slice_val", nil))
 	assert.Equal(t, []string{"default"}, req.GetStringSlice("missing_val", []string{"default"}))


### PR DESCRIPTION
- GetAnySlice 方法用于获取 []any 类型的参数，如果不存在则返回默认值
- RequireAnySlice 方法用于获取 []any 类型的参数，如果不存在或类型不匹配则返回错误