### PR TITLE
feat: support http HEAD method for langflow

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -331,7 +331,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 // handleSSE handles incoming SSE connection requests.
 // It sets up appropriate headers and creates a new session for the client.
 func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
@@ -340,6 +340,10 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
 	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method == http.MethodHead {
+		return
+	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {


### PR DESCRIPTION
## Description
Update the SSE http handler to allow http HEAD calls.

Langflow does a health check using http HEAD call for enabling any MCP server. The current http handler rejects that call with status 405. The code has been updated to fix that.
Now, if the handler receives an http HEAD call, it will just set proper response headers and return

## Type of Change
Enhancement or Bug fix to make it work with langflow

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for HTTP HEAD requests on the SSE endpoint, allowing clients to retrieve headers without establishing a streaming connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->