### PR TITLE
feat: Add GetHeader() Support for SSE Transport Sessions (ClientSession)

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"sort"
 	"testing"
@@ -1520,6 +1521,11 @@ func (f fakeSession) Initialize() {
 
 func (f fakeSession) Initialized() bool {
 	return f.initialized
+}
+
+func (f fakeSession) GetHeader() http.Header {
+	// Test session doesn't have HTTP headers, return empty header
+	return make(http.Header)
 }
 
 var _ ClientSession = fakeSession{}

--- a/server/session.go
+++ b/server/session.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -17,6 +18,8 @@ type ClientSession interface {
 	NotificationChannel() chan<- mcp.JSONRPCNotification
 	// SessionID is a unique identifier used to track user session.
 	SessionID() string
+	// GetHeader returns the HTTP headers from the initial request
+	GetHeader() http.Header
 }
 
 // SessionWithLogging is an extension of ClientSession that can receive log message notifications and set log level

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -40,6 +41,11 @@ func (f *sessionTestClient) Initialize() {
 // Initialized returns whether the session has been initialized
 func (f sessionTestClient) Initialized() bool {
 	return f.initialized
+}
+
+func (f sessionTestClient) GetHeader() http.Header {
+	// Test session doesn't have HTTP headers, return empty header
+	return make(http.Header)
 }
 
 // sessionTestClientWithTools implements the SessionWithTools interface for testing
@@ -100,6 +106,11 @@ func (f *sessionTestClientWithTools) SetSessionTools(tools map[string]ServerTool
 	f.sessionTools = toolsCopy
 }
 
+func (f *sessionTestClientWithTools) GetHeader() http.Header {
+	// Test session doesn't have HTTP headers, return empty header
+	return make(http.Header)
+}
+
 // sessionTestClientWithClientInfo implements the SessionWithClientInfo interface for testing
 type sessionTestClientWithClientInfo struct {
 	sessionID           string
@@ -137,6 +148,11 @@ func (f *sessionTestClientWithClientInfo) SetClientInfo(clientInfo mcp.Implement
 	f.clientInfo.Store(clientInfo)
 }
 
+func (f *sessionTestClientWithClientInfo) GetHeader() http.Header {
+	// Test session doesn't have HTTP headers, return empty header
+	return make(http.Header)
+}
+
 // sessionTestClientWithTools implements the SessionWithLogging interface for testing
 type sessionTestClientWithLogging struct {
 	sessionID           string
@@ -170,6 +186,11 @@ func (f *sessionTestClientWithLogging) SetLogLevel(level mcp.LoggingLevel) {
 func (f *sessionTestClientWithLogging) GetLogLevel() mcp.LoggingLevel {
 	level := f.loggingLevel.Load()
 	return level.(mcp.LoggingLevel)
+}
+
+func (f *sessionTestClientWithLogging) GetHeader() http.Header {
+	// Test session doesn't have HTTP headers, return empty header
+	return make(http.Header)
 }
 
 // Verify that all implementations satisfy their respective interfaces

--- a/server/sse.go
+++ b/server/sse.go
@@ -30,6 +30,7 @@ type sseSession struct {
 	loggingLevel        atomic.Value
 	tools               sync.Map     // stores session-specific tools
 	clientInfo          atomic.Value // stores session-specific client info
+	headers             http.Header  // stores HTTP headers from the initial request
 }
 
 // SSEContextFunc is a function that takes an existing context and the current
@@ -106,6 +107,10 @@ func (s *sseSession) GetClientInfo() mcp.Implementation {
 
 func (s *sseSession) SetClientInfo(clientInfo mcp.Implementation) {
 	s.clientInfo.Store(clientInfo)
+}
+
+func (s *sseSession) GetHeader() http.Header {
+	return s.headers
 }
 
 var (
@@ -353,6 +358,7 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 		eventQueue:          make(chan string, 100), // Buffer for events
 		sessionID:           sessionID,
 		notificationChannel: make(chan mcp.JSONRPCNotification, 100),
+		headers:             r.Header.Clone(), // Store HTTP headers from request
 	}
 
 	s.sessions.Store(sessionID, session)

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"sync/atomic"
@@ -98,6 +99,11 @@ func (s *stdioSession) GetLogLevel() mcp.LoggingLevel {
 		return mcp.LoggingLevelError
 	}
 	return level.(mcp.LoggingLevel)
+}
+
+func (s *stdioSession) GetHeader() http.Header {
+	// stdio transport doesn't have HTTP headers, return empty header
+	return make(http.Header)
 }
 
 var (


### PR DESCRIPTION
## Description
The MCP-Go library's SSE transport was missing the ability to access HTTP headers from client requests. While the ClientSession interface defined a GetHeader() method, none of the session implementations actually implemented it.

Fixes #443 

## Type of Change
- [x] New feature (non-breaking change that adds functionality)

Previously: Developers could only access session ID in hooks
```go
hooks := &server.Hooks{
    OnRegisterSession: []server.OnRegisterSessionHookFunc{
        func(ctx context.Context, session server.ClientSession) {
            sessionID := session.SessionID() //  This worked
            headers := session.GetHeader()   //  This caused compilation errors
        },
    },
}
```
Now: Just like we can get sessionID using hooks, we can get headers as well!
```go
hooks := &server.Hooks{
    OnRegisterSession: []server.OnRegisterSessionHookFunc{
        func(ctx context.Context, session server.ClientSession) {
            sessionID := session.SessionID() //  Session ID (existing)
            headers := session.GetHeader()   // HTTP Headers (NEW!)
            
            // Access specific headers
            userAgent := headers.Get("User-Agent")
            authorization := headers.Get("Authorization") 
            customHeader := headers.Get("X-Custom-Header")
            
            log.Printf("Session %s from %s", sessionID, userAgent)
        },
    },
}
```


## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Sessions now retain and provide access to the HTTP headers from the initial client request, enabling improved visibility of request metadata for supported session types.
- **Bug Fixes**
	- No user-facing bug fixes included in this update.
- **Tests**
	- Updated test session types to support the new header retrieval functionality for consistency with production code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->