### PR TITLE
feature: add support ResourceTemplates to mcptest package

### DIFF
--- a/mcptest/mcptest.go
+++ b/mcptest/mcptest.go
@@ -20,9 +20,10 @@ import (
 type Server struct {
 	name string
 
-	tools     []server.ServerTool
-	prompts   []server.ServerPrompt
-	resources []server.ServerResource
+	tools             []server.ServerTool
+	prompts           []server.ServerPrompt
+	resources         []server.ServerResource
+	resourceTemplates []server.ServerResourceTemplate
 
 	cancel func()
 
@@ -106,6 +107,25 @@ func (s *Server) AddResources(resources ...server.ServerResource) {
 	s.resources = append(s.resources, resources...)
 }
 
+// ServerResourceTemplate combines a ResourceTemplate with its handler function.
+type ServerResourceTemplate struct {
+	Template mcp.ResourceTemplate
+	Handler  server.ResourceTemplateHandlerFunc
+}
+
+// AddResourceTemplate adds a resource template to an unstarted server.
+func (s *Server) AddResourceTemplate(template mcp.ResourceTemplate, handler server.ResourceTemplateHandlerFunc) {
+	s.resourceTemplates = append(s.resourceTemplates, ServerResourceTemplate{
+		Template: template,
+		Handler:  handler,
+	})
+}
+
+// AddResourceTemplates adds multiple resource templates to an unstarted server.
+func (s *Server) AddResourceTemplates(templates ...ServerResourceTemplate) {
+	s.resourceTemplates = append(s.resourceTemplates, templates...)
+}
+
 // Start starts the server in a goroutine. Make sure to defer Close() after Start().
 // When using NewServer(), the returned server is already started.
 func (s *Server) Start(ctx context.Context) error {
@@ -122,6 +142,10 @@ func (s *Server) Start(ctx context.Context) error {
 		mcpServer.AddTools(s.tools...)
 		mcpServer.AddPrompts(s.prompts...)
 		mcpServer.AddResources(s.resources...)
+		
+		for _, template := range s.resourceTemplates {
+			mcpServer.AddResourceTemplate(template.Template, template.Handler)
+		}
 
 		logger := log.New(&s.logBuffer, "", 0)
 

--- a/mcptest/mcptest.go
+++ b/mcptest/mcptest.go
@@ -23,7 +23,7 @@ type Server struct {
 	tools             []server.ServerTool
 	prompts           []server.ServerPrompt
 	resources         []server.ServerResource
-	resourceTemplates []server.ServerResourceTemplate
+	resourceTemplates []ServerResourceTemplate
 
 	cancel func()
 

--- a/mcptest/mcptest_test.go
+++ b/mcptest/mcptest_test.go
@@ -196,8 +196,8 @@ func TestServerWithResourceTemplate(t *testing.T) {
 
 	// Create a URI template for files like "file://users/{userId}/documents/{docId}"
 	uriTemplate := &mcp.URITemplate{}
-	if err := uriTemplate.UnmarshalText([]byte("file://users/{userId}/documents/{docId}")); err != nil {
-		t.Fatal("URITemplate.UnmarshalText:", err)
+	if err := uriTemplate.UnmarshalJSON([]byte(`"file://users/{userId}/documents/{docId}"`)); err != nil {
+		t.Fatal("URITemplate.UnmarshalJSON:", err)
 	}
 
 	template := mcp.ResourceTemplate{
@@ -229,7 +229,7 @@ func TestServerWithResourceTemplate(t *testing.T) {
 
 	srv.AddResourceTemplate(template, handler)
 
-	err = srv.Start(ctx)
+	err := srv.Start(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mcptest/mcptest_test.go
+++ b/mcptest/mcptest_test.go
@@ -208,17 +208,25 @@ func TestServerWithResourceTemplate(t *testing.T) {
 	}
 
 	handler := func(ctx context.Context, request mcp.ReadResourceRequest) ([]mcp.ResourceContents, error) {
-		// For this test, we'll extract the values directly from the URI since template matching
-		// should have populated the arguments, but we'll also handle the case where we need to parse the URI
-		var userId, docId string
-		
-		if request.Params.Arguments != nil {
-			if uid, ok := request.Params.Arguments["userId"].(string); ok {
-				userId = uid
-			}
-			if did, ok := request.Params.Arguments["docId"].(string); ok {
-				docId = did
-			}
+		// First verify the arguments were correctly extracted from the URI template
+		if request.Params.Arguments == nil {
+			return nil, fmt.Errorf("expected arguments to be populated from URI template")
+		}
+
+		userId, ok := request.Params.Arguments["userId"].(string)
+		if !ok {
+			return nil, fmt.Errorf("expected userId argument to be populated from URI template")
+		}
+		if userId != "john" {
+			return nil, fmt.Errorf("expected userId argument to be 'john', got %q", userId)
+		}
+
+		docId, ok := request.Params.Arguments["docId"].(string)
+		if !ok {
+			return nil, fmt.Errorf("expected docId argument to be populated from URI template")
+		}
+		if docId != "readme.txt" {
+			return nil, fmt.Errorf("expected docId argument to be 'readme.txt', got %q", docId)
 		}
 		
 		// If arguments weren't extracted, parse from URI as fallback

--- a/mcptest/mcptest_test.go
+++ b/mcptest/mcptest_test.go
@@ -210,15 +210,21 @@ func TestServerWithResourceTemplate(t *testing.T) {
 		if !ok {
 			return nil, fmt.Errorf("expected userId argument to be populated from URI template")
 		}
-		if len(userIds) != 1 && userIds[0] != "john" {
-			return nil, fmt.Errorf("expected userId argument to be 'john', got %v", userIds)
+		if len(userIds) != 1 {
+			return nil, fmt.Errorf("expected userId to have one value, but got %d", len(userIds))
+		}
+		if userIds[0] != "john" {
+			return nil, fmt.Errorf("expected userId argument to be 'john', got %s", userIds[0])
 		}
 
 		docIds, ok := request.Params.Arguments["docId"].([]string)
 		if !ok {
 			return nil, fmt.Errorf("expected docId argument to be populated from URI template")
 		}
-		if len(docIds) != 1 && docIds[0] != "readme.txt" {
+		if len(docIds) != 1 {
+			return nil, fmt.Errorf("expected docId to have one value, but got %d", len(docIds))
+		}
+		if docIds[0] != "readme.txt" {
 			return nil, fmt.Errorf("expected docId argument to be 'readme.txt', got %v", docIds)
 		}
 

--- a/mcptest/mcptest_test.go
+++ b/mcptest/mcptest_test.go
@@ -195,9 +195,9 @@ func TestServerWithResourceTemplate(t *testing.T) {
 	defer srv.Close()
 
 	// Create a URI template for files like "file://users/{userId}/documents/{docId}"
-	uriTemplate, err := mcp.NewURITemplate("file://users/{userId}/documents/{docId}")
-	if err != nil {
-		t.Fatal("NewURITemplate:", err)
+	uriTemplate := &mcp.URITemplate{}
+	if err := uriTemplate.UnmarshalText([]byte("file://users/{userId}/documents/{docId}")); err != nil {
+		t.Fatal("URITemplate.UnmarshalText:", err)
 	}
 
 	template := mcp.ResourceTemplate{


### PR DESCRIPTION
## Description

Fixes https://github.com/mark3labs/mcp-go/issues/436

- [x] New feature (non-breaking change that adds functionality)

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for registering resource templates with the server, enabling dynamic resource handling based on URI patterns.

- **Tests**
  - Introduced a new test to verify correct handling and response for resource templates, including argument extraction and URI parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->