### PR TITLE
Added 'Definitions' field to 'ToolInputSchema'

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -516,9 +516,10 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 }
 
 type ToolInputSchema struct {
-	Type       string         `json:"type"`
-	Properties map[string]any `json:"properties,omitempty"`
-	Required   []string       `json:"required,omitempty"`
+	Type        string                     `json:"type"`
+	Properties  map[string]any             `json:"properties,omitempty"`
+	Required    []string                   `json:"required,omitempty"`
+	Definitions map[string]ToolInputSchema `json:"$defs,omitempty"`
 }
 
 // MarshalJSON implements the json.Marshaler interface for ToolInputSchema.
@@ -533,6 +534,10 @@ func (tis ToolInputSchema) MarshalJSON() ([]byte, error) {
 
 	if len(tis.Required) > 0 {
 		m["required"] = tis.Required
+	}
+
+	if len(tis.Definitions) > 0 {
+		m["$defs"] = tis.Definitions
 	}
 
 	return json.Marshal(m)


### PR DESCRIPTION
## Description
This adds the "Definitions" field to "ToolInputSchema". 

This is useful for tools that receive as input a structured type. The field is present in other SDKs, for example, the official Java SDK. This is useful for tools that accept a structured type as input. The field is present in other SDKs, such as the official Java SDK: https://github.com/modelcontextprotocol/java-sdk/blob/5bd64c2beb4232e0a7193619c9fd3faf5091b5d4/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java#L807SDK: https://github.com/modelcontextprotocol/java-sdk/blob/5bd64c2beb4232e0a7193619c9fd3faf5091b5d4/mcp/src/main/java/io/modelcontextprotocol/spec/McpSchema.java#L807

While MCP spec doesn't explicitly mention the Definitions (`json:"$defs"`) field, it is a field of JSON Schema, which is specified as the type of inputSchema: https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [X] This PR implements a feature defined in the MCP specification
- [X] Link to relevant spec section: [5.1 Tool](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool)
- [X] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
