### PR TITLE
Support creating an `Stdio` client with options

### DIFF
--- a/client/stdio.go
+++ b/client/stdio.go
@@ -19,10 +19,26 @@ func NewStdioMCPClient(
 	env []string,
 	args ...string,
 ) (*Client, error) {
+	return NewStdioMCPClientWithOptions(command, env, args)
+}
 
-	stdioTransport := transport.NewStdio(command, env, args...)
-	err := stdioTransport.Start(context.Background())
-	if err != nil {
+// NewStdioMCPClientWithOptions creates a new stdio-based MCP client that communicates with a subprocess.
+// It launches the specified command with given arguments and sets up stdin/stdout pipes for communication.
+// Optional configuration functions can be provided to customize the transport before it starts,
+// such as setting a custom command function.
+//
+// NOTICE: NewStdioMCPClientWithOptions automatically starts the underlying transport.
+// Don't call the Start method manually.
+// This is for backward compatibility.
+func NewStdioMCPClientWithOptions(
+	command string,
+	env []string,
+	args []string,
+	opts ...transport.StdioOption,
+) (*Client, error) {
+	stdioTransport := transport.NewStdioWithOptions(command, env, args, opts...)
+
+	if err := stdioTransport.Start(context.Background()); err != nil {
 		return nil, fmt.Errorf("failed to start stdio transport: %w", err)
 	}
 

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -502,7 +502,6 @@ func TestStdio_WithCommandFunc(t *testing.T) {
 		cmd := exec.CommandContext(ctx, command, "bonjour")
 
 		// Simulate some security-related settings for test purposes.
-		cmd.Env = env
 		cmd.Env = []string{"PATH=/usr/bin", "NODE_ENV=production"}
 		cmd.Dir = tmpDir
 
@@ -538,6 +537,8 @@ func TestStdio_WithCommandFunc(t *testing.T) {
 	require.Equal(t, "echo", filepath.Base(cmd.Path))
 	require.Len(t, cmd.Args, 2)
 	require.Contains(t, cmd.Args, "bonjour")
+	require.Len(t, cmd.Env, 2)
+	require.Contains(t, cmd.Env, "PATH=/usr/bin")
 	require.Contains(t, cmd.Env, "NODE_ENV=production")
 }
 

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -3,13 +3,18 @@ package transport
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"sync"
+	"syscall"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -148,7 +153,6 @@ func TestStdio(t *testing.T) {
 	})
 
 	t.Run("SendNotification & NotificationHandler", func(t *testing.T) {
-
 		var wg sync.WaitGroup
 		notificationChan := make(chan mcp.JSONRPCNotification, 1)
 
@@ -380,7 +384,6 @@ func TestStdio(t *testing.T) {
 			t.Errorf("Expected array with 3 items, got %v", result.Params["array"])
 		}
 	})
-
 }
 
 func TestStdioErrors(t *testing.T) {
@@ -483,5 +486,136 @@ func TestStdioErrors(t *testing.T) {
 			t.Errorf("Expected error when sending request after close, got nil")
 		}
 	})
+}
 
+func TestStdio_WithCommandFunc(t *testing.T) {
+	called := false
+	tmpDir := t.TempDir()
+	chrootDir := filepath.Join(tmpDir, "sandbox-root")
+	err := os.MkdirAll(chrootDir, 0o755)
+	require.NoError(t, err, "failed to create chroot dir")
+
+	fakeCmdFunc := func(ctx context.Context, command string, args []string, env []string) (*exec.Cmd, error) {
+		called = true
+
+		// Override the args inside our command func.
+		cmd := exec.CommandContext(ctx, command, "bonjour")
+
+		// Simulate some security-related settings for test purposes.
+		cmd.Env = env
+		cmd.Env = []string{"PATH=/usr/bin", "NODE_ENV=production"}
+		cmd.Dir = tmpDir
+
+		cmd.SysProcAttr = &syscall.SysProcAttr{
+			Credential: &syscall.Credential{
+				Uid: 1001,
+				Gid: 1001,
+			},
+			Chroot: chrootDir,
+		}
+
+		return cmd, nil
+	}
+
+	stdio := NewStdioWithOptions(
+		"echo",
+		[]string{"foo=bar"},
+		[]string{"hello"},
+		WithCommandFunc(fakeCmdFunc),
+	)
+	require.NotNil(t, stdio)
+	require.NotNil(t, stdio.cmdFunc)
+
+	// Manually call the cmdFunc passing the same values as in spawnCommand.
+	cmd, err := stdio.cmdFunc(context.Background(), "echo", nil, []string{"hello"})
+	require.NoError(t, err)
+	require.True(t, called)
+	require.NotNil(t, cmd)
+	require.NotNil(t, cmd.SysProcAttr)
+	require.Equal(t, chrootDir, cmd.SysProcAttr.Chroot)
+	require.Equal(t, tmpDir, cmd.Dir)
+	require.Equal(t, uint32(1001), cmd.SysProcAttr.Credential.Uid)
+	require.Equal(t, "echo", filepath.Base(cmd.Path))
+	require.Len(t, cmd.Args, 2)
+	require.Contains(t, cmd.Args, "bonjour")
+	require.Contains(t, cmd.Env, "NODE_ENV=production")
+}
+
+func TestStdio_SpawnCommand(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("TEST_ENVIRON_VAR", "true")
+
+	// Explicitly not passing any environment, so we can see if it
+	// is picked up by spawn command merging the os.Environ.
+	stdio := NewStdio("echo", nil, "hello")
+	require.NotNil(t, stdio)
+
+	err := stdio.spawnCommand(ctx)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = stdio.cmd.Process.Kill()
+	})
+
+	require.Equal(t, "echo", filepath.Base(stdio.cmd.Path))
+	require.Contains(t, stdio.cmd.Args, "hello")
+	require.Contains(t, stdio.cmd.Env, "TEST_ENVIRON_VAR=true")
+}
+
+func TestStdio_SpawnCommand_UsesCommandFunc(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("TEST_ENVIRON_VAR", "true")
+
+	stdio := NewStdioWithOptions(
+		"echo",
+		nil,
+		[]string{"test"},
+		WithCommandFunc(func(ctx context.Context, cmd string, args []string, env []string) (*exec.Cmd, error) {
+			c := exec.CommandContext(ctx, cmd, "hola")
+			c.Env = env
+			return c, nil
+		}),
+	)
+	require.NotNil(t, stdio)
+	err := stdio.spawnCommand(ctx)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = stdio.cmd.Process.Kill()
+	})
+
+	require.Equal(t, "echo", filepath.Base(stdio.cmd.Path))
+	require.Contains(t, stdio.cmd.Args, "hola")
+	require.NotContains(t, stdio.cmd.Env, "TEST_ENVIRON_VAR=true")
+	require.NotNil(t, stdio.stdin)
+	require.NotNil(t, stdio.stdout)
+	require.NotNil(t, stdio.stderr)
+}
+
+func TestStdio_SpawnCommand_UsesCommandFunc_Error(t *testing.T) {
+	ctx := context.Background()
+
+	stdio := NewStdioWithOptions(
+		"echo",
+		nil,
+		[]string{"test"},
+		WithCommandFunc(func(ctx context.Context, cmd string, args []string, env []string) (*exec.Cmd, error) {
+			return nil, errors.New("test error")
+		}),
+	)
+	require.NotNil(t, stdio)
+	err := stdio.spawnCommand(ctx)
+	require.Error(t, err)
+	require.EqualError(t, err, "test error")
+}
+
+func TestStdio_NewStdioWithOptions_AppliesOptions(t *testing.T) {
+	configured := false
+
+	opt := func(s *Stdio) {
+		configured = true
+	}
+
+	stdio := NewStdioWithOptions("echo", nil, []string{"test"}, opt)
+	require.NotNil(t, stdio)
+	require.True(t, configured, "option was not applied")
 }

--- a/www/docs/pages/transports/stdio.mdx
+++ b/www/docs/pages/transports/stdio.mdx
@@ -323,7 +323,7 @@ import (
 func main() {
     // Create STDIO client
     c, err := client.NewStdioClient(
-        "go", nil, "run", "/path/to/server/main.go",
+        "go", nil /* inherit env */, "run", "/path/to/server/main.go",
     )
     if err != nil {
         log.Fatal(err)
@@ -376,6 +376,8 @@ func main() {
 }
 ```
 
+#### Customizing Subprocess Execution
+
 If you need more control over how a sub-process is spawned when creating a new STDIO client, you can use
 `NewStdioMCPClientWithOptions` instead of `NewStdioMCPClient`.
 
@@ -397,7 +399,7 @@ c, err := client.NewStdioMCPClientWithOptions(
 	"go",
 	nil,
 	[]string {"run", "/path/to/server/main.go"},
-	WithCommandFunc(func(ctx context.Context, command string, args []string, env []string) (*exec.Cmd, error) {
+	transport.WithCommandFunc(func(ctx context.Context, command string, args []string, env []string) (*exec.Cmd, error) {
         cmd := exec.CommandContext(ctx, command, args...)
         cmd.Env = env // Explicit environment for the subprocess.
         cmd.Dir = "/var/sandbox/mcp-server" // Working directory (not isolated unless paired with chroot or namespace).

--- a/www/docs/pages/transports/stdio.mdx
+++ b/www/docs/pages/transports/stdio.mdx
@@ -313,29 +313,30 @@ package main
 import (
     "context"
     "log"
+    "time"
+
 
     "github.com/mark3labs/mcp-go/client"
+    "github.com/mark3labs/mcp-go/mcp"
 )
 
 func main() {
     // Create STDIO client
     c, err := client.NewStdioClient(
-        "go", "run", "/path/to/server/main.go",
+        "go", nil, "run", "/path/to/server/main.go",
     )
     if err != nil {
         log.Fatal(err)
     }
     defer c.Close()
 
-    ctx := context.Background()
+    ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+    defer cancel()
 
     // Initialize connection
     _, err = c.Initialize(ctx, mcp.InitializeRequest{
         Params: mcp.InitializeRequestParams{
-            ProtocolVersion: "2024-11-05",
-            Capabilities: mcp.ClientCapabilities{
-                Tools: &mcp.ToolsCapability{},
-            },
+            ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
             ClientInfo: mcp.Implementation{
                 Name:    "test-client",
                 Version: "1.0.0",
@@ -373,6 +374,56 @@ func main() {
 
     log.Printf("Tool result: %+v", result)
 }
+```
+
+If you need more control over how a sub-process is spawned when creating a new STDIO client, you can use
+`NewStdioMCPClientWithOptions` instead of `NewStdioMCPClient`.
+
+By passing the `WithCommandFunc` option, you can supply a custom factory function to create the `exec.Cmd` that launches
+the server. This allows configuration of environment variables, working directories, and system-level process attributes.
+
+Referring to the previous example, we can replace the line that creates the client:
+
+```go
+c, err := client.NewStdioClient(
+    "go", nil, "run", "/path/to/server/main.go",
+)
+```
+
+With the options-aware version:
+
+```go
+c, err := client.NewStdioMCPClientWithOptions(
+	"go",
+	nil,
+	[]string {"run", "/path/to/server/main.go"},
+	WithCommandFunc(func(ctx context.Context, command string, args []string, env []string) (*exec.Cmd, error) {
+        cmd := exec.CommandContext(ctx, command, args...)
+        cmd.Env = env // Explicit environment for the subprocess.
+        cmd.Dir = "/var/sandbox/mcp-server" // Working directory (not isolated unless paired with chroot or namespace).
+
+        // Apply low-level process isolation and privilege dropping.
+        cmd.SysProcAttr = &syscall.SysProcAttr{
+            // Drop to non-root user (e.g., user/group ID 1001)
+            Credential: &syscall.Credential{
+                Uid: 1001,
+                Gid: 1001,
+            },
+            // File system isolation: only works if running as root.
+            Chroot: "/var/sandbox/mcp-server",
+
+            // Linux namespace isolation (Linux only):
+            // Prevents access to other processes, mounts, IPC, networks, etc.
+            Cloneflags: syscall.CLONE_NEWIPC | // Isolate inter-process comms
+                syscall.CLONE_NEWNS  | // Isolate filesystem mounts
+                syscall.CLONE_NEWPID | // Isolate PID namespace (child sees itself as PID 1)
+                syscall.CLONE_NEWUTS | // Isolate hostname
+                syscall.CLONE_NEWNET,  // Isolate networking (optional)
+        }
+
+		return cmd, nil
+	}),
+)
 ```
 
 ## Debugging


### PR DESCRIPTION
## Description

Currently it is not possible to control how a sub-process is created over supplying the command, args and env. The existing `spawnCommand` in `client/transport/stdio.go` always takes the current `os.Environ` and merges any supplied env vars into it. 

This PR adds `NewStdioMCPClientWithOptions` and `NewStdioWithOptions` which are complimentary to `NewStdioMCPClient` and `NewStdio`.

The new functions accept variadic options (following the options pattern), which include  a command func/factory (named `WithCommandFunc`) which can handle creating and configuring the `exec.Cmd` for additional control.

Because of the existing function signatures (where variadic arguments are already present for `args`) it was not possible to simply add the options in situ, which may have been a cleaner change and would introduce no breaking changes, or additional exported functions. 

New unit tests have been added, as an example of how we now have more fine-grained control over sub-process creation please refer to `TestStdio_WithCommandFunc`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for customizing subprocess command creation and launching with flexible options.
  * Introduced automatic starting of subprocess transport upon client creation, simplifying usage.
  * Updated documentation with examples demonstrating advanced subprocess configuration, including environment, working directory, and privilege isolation.

* **Bug Fixes**
  * Enhanced error reporting when subprocess startup fails.

* **Tests**
  * Added tests covering custom command functions, subprocess spawning behavior, error handling, and option application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->