### PR TITLE
feat: Implement per-session prompt functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,7 @@ MCP-Go provides a robust session management system that allows you to:
 - Register and track client sessions
 - Send notifications to specific clients
 - Provide per-session tool customization
+- Provide per-session prompt customization
 
 <details>
 <summary>Show Session Management Examples</summary>

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,11 @@ require (
 	github.com/yosida95/uritemplate/v3 v3.0.2
 )
 
+require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,5 @@ require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/sirupsen/logrus v1.9.3
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
-github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
-github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,4 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
@@ -14,13 +15,20 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
+github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/server/errors.go
+++ b/server/errors.go
@@ -17,6 +17,7 @@ var (
 	ErrSessionExists                = errors.New("session already exists")
 	ErrSessionNotInitialized        = errors.New("session not properly initialized")
 	ErrSessionDoesNotSupportTools   = errors.New("session does not support per-session tools")
+	ErrSessionDoesNotSupportPrompts = errors.New("session does not support per-session prompts")
 	ErrSessionDoesNotSupportLogging = errors.New("session does not support setting logging level")
 
 	// Notification-related errors

--- a/server/server.go
+++ b/server/server.go
@@ -896,13 +896,17 @@ func (s *MCPServer) handleGetPrompt(
 	var handler PromptHandlerFunc
 	var ok bool
 
-	logrus.Infof("handleGetPrompt: %s", request.Params.Name)
+	logrus.Infof("[handleGetPrompt]: %s", request.Params.Name)
 
 	session := ClientSessionFromContext(ctx)
 	if session != nil {
+		logrus.Infof("[handleGetPrompt] session: %s", session.SessionID())
 		if sessionWithPrompts, typeAssertOk := session.(SessionWithPrompts); typeAssertOk {
+			logrus.Info("[handleGetPrompt] SessionWithPrompts: ok")
 			if sessionPrompts := sessionWithPrompts.GetSessionPrompts(); sessionPrompts != nil {
+				logrus.Info("[handleGetPrompt] GetSessionPrompts: ok")
 				if serverPrompt, sessionOk := sessionPrompts[request.Params.Name]; sessionOk {
+					logrus.Info("[handleGetPrompt] handler: ok")
 					handler = serverPrompt.Handler
 					ok = true
 				}

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/sirupsen/logrus"
 )
 
 // resourceEntry holds both a resource and its handler
@@ -894,6 +895,8 @@ func (s *MCPServer) handleGetPrompt(
 	// First check session-specific prompts
 	var handler PromptHandlerFunc
 	var ok bool
+
+	logrus.Infof("handleGetPrompt: %s", request.Params.Name)
 
 	session := ClientSessionFromContext(ctx)
 	if session != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 
 	"github.com/mark3labs/mcp-go/mcp"
-	"github.com/sirupsen/logrus"
 )
 
 // resourceEntry holds both a resource and its handler
@@ -896,17 +895,11 @@ func (s *MCPServer) handleGetPrompt(
 	var handler PromptHandlerFunc
 	var ok bool
 
-	logrus.Infof("[handleGetPrompt]: %s", request.Params.Name)
-
 	session := ClientSessionFromContext(ctx)
 	if session != nil {
-		logrus.Infof("[handleGetPrompt] session: %s", session.SessionID())
 		if sessionWithPrompts, typeAssertOk := session.(SessionWithPrompts); typeAssertOk {
-			logrus.Info("[handleGetPrompt] SessionWithPrompts: ok")
 			if sessionPrompts := sessionWithPrompts.GetSessionPrompts(); sessionPrompts != nil {
-				logrus.Info("[handleGetPrompt] GetSessionPrompts: ok")
 				if serverPrompt, sessionOk := sessionPrompts[request.Params.Name]; sessionOk {
-					logrus.Info("[handleGetPrompt] handler: ok")
 					handler = serverPrompt.Handler
 					ok = true
 				}

--- a/server/session.go
+++ b/server/session.go
@@ -42,9 +42,9 @@ type SessionWithTools interface {
 type SessionWithPrompts interface {
 	ClientSession
 	// GetPrompts returns the prompts specific to this session, if any
-	GetPrompts() map[string]string
+	GetSessionPrompts() map[string]ServerPrompt
 	// SetPrompts sets prompts specific to this session
-	SetPrompts(prompts map[string]string)
+	SetSessionPrompts(prompts map[string]ServerPrompt)
 }
 
 // SessionWithClientInfo is an extension of ClientSession that can store client info

--- a/server/session.go
+++ b/server/session.go
@@ -439,3 +439,7 @@ func (s *MCPServer) AddSessionPrompts(sessionID string, prompts ...ServerPrompt)
 
 	return nil
 }
+
+func (s *MCPServer) AddSessionPrompt(sessionID string, prompt mcp.Prompt, handler PromptHandlerFunc) error {
+	return s.AddSessionPrompts(sessionID, ServerPrompt{Prompt: prompt, Handler: handler})
+}

--- a/server/session.go
+++ b/server/session.go
@@ -39,6 +39,14 @@ type SessionWithTools interface {
 	SetSessionTools(tools map[string]ServerTool)
 }
 
+type SessionWithPrompts interface {
+	ClientSession
+	// GetPrompts returns the prompts specific to this session, if any
+	GetPrompts() map[string]string
+	// SetPrompts sets prompts specific to this session
+	SetPrompts(prompts map[string]string)
+}
+
 // SessionWithClientInfo is an extension of ClientSession that can store client info
 type SessionWithClientInfo interface {
 	ClientSession

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -137,7 +137,7 @@ func (f *sessionTestClientWithClientInfo) SetClientInfo(clientInfo mcp.Implement
 	f.clientInfo.Store(clientInfo)
 }
 
-// sessionTestClientWithTools implements the SessionWithLogging interface for testing
+// sessionTestClientWithLogging implements the SessionWithLogging interface for testing
 type sessionTestClientWithLogging struct {
 	sessionID           string
 	notificationChannel chan mcp.JSONRPCNotification

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -467,6 +467,50 @@ func TestMCPServer_AddSessionTool(t *testing.T) {
 	assert.Contains(t, session.GetSessionTools(), "session-tool-helper")
 }
 
+func TestMCPServer_AddSessionPrompt(t *testing.T) {
+	server := NewMCPServer("test-server", "1.0.0", WithPromptCapabilities(true))
+	ctx := context.Background()
+
+	// Create a session
+	sessionChan := make(chan mcp.JSONRPCNotification, 10)
+	session := &sessionTestClientWithPrompts{
+		sessionID:           "session-1",
+		notificationChannel: sessionChan,
+		initialized:         true,
+	}
+
+	// Register the session
+	err := server.RegisterSession(ctx, session)
+	require.NoError(t, err)
+
+	// Add session-specific tool using the new helper method
+	err = server.AddSessionPrompt(
+		session.SessionID(),
+		mcp.NewPrompt("session-prompt-helper"),
+		func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+			return mcp.NewGetPromptResult("helper result", []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Text: "helper result"},
+				},
+			}), nil
+		},
+	)
+	require.NoError(t, err)
+
+	// Check that notification was sent
+	select {
+	case notification := <-sessionChan:
+		assert.Equal(t, "notifications/prompts/list_changed", notification.Method)
+	case <-time.After(100 * time.Millisecond):
+		t.Error("Expected notification not received")
+	}
+
+	// Verify tool was added to session
+	assert.Len(t, session.GetSessionPrompts(), 1)
+	assert.Contains(t, session.GetSessionPrompts(), "session-prompt-helper")
+}
+
 func TestMCPServer_AddSessionToolsUninitialized(t *testing.T) {
 	// This test verifies that adding tools to an uninitialized session works correctly.
 	//


### PR DESCRIPTION
## Description

This PR adds support for session-specific prompts in the MCP server, allowing different prompts to be available per client session. This mirrors the existing session-specific tools functionality and enables dynamic prompt customization based on session context.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [x] Tests only (no functional changes)

## Changes Made

### Core Functionality
1. **Enhanced `sseSession` struct**: Added `prompts sync.Map` field to store session-specific prompts
2. **Implemented `SessionWithPrompts` interface**: Added methods for managing session prompts
3. **Updated `handleGetPrompt`**: Modified to check session-specific prompts first, then fall back to global prompts
4. **Updated `handleListPrompts`**: Modified to merge session-specific prompts with global prompts in the list

### Server Methods
- Added `AddSessionPrompts(sessionID string, prompts ...ServerPrompt) error`
- Added `AddSessionPrompt(sessionID string, prompt mcp.Prompt, handler PromptHandlerFunc) error`
- Added `DeleteSessionPrompts(sessionID string, names ...string) error`

### Testing
- Added comprehensive test suite for session-specific prompts functionality
- Tests cover integration, uninitialized sessions, prompt overriding, and concurrent access
- All tests pass and maintain backward compatibility

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Prompts](https://modelcontextprotocol.io/docs/concepts/prompts)
- [x] Implementation follows the specification exactly

## Additional Information

This implementation follows the same pattern as the existing session-specific tools functionality, ensuring consistency across the codebase. The feature allows for:

- Session-specific prompt overrides of global prompts
- Dynamic prompt management per session
- Proper notification handling for prompt list changes
- Thread-safe concurrent access to session prompts

The implementation maintains full backward compatibility and doesn't affect existing global prompt functionality.
