### PR TITLE
fix: use bufio.Scanner for stdio transport to avoid panic when stdio mcp server outputs a long line

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -27,7 +27,7 @@ type Stdio struct {
 	cmd            *exec.Cmd
 	cmdFunc        CommandFunc
 	stdin          io.WriteCloser
-	stdout         *bufio.Reader
+	stdout         *bufio.Scanner
 	stderr         io.ReadCloser
 	responses      map[string]chan *JSONRPCResponse
 	mu             sync.RWMutex
@@ -72,7 +72,7 @@ func WithCommandLogger(logger util.Logger) StdioOption {
 func NewIO(input io.Reader, output io.WriteCloser, logging io.ReadCloser) *Stdio {
 	return &Stdio{
 		stdin:  output,
-		stdout: bufio.NewReader(input),
+		stdout: bufio.NewScanner(input),
 		stderr: logging,
 
 		responses: make(map[string]chan *JSONRPCResponse),
@@ -180,7 +180,7 @@ func (c *Stdio) spawnCommand(ctx context.Context) error {
 	c.cmd = cmd
 	c.stdin = stdin
 	c.stderr = stderr
-	c.stdout = bufio.NewReader(stdout)
+	c.stdout = bufio.NewScanner(stdout)
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start command: %w", err)
@@ -247,14 +247,15 @@ func (c *Stdio) readResponses() {
 		case <-c.done:
 			return
 		default:
-			line, err := c.stdout.ReadString('\n')
-			if err != nil {
-				if err != io.EOF && !errors.Is(err, context.Canceled) {
+			if !c.stdout.Scan() {
+				err := c.stdout.Err()
+				if err != nil && !errors.Is(err, context.Canceled) {
 					c.logger.Errorf("Error reading from stdout: %v", err)
 				}
 				return
 			}
 
+			line := c.stdout.Text()
 			// First try to parse as a generic message to check for ID field
 			var baseMessage struct {
 				JSONRPC string         `json:"jsonrpc"`


### PR DESCRIPTION
## Description

Fixes #462

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved the way output is read from subprocesses for better reliability and error handling. No changes to user-facing features or workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->