### PR TITLE
fix `Content-Type: application/json; charset=utf-8` error

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -213,7 +213,7 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 
 	// Check content type
 	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/json" {
+	if !strings.Contains(contentType, "application/json") {
 		http.Error(w, "Invalid content type: must be 'application/json'", http.StatusBadRequest)
 		return
 	}

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -213,7 +214,8 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 
 	// Check content type
 	contentType := r.Header.Get("Content-Type")
-	if !strings.Contains(contentType, "application/json") {
+	mediaType, _, err := mime.ParseMediaType(contentType)
+	if err != nil || mediaType != "application/json" {
 		http.Error(w, "Invalid content type: must be 'application/json'", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
## Description

Fixes an issue where requests with `Content-Type: application/json; charset=utf-8` would be incorrectly rejected. The original code only checks for an exact match of `application/json`, which causes requests with additional parameters like `charset=utf-8` to fail. This update uses `strings.Contains` to ensure that the request is valid as long as the `Content-Type` contains `application/json`.

Fixes #\<issue\_number> (if applicable)

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] MCP spec compatibility implementation
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Code refactoring (no functional changes)
* [ ] Performance improvement
* [ ] Tests only (no functional changes)
* [ ] Other (please describe):

## Checklist

* [x] My code follows the code style of this project
* [x] I have performed a self-review of my own code
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have updated the documentation accordingly

## MCP Spec Compliance

* [ ] This PR implements a feature defined in the MCP specification
* [ ] Link to relevant spec section: [[Link text](https://modelcontextprotocol.io/specification/path-to-section)](https://modelcontextprotocol.io/specification/path-to-section)
* [ ] Implementation follows the specification exactly

## Additional Information

The update ensures that requests with `Content-Type` values like `application/json; charset=utf-8` are correctly handled, avoiding unnecessary errors due to the presence of the charset parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incoming requests by validating the Content-Type header more accurately, ensuring better compatibility with various clients. Invalid content types now return a clearer error message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->