### PR TITLE
Http headers

### DIFF
--- a/mcp/prompts.go
+++ b/mcp/prompts.go
@@ -1,11 +1,14 @@
 package mcp
 
+import "net/http"
+
 /* Prompts */
 
 // ListPromptsRequest is sent from the client to request a list of prompts and
 // prompt templates the server has.
 type ListPromptsRequest struct {
 	PaginatedRequest
+	Header http.Header `json:"-"`
 }
 
 // ListPromptsResult is the server's response to a prompts/list request from
@@ -20,6 +23,7 @@ type ListPromptsResult struct {
 type GetPromptRequest struct {
 	Request
 	Params GetPromptParams `json:"params"`
+	Header http.Header     `json:"-"`
 }
 
 type GetPromptParams struct {

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"reflect"
 	"strconv"
 )
@@ -45,6 +46,7 @@ type CallToolResult struct {
 // CallToolRequest is used by the client to invoke a tool provided by the server.
 type CallToolRequest struct {
 	Request
+	Header http.Header
 	Params CallToolParams `json:"params"`
 }
 

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -47,9 +47,7 @@ type CallToolResult struct {
 // CallToolRequest is used by the client to invoke a tool provided by the server.
 type CallToolRequest struct {
 	Request
-	// Header must be read from request
-	// Prevent Header being passed as request payload
-	Header http.Header    `json:"-"`
+	Header http.Header    `json:"-"` // HTTP headers from the original request
 	Params CallToolParams `json:"params"`
 }
 

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -15,6 +15,7 @@ var errToolSchemaConflict = errors.New("provide either InputSchema or RawInputSc
 // server has.
 type ListToolsRequest struct {
 	PaginatedRequest
+	Header http.Header `json:"-"`
 }
 
 // ListToolsResult is the server's response to a tools/list request from the
@@ -46,7 +47,9 @@ type CallToolResult struct {
 // CallToolRequest is used by the client to invoke a tool provided by the server.
 type CallToolRequest struct {
 	Request
-	Header http.Header
+	// Header must be read from request
+	// Prevent Header being passed as request payload
+	Header http.Header    `json:"-"`
 	Params CallToolParams `json:"params"`
 }
 

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	"github.com/yosida95/uritemplate/v3"
+	"net/http"
 )
 
 type MCPMethod string
@@ -399,6 +400,7 @@ type CancelledNotificationParams struct {
 type InitializeRequest struct {
 	Request
 	Params InitializeParams `json:"params"`
+	Header http.Header      `json:"-"`
 }
 
 type InitializeParams struct {
@@ -489,6 +491,7 @@ type Implementation struct {
 // or else may be disconnected.
 type PingRequest struct {
 	Request
+	Header http.Header `json:"-"`
 }
 
 /* Progress notifications */
@@ -541,6 +544,7 @@ type PaginatedResult struct {
 // the server has.
 type ListResourcesRequest struct {
 	PaginatedRequest
+	Header http.Header `json:"-"`
 }
 
 // ListResourcesResult is the server's response to a resources/list request
@@ -554,6 +558,7 @@ type ListResourcesResult struct {
 // resource templates the server has.
 type ListResourceTemplatesRequest struct {
 	PaginatedRequest
+	Header http.Header `json:"-"`
 }
 
 // ListResourceTemplatesResult is the server's response to a
@@ -567,6 +572,7 @@ type ListResourceTemplatesResult struct {
 // specific resource URI.
 type ReadResourceRequest struct {
 	Request
+	Header http.Header        `json:"-"`
 	Params ReadResourceParams `json:"params"`
 }
 
@@ -598,6 +604,7 @@ type ResourceListChangedNotification struct {
 type SubscribeRequest struct {
 	Request
 	Params SubscribeParams `json:"params"`
+	Header http.Header     `json:"-"`
 }
 
 type SubscribeParams struct {
@@ -612,6 +619,7 @@ type SubscribeParams struct {
 type UnsubscribeRequest struct {
 	Request
 	Params UnsubscribeParams `json:"params"`
+	Header http.Header       `json:"-"`
 }
 
 type UnsubscribeParams struct {
@@ -717,6 +725,7 @@ func (BlobResourceContents) isResourceContents() {}
 type SetLevelRequest struct {
 	Request
 	Params SetLevelParams `json:"params"`
+	Header http.Header    `json:"-"`
 }
 
 type SetLevelParams struct {
@@ -960,6 +969,7 @@ type ModelHint struct {
 type CompleteRequest struct {
 	Request
 	Params CompleteParams `json:"params"`
+	Header http.Header    `json:"-"`
 }
 
 type CompleteParams struct {
@@ -1012,6 +1022,7 @@ type PromptReference struct {
 // structure or access specific locations that the client has permission to read from.
 type ListRootsRequest struct {
 	Request
+	Header http.Header `json:"-"`
 }
 
 // ListRootsResult is the client's response to a roots/list request from the server.

--- a/server/ctx.go
+++ b/server/ctx.go
@@ -1,0 +1,8 @@
+package server
+
+type contextKey int
+
+const (
+	// This const is used as key for context value lookup
+	requestHeader contextKey = iota
+)

--- a/server/internal/gen/request_handler.go.tmpl
+++ b/server/internal/gen/request_handler.go.tmpl
@@ -72,6 +72,14 @@ func (s *MCPServer) HandleMessage(
     	)
     }
 
+    // Get request header from ctx
+    h := ctx.Value(requestHeader)
+	headers, ok := h.(http.Header)
+
+	if headers == nil || !ok {
+		headers = make(http.Header)
+	}
+
 	switch baseMessage.Method {
 	{{- range .}}
 	case mcp.{{.MethodName}}:
@@ -90,6 +98,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+            request.Header = headers
 			s.hooks.before{{.HookName}}(ctx, baseMessage.ID, &request)
 			result, err = s.{{.HandlerFunc}}(ctx, baseMessage.ID, request)
 		}

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -72,6 +72,14 @@ func (s *MCPServer) HandleMessage(
 		)
 	}
 
+	// Get request header from ctx
+	h := ctx.Value(requestHeader)
+	headers, ok := h.(http.Header)
+
+	if headers == nil || !ok {
+		headers = make(http.Header)
+	}
+
 	switch baseMessage.Method {
 	case mcp.MethodInitialize:
 		var request mcp.InitializeRequest
@@ -83,6 +91,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeInitialize(ctx, baseMessage.ID, &request)
 			result, err = s.handleInitialize(ctx, baseMessage.ID, request)
 		}
@@ -102,6 +111,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforePing(ctx, baseMessage.ID, &request)
 			result, err = s.handlePing(ctx, baseMessage.ID, request)
 		}
@@ -127,6 +137,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeSetLevel(ctx, baseMessage.ID, &request)
 			result, err = s.handleSetLevel(ctx, baseMessage.ID, request)
 		}
@@ -152,6 +163,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeListResources(ctx, baseMessage.ID, &request)
 			result, err = s.handleListResources(ctx, baseMessage.ID, request)
 		}
@@ -177,6 +189,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeListResourceTemplates(ctx, baseMessage.ID, &request)
 			result, err = s.handleListResourceTemplates(ctx, baseMessage.ID, request)
 		}
@@ -202,6 +215,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeReadResource(ctx, baseMessage.ID, &request)
 			result, err = s.handleReadResource(ctx, baseMessage.ID, request)
 		}
@@ -227,6 +241,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeListPrompts(ctx, baseMessage.ID, &request)
 			result, err = s.handleListPrompts(ctx, baseMessage.ID, request)
 		}
@@ -252,6 +267,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeGetPrompt(ctx, baseMessage.ID, &request)
 			result, err = s.handleGetPrompt(ctx, baseMessage.ID, request)
 		}
@@ -277,6 +293,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			request.Header = headers
 			s.hooks.beforeListTools(ctx, baseMessage.ID, &request)
 			result, err = s.handleListTools(ctx, baseMessage.ID, request)
 		}
@@ -302,13 +319,7 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
-			headers := ctx.Value(requestHeader)
-			if headers != nil {
-				headers, ok := headers.(http.Header)
-				if ok {
-					request.Header = headers
-				}
-			}
+			request.Header = headers
 			s.hooks.beforeCallTool(ctx, baseMessage.ID, &request)
 			result, err = s.handleToolCall(ctx, baseMessage.ID, request)
 		}

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -301,6 +302,13 @@ func (s *MCPServer) HandleMessage(
 				err:  &UnparsableMessageError{message: message, err: unmarshalErr, method: baseMessage.Method},
 			}
 		} else {
+			headers := ctx.Value(requestHeader)
+			if headers != nil {
+				headers, ok := headers.(http.Header)
+				if ok {
+					request.Header = headers
+				}
+			}
 			s.hooks.beforeCallTool(ctx, baseMessage.ID, &request)
 			result, err = s.handleToolCall(ctx, baseMessage.ID, request)
 		}

--- a/server/sse.go
+++ b/server/sse.go
@@ -504,9 +504,8 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusAccepted)
 
 	// Create a new context for handling the message that will be canceled when the message handling is done
-	messageCtx, cancel := context.WithCancel(detachedCtx)
-
-	messageCtx = context.WithValue(messageCtx, requestHeader, r.Header)
+	messageCtx := context.WithValue(detachedCtx, requestHeader, r.Header)
+	messageCtx, cancel := context.WithCancel(messageCtx)
 
 	go func(ctx context.Context) {
 		defer cancel()

--- a/server/sse.go
+++ b/server/sse.go
@@ -506,6 +506,8 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 	// Create a new context for handling the message that will be canceled when the message handling is done
 	messageCtx, cancel := context.WithCancel(detachedCtx)
 
+	messageCtx = context.WithValue(messageCtx, requestHeader, r.Header)
+
 	go func(ctx context.Context) {
 		defer cancel()
 		// Use the context that will be canceled when session is done

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -268,6 +268,7 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	upgradedHeader := false
 	done := make(chan struct{})
 
+	ctx = context.WithValue(ctx, requestHeader, r.Header)
 	go func() {
 		for {
 			select {
@@ -309,8 +310,6 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 			}
 		}
 	}()
-
-	ctx = context.WithValue(ctx, requestHeader, r.Header)
 
 	// Process message through MCPServer
 	response := s.server.HandleMessage(ctx, rawData)

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -310,6 +310,8 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 		}
 	}()
 
+	ctx = context.WithValue(ctx, requestHeader, r.Header)
+
 	// Process message through MCPServer
 	response := s.server.HandleMessage(ctx, rawData)
 	if response == nil {

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -775,6 +775,59 @@ func TestStreamableHTTPServer_WithOptions(t *testing.T) {
 	})
 }
 
+func TestStreamableHTTP_HeaderPassthrough(t *testing.T) {
+    mcpServer := NewMCPServer("test-mcp-server", "1.0")
+    
+    var receivedHeaders struct {
+        contentType string
+        customHeader string
+    }
+    mcpServer.AddTool(
+        mcp.NewTool("check-headers"),
+        func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+            receivedHeaders.contentType = request.Header.Get("Content-Type")
+            receivedHeaders.customHeader = request.Header.Get("X-Custom-Header")
+            return mcp.NewToolResultText("ok"), nil
+        },
+    )
+
+    server := NewTestStreamableHTTPServer(mcpServer)
+    defer server.Close()
+
+    // Initialize to get session
+    resp, _ := postJSON(server.URL, initRequest)
+    sessionID := resp.Header.Get(headerKeySessionID)
+    resp.Body.Close()
+
+    // Test header passthrough
+    toolRequest := map[string]any{
+        "jsonrpc": "2.0",
+        "id":      2,
+        "method":  "tools/call",
+        "params": map[string]any{
+            "name": "check-headers",
+        },
+    }
+    toolBody, _ := json.Marshal(toolRequest)
+    req, _ := http.NewRequest("POST", server.URL, bytes.NewReader(toolBody))
+
+    const expectedContentType = "application/json"
+    const expectedCustomHeader = "test-value"
+    req.Header.Set("Content-Type", expectedContentType)
+    req.Header.Set("X-Custom-Header", expectedCustomHeader)
+    req.Header.Set(headerKeySessionID, sessionID)
+
+    resp, _ = server.Client().Do(req)
+    resp.Body.Close()
+
+    if receivedHeaders.contentType != expectedContentType {
+        t.Errorf("Expected Content-Type header '%s', got '%s'", expectedContentType, receivedHeaders.contentType)
+    }
+    if receivedHeaders.customHeader != expectedCustomHeader {
+        t.Errorf("Expected X-Custom-Header '%s', got '%s'", expectedCustomHeader, receivedHeaders.customHeader)
+    }
+}
+
 func postJSON(url string, bodyObject any) (*http.Response, error) {
 	jsonBody, _ := json.Marshal(bodyObject)
 	req, _ := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(jsonBody))

--- a/www/docs/pages/transports/http.mdx
+++ b/www/docs/pages/transports/http.mdx
@@ -652,7 +652,42 @@ type Claims struct {
 }
 ```
 
+### Request Headers
 
+The StreamableHTTP transport now passes HTTP request headers to MCP handlers. This allows you to access the original HTTP headers that were sent with the request in your tool and resource handlers.
+
+#### Accessing Headers in Handlers
+
+Headers are available in all MCP request objects:
+
+```go
+func handleGetUser(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    // Access request headers
+    headers := req.Header
+
+    // Use headers for authentication, tracing, etc.
+    authToken := headers.Get("Authorization")
+    if authToken == "" {
+        return nil, fmt.Errorf("authentication required")
+    }
+    
+    // Access other headers
+    requestID := headers.Get("X-Request-ID")
+    userAgent := headers.Get("User-Agent")
+    
+    // Rest of your handler code...
+}
+```
+
+This works for all MCP request types including:
+- `CallToolRequest`
+- `ReadResourceRequest`
+- `ListToolsRequest`
+- `ListResourcesRequest`
+- `InitializeRequest`
+- And other MCP request types
+
+The headers are automatically populated by the transport layer and are available in your handlers without any additional configuration.
 
 ## Next Steps
 

--- a/www/docs/pages/transports/sse.mdx
+++ b/www/docs/pages/transports/sse.mdx
@@ -80,6 +80,19 @@ func main() {
 }
 
 func handleStreamData(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    // Access request headers
+    headers := req.Header
+
+    // Use headers for authentication, tracing, etc.
+    authToken := headers.Get("Authorization")
+    if authToken == "" {
+        return nil, fmt.Errorf("authentication required")
+    }
+    
+    // Access other headers
+    requestID := headers.Get("X-Request-ID")
+    userAgent := headers.Get("User-Agent")
+    
     source := req.GetString("source", "")
     count := req.GetInt("count", 10)
 
@@ -318,6 +331,47 @@ mcpServer.SendNotificationToClient(ctx, "progress_update", progressData)
 // Send notification to all connected clients (if supported)
 // Note: Check the server implementation for broadcast capabilities
 ```
+
+### Request Headers
+
+Like the StreamableHTTP transport, the SSE transport passes HTTP request headers to MCP handlers. This allows you to access the original HTTP headers that were sent with the SSE connection in your tool and resource handlers.
+
+#### Accessing Headers in Handlers
+
+Headers from the SSE connection are available in all MCP request objects:
+
+```go
+func handleStreamData(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    // Access request headers
+    headers := req.Header
+
+    // Use headers for authentication, tracing, etc.
+    authToken := headers.Get("Authorization")
+    if authToken == "" {
+        return nil, fmt.Errorf("authentication required")
+    }
+    
+    // Access other headers
+    requestID := headers.Get("X-Request-ID")
+    userAgent := headers.Get("User-Agent")
+    
+    // Rest of your handler code...
+    mcpServer := server.ServerFromContext(ctx)
+    // ...
+}
+```
+
+This works for all MCP request types including:
+- `CallToolRequest`
+- `ReadResourceRequest`
+- `ListToolsRequest`
+- `ListResourcesRequest`
+- `InitializeRequest`
+- And other MCP request types
+
+The headers are automatically populated by the SSE transport layer from the initial SSE connection and are available in your handlers without any additional configuration.
+
+Note: Since SSE maintains a persistent connection, the headers are captured when the connection is established and remain the same for all requests during that connection's lifetime.
 
 ## Next Steps
 


### PR DESCRIPTION
## Description

HTTP header passthrough to Request struct.
This is useful for situations where out-of band information is passed by API Gateways and needs to be further passed on to downstream APIs.

## Type of Change


- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist


- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HTTP request headers are now automatically included in all MCP request objects, making them accessible to handlers for authentication, tracing, and other purposes across both HTTP and SSE transports.

* **Documentation**
  * Updated documentation for HTTP and SSE transports to describe how handlers can access HTTP request headers directly from request objects, with usage examples provided.

* **Tests**
  * Added new tests to verify correct propagation and availability of HTTP headers in tool requests for both HTTP and SSE transports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->