### PR TITLE
enhc(server): allow adding multiple resource templates at once

### DIFF
--- a/mcptest/mcptest.go
+++ b/mcptest/mcptest.go
@@ -23,7 +23,7 @@ type Server struct {
 	tools             []server.ServerTool
 	prompts           []server.ServerPrompt
 	resources         []server.ServerResource
-	resourceTemplates []ServerResourceTemplate
+	resourceTemplates []server.ServerResourceTemplate
 
 	cancel func()
 
@@ -107,22 +107,16 @@ func (s *Server) AddResources(resources ...server.ServerResource) {
 	s.resources = append(s.resources, resources...)
 }
 
-// ServerResourceTemplate combines a ResourceTemplate with its handler function.
-type ServerResourceTemplate struct {
-	Template mcp.ResourceTemplate
-	Handler  server.ResourceTemplateHandlerFunc
-}
-
 // AddResourceTemplate adds a resource template to an unstarted server.
 func (s *Server) AddResourceTemplate(template mcp.ResourceTemplate, handler server.ResourceTemplateHandlerFunc) {
-	s.resourceTemplates = append(s.resourceTemplates, ServerResourceTemplate{
+	s.resourceTemplates = append(s.resourceTemplates, server.ServerResourceTemplate{
 		Template: template,
 		Handler:  handler,
 	})
 }
 
 // AddResourceTemplates adds multiple resource templates to an unstarted server.
-func (s *Server) AddResourceTemplates(templates ...ServerResourceTemplate) {
+func (s *Server) AddResourceTemplates(templates ...server.ServerResourceTemplate) {
 	s.resourceTemplates = append(s.resourceTemplates, templates...)
 }
 
@@ -142,7 +136,7 @@ func (s *Server) Start(ctx context.Context) error {
 		mcpServer.AddTools(s.tools...)
 		mcpServer.AddPrompts(s.prompts...)
 		mcpServer.AddResources(s.resources...)
-		
+
 		for _, template := range s.resourceTemplates {
 			mcpServer.AddResourceTemplate(template.Template, template.Handler)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -64,6 +64,12 @@ type ServerResource struct {
 	Handler  ResourceHandlerFunc
 }
 
+// ServerResourceTemplate combines a ResourceTemplate with its handler function.
+type ServerResourceTemplate struct {
+	Template mcp.ResourceTemplate
+	Handler  ResourceTemplateHandlerFunc
+}
+
 // serverKey is the context key for storing the server instance
 type serverKey struct{}
 
@@ -360,17 +366,16 @@ func (s *MCPServer) RemoveResource(uri string) {
 	}
 }
 
-// AddResourceTemplate registers a new resource template and its handler
-func (s *MCPServer) AddResourceTemplate(
-	template mcp.ResourceTemplate,
-	handler ResourceTemplateHandlerFunc,
-) {
+// AddResourceTemplates registers multiple resource templates at once
+func (s *MCPServer) AddResourceTemplates(resourceTemplates ...ServerResourceTemplate) {
 	s.implicitlyRegisterResourceCapabilities()
 
 	s.resourcesMu.Lock()
-	s.resourceTemplates[template.URITemplate.Raw()] = resourceTemplateEntry{
-		template: template,
-		handler:  handler,
+	for _, entry := range resourceTemplates {
+		s.resourceTemplates[entry.Template.URITemplate.Raw()] = resourceTemplateEntry{
+			template: entry.Template,
+			handler:  entry.Handler,
+		}
 	}
 	s.resourcesMu.Unlock()
 
@@ -379,6 +384,14 @@ func (s *MCPServer) AddResourceTemplate(
 		// Send notification to all initialized sessions
 		s.SendNotificationToAllClients(mcp.MethodNotificationResourcesListChanged, nil)
 	}
+}
+
+// AddResourceTemplate registers a new resource template and its handler
+func (s *MCPServer) AddResourceTemplate(
+	template mcp.ResourceTemplate,
+	handler ResourceTemplateHandlerFunc,
+) {
+	s.AddResourceTemplates(ServerResourceTemplate{Template: template, Handler: handler})
 }
 
 // AddPrompts registers multiple prompts at once


### PR DESCRIPTION
## Description

Following the same pattern from tools, prompts and resources, this patch allows adding multiple resource templates at once.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information

The tests were already added by https://github.com/mark3labs/mcp-go/pull/449 .