### PR TITLE
feat(logging): add support for send log message notifications and implemented the `SessionWithLogging` interface on `streamableHttpSession`

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -761,6 +761,26 @@ const (
 	LoggingLevelEmergency LoggingLevel = "emergency"
 )
 
+var levelToInt = map[LoggingLevel]int{
+	LoggingLevelDebug:     0,
+	LoggingLevelInfo:      1,
+	LoggingLevelNotice:    2,
+	LoggingLevelWarning:   3,
+	LoggingLevelError:     4,
+	LoggingLevelCritical:  5,
+	LoggingLevelAlert:     6,
+	LoggingLevelEmergency: 7,
+}
+
+func (l LoggingLevel) ShouldSendTo(minLevel LoggingLevel) bool {
+	ia, oka := levelToInt[l]
+	ib, okb := levelToInt[minLevel]
+	if !oka || !okb {
+		return false
+	}
+	return ia >= ib
+}
+
 /* Sampling */
 
 const (

--- a/server/session.go
+++ b/server/session.go
@@ -247,7 +247,7 @@ func (s *MCPServer) sendNotificationCore(
 	default:
 		// Channel is blocked, if there's an error hook, use it
 		if s.hooks != nil && len(s.hooks.OnError) > 0 {
-			method := notification.Notification.Method
+			method := notification.Method
 			err := ErrNotificationChannelBlocked
 			// Copy hooks pointer to local variable to avoid race condition
 			hooks := s.hooks

--- a/server/session.go
+++ b/server/session.go
@@ -96,6 +96,110 @@ func (s *MCPServer) RegisterSession(
 	return nil
 }
 
+func (s *MCPServer) buildLogNotification(notification mcp.LoggingMessageNotification) mcp.JSONRPCNotification {
+	return mcp.JSONRPCNotification{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		Notification: mcp.Notification{
+			Method: notification.Method,
+			Params: mcp.NotificationParams{
+				AdditionalFields: map[string]any{
+					"level":  notification.Params.Level,
+					"logger": notification.Params.Logger,
+					"data":   notification.Params.Data,
+				},
+			},
+		},
+	}
+}
+
+func (s *MCPServer) SendLogMessageToClient(ctx context.Context, notification mcp.LoggingMessageNotification) error {
+	session := ClientSessionFromContext(ctx)
+	if session == nil || !session.Initialized() {
+		return ErrNotificationNotInitialized
+	}
+	sessionLogging, ok := session.(SessionWithLogging)
+	if !ok {
+		return ErrSessionDoesNotSupportLogging
+	}
+	if !notification.Params.Level.ShouldSendTo(sessionLogging.GetLogLevel()) {
+		return nil
+	}
+	return s.sendNotificationCore(ctx, session, s.buildLogNotification(notification))
+}
+
+func (s *MCPServer) sendNotificationToAllClients(notification mcp.JSONRPCNotification) {
+	s.sessions.Range(func(k, v any) bool {
+		if session, ok := v.(ClientSession); ok && session.Initialized() {
+			select {
+			case session.NotificationChannel() <- notification:
+				// Successfully sent notification
+			default:
+				// Channel is blocked, if there's an error hook, use it
+				if s.hooks != nil && len(s.hooks.OnError) > 0 {
+					err := ErrNotificationChannelBlocked
+					// Copy hooks pointer to local variable to avoid race condition
+					hooks := s.hooks
+					go func(sessionID string, hooks *Hooks) {
+						ctx := context.Background()
+						// Use the error hook to report the blocked channel
+						hooks.onError(ctx, nil, "notification", map[string]any{
+							"method":    notification.Method,
+							"sessionID": sessionID,
+						}, fmt.Errorf("notification channel blocked for session %s: %w", sessionID, err))
+					}(session.SessionID(), hooks)
+				}
+			}
+		}
+		return true
+	})
+}
+
+func (s *MCPServer) sendNotificationToSpecificClient(session ClientSession, notification mcp.JSONRPCNotification) error {
+	// upgrades the client-server communication to SSE stream when the server sends notifications to the client
+	if sessionWithStreamableHTTPConfig, ok := session.(SessionWithStreamableHTTPConfig); ok {
+		sessionWithStreamableHTTPConfig.UpgradeToSSEWhenReceiveNotification()
+	}
+	select {
+	case session.NotificationChannel() <- notification:
+		return nil
+	default:
+		// Channel is blocked, if there's an error hook, use it
+		if s.hooks != nil && len(s.hooks.OnError) > 0 {
+			err := ErrNotificationChannelBlocked
+			ctx := context.Background()
+			// Copy hooks pointer to local variable to avoid race condition
+			hooks := s.hooks
+			go func(sID string, hooks *Hooks) {
+				// Use the error hook to report the blocked channel
+				hooks.onError(ctx, nil, "notification", map[string]any{
+					"method":    notification.Method,
+					"sessionID": sID,
+				}, fmt.Errorf("notification channel blocked for session %s: %w", sID, err))
+			}(session.SessionID(), hooks)
+		}
+		return ErrNotificationChannelBlocked
+	}
+}
+
+func (s *MCPServer) SendLogMessageToSpecificClient(sessionID string, notification mcp.LoggingMessageNotification) error {
+	sessionValue, ok := s.sessions.Load(sessionID)
+	if !ok {
+		return ErrSessionNotFound
+	}
+	session, ok := sessionValue.(ClientSession)
+	if !ok || !session.Initialized() {
+		return ErrSessionNotInitialized
+	}
+	sessionLogging, ok := session.(SessionWithLogging)
+	if !ok {
+		return ErrSessionDoesNotSupportLogging
+	}
+	if !notification.Params.Level.ShouldSendTo(sessionLogging.GetLogLevel()) {
+		return nil
+	}
+	return s.sendNotificationToSpecificClient(session, s.buildLogNotification(notification))
+}
+
 // UnregisterSession removes from storage session that is shut down.
 func (s *MCPServer) UnregisterSession(
 	ctx context.Context,
@@ -124,65 +228,26 @@ func (s *MCPServer) SendNotificationToAllClients(
 			},
 		},
 	}
-
-	s.sessions.Range(func(k, v any) bool {
-		if session, ok := v.(ClientSession); ok && session.Initialized() {
-			select {
-			case session.NotificationChannel() <- notification:
-				// Successfully sent notification
-			default:
-				// Channel is blocked, if there's an error hook, use it
-				if s.hooks != nil && len(s.hooks.OnError) > 0 {
-					err := ErrNotificationChannelBlocked
-					// Copy hooks pointer to local variable to avoid race condition
-					hooks := s.hooks
-					go func(sessionID string, hooks *Hooks) {
-						ctx := context.Background()
-						// Use the error hook to report the blocked channel
-						hooks.onError(ctx, nil, "notification", map[string]any{
-							"method":    method,
-							"sessionID": sessionID,
-						}, fmt.Errorf("notification channel blocked for session %s: %w", sessionID, err))
-					}(session.SessionID(), hooks)
-				}
-			}
-		}
-		return true
-	})
+	s.sendNotificationToAllClients(notification)
 }
 
 // SendNotificationToClient sends a notification to the current client
-func (s *MCPServer) SendNotificationToClient(
+func (s *MCPServer) sendNotificationCore(
 	ctx context.Context,
-	method string,
-	params map[string]any,
+	session ClientSession,
+	notification mcp.JSONRPCNotification,
 ) error {
-	session := ClientSessionFromContext(ctx)
-	if session == nil || !session.Initialized() {
-		return ErrNotificationNotInitialized
-	}
-
 	// upgrades the client-server communication to SSE stream when the server sends notifications to the client
 	if sessionWithStreamableHTTPConfig, ok := session.(SessionWithStreamableHTTPConfig); ok {
 		sessionWithStreamableHTTPConfig.UpgradeToSSEWhenReceiveNotification()
 	}
-
-	notification := mcp.JSONRPCNotification{
-		JSONRPC: mcp.JSONRPC_VERSION,
-		Notification: mcp.Notification{
-			Method: method,
-			Params: mcp.NotificationParams{
-				AdditionalFields: params,
-			},
-		},
-	}
-
 	select {
 	case session.NotificationChannel() <- notification:
 		return nil
 	default:
 		// Channel is blocked, if there's an error hook, use it
 		if s.hooks != nil && len(s.hooks.OnError) > 0 {
+			method := notification.Notification.Method
 			err := ErrNotificationChannelBlocked
 			// Copy hooks pointer to local variable to avoid race condition
 			hooks := s.hooks
@@ -198,6 +263,28 @@ func (s *MCPServer) SendNotificationToClient(
 	}
 }
 
+// SendNotificationToClient sends a notification to the current client
+func (s *MCPServer) SendNotificationToClient(
+	ctx context.Context,
+	method string,
+	params map[string]any,
+) error {
+	session := ClientSessionFromContext(ctx)
+	if session == nil || !session.Initialized() {
+		return ErrNotificationNotInitialized
+	}
+	notification := mcp.JSONRPCNotification{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		Notification: mcp.Notification{
+			Method: method,
+			Params: mcp.NotificationParams{
+				AdditionalFields: params,
+			},
+		},
+	}
+	return s.sendNotificationCore(ctx, session, notification)
+}
+
 // SendNotificationToSpecificClient sends a notification to a specific client by session ID
 func (s *MCPServer) SendNotificationToSpecificClient(
 	sessionID string,
@@ -208,17 +295,10 @@ func (s *MCPServer) SendNotificationToSpecificClient(
 	if !ok {
 		return ErrSessionNotFound
 	}
-
 	session, ok := sessionValue.(ClientSession)
 	if !ok || !session.Initialized() {
 		return ErrSessionNotInitialized
 	}
-
-	// upgrades the client-server communication to SSE stream when the server sends notifications to the client
-	if sessionWithStreamableHTTPConfig, ok := session.(SessionWithStreamableHTTPConfig); ok {
-		sessionWithStreamableHTTPConfig.UpgradeToSSEWhenReceiveNotification()
-	}
-
 	notification := mcp.JSONRPCNotification{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		Notification: mcp.Notification{
@@ -228,27 +308,7 @@ func (s *MCPServer) SendNotificationToSpecificClient(
 			},
 		},
 	}
-
-	select {
-	case session.NotificationChannel() <- notification:
-		return nil
-	default:
-		// Channel is blocked, if there's an error hook, use it
-		if s.hooks != nil && len(s.hooks.OnError) > 0 {
-			err := ErrNotificationChannelBlocked
-			ctx := context.Background()
-			// Copy hooks pointer to local variable to avoid race condition
-			hooks := s.hooks
-			go func(sID string, hooks *Hooks) {
-				// Use the error hook to report the blocked channel
-				hooks.onError(ctx, nil, "notification", map[string]any{
-					"method":    method,
-					"sessionID": sID,
-				}, fmt.Errorf("notification channel blocked for session %s: %w", sID, err))
-			}(sessionID, hooks)
-		}
-		return ErrNotificationChannelBlocked
-	}
+	return s.sendNotificationToSpecificClient(session, notification)
 }
 
 // AddSessionTool adds a tool for a specific session

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -129,6 +129,7 @@ type StreamableHTTPServer struct {
 	sessionIdManager        SessionIdManager
 	listenHeartbeatInterval time.Duration
 	logger                  util.Logger
+	sessionLogLevels        *sessionLogLevelsStore
 }
 
 // NewStreamableHTTPServer creates a new streamable-http server instance
@@ -136,6 +137,7 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 	s := &StreamableHTTPServer{
 		server:           server,
 		sessionTools:     newSessionToolsStore(),
+		sessionLogLevels: newSessionLogLevelsStore(),
 		endpointPath:     "/mcp",
 		sessionIdManager: &InsecureStatefulSessionIdManager{},
 		logger:           util.DefaultLogger(),
@@ -255,7 +257,7 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 		}
 	}
 
-	session := newStreamableHttpSession(sessionID, s.sessionTools)
+	session := newStreamableHttpSession(sessionID, s.sessionTools, s.sessionLogLevels)
 
 	// Set the client context before handling the message
 	ctx := s.server.WithContext(r.Context(), session)
@@ -365,7 +367,7 @@ func (s *StreamableHTTPServer) handleGet(w http.ResponseWriter, r *http.Request)
 		sessionID = uuid.New().String()
 	}
 
-	session := newStreamableHttpSession(sessionID, s.sessionTools)
+	session := newStreamableHttpSession(sessionID, s.sessionTools, s.sessionLogLevels)
 	if err := s.server.RegisterSession(r.Context(), session); err != nil {
 		http.Error(w, fmt.Sprintf("Session registration failed: %v", err), http.StatusBadRequest)
 		return
@@ -468,7 +470,7 @@ func (s *StreamableHTTPServer) handleDelete(w http.ResponseWriter, r *http.Reque
 
 	// remove the session relateddata from the sessionToolsStore
 	s.sessionTools.delete(sessionID)
-
+	s.sessionLogLevels.delete(sessionID)
 	// remove current session's requstID information
 	s.sessionRequestIDs.Delete(sessionID)
 
@@ -511,6 +513,38 @@ func (s *StreamableHTTPServer) nextRequestID(sessionID string) int64 {
 }
 
 // --- session ---
+type sessionLogLevelsStore struct {
+	mu   sync.RWMutex
+	logs map[string]mcp.LoggingLevel
+}
+
+func newSessionLogLevelsStore() *sessionLogLevelsStore {
+	return &sessionLogLevelsStore{
+		logs: make(map[string]mcp.LoggingLevel),
+	}
+}
+
+func (s *sessionLogLevelsStore) get(sessionID string) mcp.LoggingLevel {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	val, ok := s.logs[sessionID]
+	if !ok {
+		return mcp.LoggingLevelError
+	}
+	return val
+}
+
+func (s *sessionLogLevelsStore) set(sessionID string, level mcp.LoggingLevel) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.logs[sessionID] = level
+}
+
+func (s *sessionLogLevelsStore) delete(sessionID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.logs, sessionID)
+}
 
 type sessionToolsStore struct {
 	mu    sync.RWMutex
@@ -549,14 +583,17 @@ type streamableHttpSession struct {
 	notificationChannel chan mcp.JSONRPCNotification // server -> client notifications
 	tools               *sessionToolsStore
 	upgradeToSSE        atomic.Bool
+	logLevels           *sessionLogLevelsStore
 }
 
-func newStreamableHttpSession(sessionID string, toolStore *sessionToolsStore) *streamableHttpSession {
-	return &streamableHttpSession{
+func newStreamableHttpSession(sessionID string, toolStore *sessionToolsStore, levels *sessionLogLevelsStore) *streamableHttpSession {
+	s := &streamableHttpSession{
 		sessionID:           sessionID,
 		notificationChannel: make(chan mcp.JSONRPCNotification, 100),
 		tools:               toolStore,
+		logLevels:           levels,
 	}
+	return s
 }
 
 func (s *streamableHttpSession) SessionID() string {
@@ -577,6 +614,14 @@ func (s *streamableHttpSession) Initialized() bool {
 	return true
 }
 
+func (s *streamableHttpSession) SetLogLevel(level mcp.LoggingLevel) {
+	s.logLevels.set(s.sessionID, level)
+}
+
+func (s *streamableHttpSession) GetLogLevel() mcp.LoggingLevel {
+	return s.logLevels.get(s.sessionID)
+}
+
 var _ ClientSession = (*streamableHttpSession)(nil)
 
 func (s *streamableHttpSession) GetSessionTools() map[string]ServerTool {
@@ -587,7 +632,10 @@ func (s *streamableHttpSession) SetSessionTools(tools map[string]ServerTool) {
 	s.tools.set(s.sessionID, tools)
 }
 
-var _ SessionWithTools = (*streamableHttpSession)(nil)
+var (
+	_ SessionWithTools   = (*streamableHttpSession)(nil)
+	_ SessionWithLogging = (*streamableHttpSession)(nil)
+)
 
 func (s *streamableHttpSession) UpgradeToSSEWhenReceiveNotification() {
 	s.upgradeToSSE.Store(true)
@@ -615,10 +663,12 @@ type StatelessSessionIdManager struct{}
 func (s *StatelessSessionIdManager) Generate() string {
 	return ""
 }
+
 func (s *StatelessSessionIdManager) Validate(sessionID string) (isTerminated bool, err error) {
 	// In stateless mode, ignore session IDs completely - don't validate or reject them
 	return false, nil
 }
+
 func (s *StatelessSessionIdManager) Terminate(sessionID string) (isNotAllowed bool, err error) {
 	return false, nil
 }
@@ -633,6 +683,7 @@ const idPrefix = "mcp-session-"
 func (s *InsecureStatefulSessionIdManager) Generate() string {
 	return idPrefix + uuid.New().String()
 }
+
 func (s *InsecureStatefulSessionIdManager) Validate(sessionID string) (isTerminated bool, err error) {
 	// validate the session id is a valid uuid
 	if !strings.HasPrefix(sessionID, idPrefix) {
@@ -643,6 +694,7 @@ func (s *InsecureStatefulSessionIdManager) Validate(sessionID string) (isTermina
 	}
 	return false, nil
 }
+
 func (s *InsecureStatefulSessionIdManager) Terminate(sessionID string) (isNotAllowed bool, err error) {
 	return false, nil
 }


### PR DESCRIPTION
- Introduced `LoggingLevel.ShouldSendTo` for log level comparison
- Added `SendLogMessageToSpecificClient` to send log notifications to a specific client
- Added `SendLogMessageToClient` to send log notifications to the current session client
- Implemented `SessionWithLogging` interface for `streamableHttpSession`
- Added `sessionLogLevelsStore` to manage per-session log levels
- Updated `StreamableHTTPServer` to support setting and retrieving log levels
- Added tests covering log notification sending logic and format validation

## Description
This PR adds support for sent structured log message notifications in MCP sessions.
This enables server-to-client structured logging over the MCP notification channel, respecting the client’s configured verbosity.

For example:
```go
	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mm.CallToolRequest, result *mm.CallToolResult) {
		s := ms.ServerFromContext(ctx)
		notification := mm.NewLoggingMessageNotification(
			mm.LoggingLevelError,
			"added tool",
			map[string]any{
				"tool": message.Params,
			},
		)
		err := s.SendLogMessageToClient(ctx, notification)
		if err != nil {
			log.Printf("Failed to send notification: %v", err)
		}
	})
```

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [issue](https://github.com/mark3labs/mcp-go/issues/12)
- [x] Implementation follows the specification exactly

## Additional Information
This PR lays the foundation for server-driven structured logging toward clients via MCP protocol. It supports log filtering by level and ensures format consistency for different `data` . The mechanism respects client preferences and ensures graceful degradation in unsupported or uninitialized cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced per-session logging level management, allowing sessions to set and retrieve their own log levels.
  * Added support for sending log notifications to clients based on their configured log level.

* **Bug Fixes**
  * Improved error handling when sending log messages to uninitialized or unsupported sessions.

* **Tests**
  * Added comprehensive tests for logging notification delivery, log level filtering, and notification formatting.
  * Introduced tests to verify session log level management and correct propagation of logging level changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->