### PR TITLE
refactor: replace fmt.Errorf with TransportError wrapper

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -39,7 +39,7 @@ func WithClientCapabilities(capabilities mcp.ClientCapabilities) ClientOption {
 func WithSamplingHandler(handler SamplingHandler) ClientOption {
 	return func(c *Client) {
 		c.samplingHandler = handler
-  }
+	}
 }
 
 // WithSession assumes a MCP Session has already been initialized
@@ -133,7 +133,7 @@ func (c *Client) sendRequest(
 
 	response, err := c.transport.SendRequest(ctx, request)
 	if err != nil {
-		return nil, fmt.Errorf("transport error: %w", err)
+		return nil, transport.NewError(err)
 	}
 
 	if response.Error != nil {

--- a/client/transport/error.go
+++ b/client/transport/error.go
@@ -1,0 +1,22 @@
+package transport
+
+import "fmt"
+
+// Error wraps a low-level transport error in a concrete type.
+type Error struct {
+	Err error
+}
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("transport error %v", e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	return e.Err
+}
+
+func NewError(err error) *Error {
+	return &Error{
+		Err: err,
+	}
+}

--- a/client/transport/error.go
+++ b/client/transport/error.go
@@ -8,7 +8,7 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("transport error %v", e.Err)
+	return fmt.Sprintf("transport error: %v", e.Err)
 }
 
 func (e *Error) Unwrap() error {


### PR DESCRIPTION
## Description
Refactor transport error handling to introduce a typed `TransportError` instead of generic `fmt.Errorf` wrapping. This allows callers to reliably detect and handle transport-level errors via Go’s standard error inspection (errors.As).

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages for transport failures to provide clearer information to users.

* **Refactor**
  * Enhanced internal error handling for transport-related issues, ensuring more consistent error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->