### PR TITLE
Embed client capabilities into the Session

### DIFF
--- a/server/inprocess_session.go
+++ b/server/inprocess_session.go
@@ -16,13 +16,14 @@ type SamplingHandler interface {
 }
 
 type InProcessSession struct {
-	sessionID       string
-	notifications   chan mcp.JSONRPCNotification
-	initialized     atomic.Bool
-	loggingLevel    atomic.Value
-	clientInfo      atomic.Value
-	samplingHandler SamplingHandler
-	mu              sync.RWMutex
+	sessionID          string
+	notifications      chan mcp.JSONRPCNotification
+	initialized        atomic.Bool
+	loggingLevel       atomic.Value
+	clientInfo         atomic.Value
+	clientCapabilities atomic.Value
+	samplingHandler    SamplingHandler
+	mu                 sync.RWMutex
 }
 
 func NewInProcessSession(sessionID string, samplingHandler SamplingHandler) *InProcessSession {
@@ -61,6 +62,19 @@ func (s *InProcessSession) GetClientInfo() mcp.Implementation {
 
 func (s *InProcessSession) SetClientInfo(clientInfo mcp.Implementation) {
 	s.clientInfo.Store(clientInfo)
+}
+
+func (s *InProcessSession) GetClientCapabilities() mcp.ClientCapabilities {
+	if value := s.clientCapabilities.Load(); value != nil {
+		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
+			return clientCapabilities
+		}
+	}
+	return mcp.ClientCapabilities{}
+}
+
+func (s *InProcessSession) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
+	s.clientCapabilities.Store(clientCapabilities)
 }
 
 func (s *InProcessSession) SetLogLevel(level mcp.LoggingLevel) {

--- a/server/server.go
+++ b/server/server.go
@@ -583,8 +583,10 @@ func (s *MCPServer) handleInitialize(
 		// Store client info if the session supports it
 		if sessionWithClientInfo, ok := session.(SessionWithClientInfo); ok {
 			sessionWithClientInfo.SetClientInfo(request.Params.ClientInfo)
+			sessionWithClientInfo.SetClientCapabilities(request.Params.Capabilities)
 		}
 	}
+
 	return &result, nil
 }
 

--- a/server/session.go
+++ b/server/session.go
@@ -46,6 +46,10 @@ type SessionWithClientInfo interface {
 	GetClientInfo() mcp.Implementation
 	// SetClientInfo sets the client information for this session
 	SetClientInfo(clientInfo mcp.Implementation)
+	// GetClientCapabilities returns the client capabilities for this session
+	GetClientCapabilities() mcp.ClientCapabilities
+	// SetClientCapabilities sets the client capabilities for this session
+	SetClientCapabilities(clientCapabilities mcp.ClientCapabilities)
 }
 
 // SessionWithStreamableHTTPConfig extends ClientSession to support streamable HTTP transport configurations

--- a/server/sse.go
+++ b/server/sse.go
@@ -30,7 +30,7 @@ type sseSession struct {
 	loggingLevel        atomic.Value
 	tools               sync.Map     // stores session-specific tools
 	clientInfo          atomic.Value // stores session-specific client info
-	clientCapabilities  atomic.Value // stores session-specific client capaabilities
+	clientCapabilities  atomic.Value // stores session-specific client capabilities
 }
 
 // SSEContextFunc is a function that takes an existing context and the current

--- a/server/sse.go
+++ b/server/sse.go
@@ -30,6 +30,7 @@ type sseSession struct {
 	loggingLevel        atomic.Value
 	tools               sync.Map     // stores session-specific tools
 	clientInfo          atomic.Value // stores session-specific client info
+	clientCapabilities  atomic.Value // stores session-specific client capaabilities
 }
 
 // SSEContextFunc is a function that takes an existing context and the current
@@ -106,6 +107,19 @@ func (s *sseSession) GetClientInfo() mcp.Implementation {
 
 func (s *sseSession) SetClientInfo(clientInfo mcp.Implementation) {
 	s.clientInfo.Store(clientInfo)
+}
+
+func (s *sseSession) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
+	s.clientCapabilities.Store(clientCapabilities)
+}
+
+func (s *sseSession) GetClientCapabilities() mcp.ClientCapabilities {
+	if value := s.clientCapabilities.Load(); value != nil {
+		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
+			return clientCapabilities
+		}
+	}
+	return mcp.ClientCapabilities{}
 }
 
 var (

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -103,8 +103,8 @@ func (s *stdioSession) SetClientInfo(clientInfo mcp.Implementation) {
 
 func (s *stdioSession) GetClientCapabilities() mcp.ClientCapabilities {
 	if value := s.clientCapabilities.Load(); value != nil {
-		if clientInfo, ok := value.(mcp.ClientCapabilities); ok {
-			return clientInfo
+		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
+			return clientCapabilities
 		}
 	}
 	return mcp.ClientCapabilities{}

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -52,15 +52,16 @@ func WithStdioContextFunc(fn StdioContextFunc) StdioOption {
 
 // stdioSession is a static client session, since stdio has only one client.
 type stdioSession struct {
-	notifications   chan mcp.JSONRPCNotification
-	initialized     atomic.Bool
-	loggingLevel    atomic.Value
-	clientInfo      atomic.Value                     // stores session-specific client info
-	writer          io.Writer                        // for sending requests to client
-	requestID       atomic.Int64                     // for generating unique request IDs
-	mu              sync.RWMutex                     // protects writer
-	pendingRequests map[int64]chan *samplingResponse // for tracking pending sampling requests
-	pendingMu       sync.RWMutex                     // protects pendingRequests
+	notifications      chan mcp.JSONRPCNotification
+	initialized        atomic.Bool
+	loggingLevel       atomic.Value
+	clientInfo         atomic.Value                     // stores session-specific client info
+	clientCapabilities atomic.Value                     // stores session-specific client capabilities
+	writer             io.Writer                        // for sending requests to client
+	requestID          atomic.Int64                     // for generating unique request IDs
+	mu                 sync.RWMutex                     // protects writer
+	pendingRequests    map[int64]chan *samplingResponse // for tracking pending sampling requests
+	pendingMu          sync.RWMutex                     // protects pendingRequests
 }
 
 // samplingResponse represents a response to a sampling request
@@ -98,6 +99,19 @@ func (s *stdioSession) GetClientInfo() mcp.Implementation {
 
 func (s *stdioSession) SetClientInfo(clientInfo mcp.Implementation) {
 	s.clientInfo.Store(clientInfo)
+}
+
+func (s *stdioSession) GetClientCapabilities() mcp.ClientCapabilities {
+	if value := s.clientCapabilities.Load(); value != nil {
+		if clientInfo, ok := value.(mcp.ClientCapabilities); ok {
+			return clientInfo
+		}
+	}
+	return mcp.ClientCapabilities{}
+}
+
+func (s *stdioSession) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
+	s.clientCapabilities.Store(clientCapabilities)
 }
 
 func (s *stdioSession) SetLogLevel(level mcp.LoggingLevel) {

--- a/www/docs/pages/servers/advanced.mdx
+++ b/www/docs/pages/servers/advanced.mdx
@@ -821,6 +821,56 @@ func startWithGracefulShutdown(s *server.MCPServer) {
 }
 ```
 
+## Client Capability Based Filtering
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+
+    "github.com/mark3labs/mcp-go/mcp"
+    "github.com/mark3labs/mcp-go/server"
+)
+
+func main() {
+    s := server.NewMCPServer("Typed Server", "1.0.0",
+        server.WithToolCapabilities(true),
+    )
+
+     s.AddTool(
+        mcp.NewTool("calculate",
+            mcp.WithDescription("Perform basic mathematical calculations"),
+            mcp.WithString("operation",
+                mcp.Required(),
+                mcp.Enum("add", "subtract", "multiply", "divide"),
+                mcp.Description("The operation to perform"),
+            ),
+            mcp.WithNumber("x", mcp.Required(), mcp.Description("First number")),
+            mcp.WithNumber("y", mcp.Required(), mcp.Description("Second number")),
+        ),
+        handleCalculate,
+    )
+
+    server.ServeStdio(s)
+}
+
+func handleCalculate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    session := server.ClientSessionFromContext(ctx)
+	if session == nil {
+		return nil, fmt.Errorf("no active session")
+	}
+
+	if clientSession, ok := session.(server.SessionWithClientInfo); ok {
+             clientCapabilities := clientSession.GetClientCapabilities()
+			 if clientCapabilities.Sampling == nil {
+				 fmt.Println("sampling is not enabled in client")
+			 }
+	}
+}
+```
+
 ## Sampling (Advanced)
 
 Sampling is an advanced feature that allows servers to request LLM completions from clients. This enables bidirectional communication where servers can leverage client-side LLM capabilities for content generation, reasoning, and question answering.

--- a/www/docs/pages/servers/advanced.mdx
+++ b/www/docs/pages/servers/advanced.mdx
@@ -868,6 +868,9 @@ func handleCalculate(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToo
 				 fmt.Println("sampling is not enabled in client")
 			 }
 	}
+
+    // TODO: implement calculation logic
+    return mcp.NewToolResultError("not implemented"), nil
 }
 ```
 


### PR DESCRIPTION
## Description
Client sends its capabilities during the initialization step.

This PR embeds the client capabilities into the client session  in this step to enable subsequent executions are able to check the client capabilities to determine what actions they can perform. For instance, MCP Server checks the support of elicitation. If elicitation is supported by the client, MCP Server can send elicitation request.

Fixes #https://github.com/mark3labs/mcp-go/issues/144

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now store and retrieve client capabilities, enabling improved client feature awareness.
  * Added documentation with an example demonstrating client capability-based filtering for tool execution.
* **Tests**
  * Verified correct storage and retrieval of client capabilities during session initialization.
* **Style**
  * Minor formatting improvements in test case naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->