### PR TITLE
fix: check if resp is nil on error for initialize methods

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -252,12 +252,14 @@ func (c *StreamableHTTP) SendRequest(
 			return nil, fmt.Errorf("failed to send request: %w", err)
 		}
 	}
+
+	// Only proceed if we have a valid response.
 	// When sendHTTP fails and resp is nil but method is mcp.MethodInitialize
 	// defer resp.Body.Close() fails with nil pointer dereference.
-	// TODO: Restructure this fallthrough logic properly.
-	if resp != nil {
-		defer resp.Body.Close()
+	if resp == nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
 	}
+	defer resp.Body.Close()
 
 	// Check if we got an error response
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -252,7 +252,12 @@ func (c *StreamableHTTP) SendRequest(
 			return nil, fmt.Errorf("failed to send request: %w", err)
 		}
 	}
-	defer resp.Body.Close()
+	// When sendHTTP fails and resp is nil but method is mcp.MethodInitialize
+	// defer resp.Body.Close() fails with nil pointer dereference.
+	// TODO: Restructure this fallthrough logic properly.
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	// Check if we got an error response
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusAccepted {


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->

Fixes the nil pointer dereference error when sendHTTP fails but the method is initialize and the resp is nil.

Ideally, we might need to rethink this to handle carefully.

There's also a race condition in the test which surfaced when I made this change. That is also fixed.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare issue that could cause the application to crash during certain request initializations.
  * Improved reliability of internal processes by enhancing test synchronization methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->