### PR TITLE
feat: open content interface for users to freely implement

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -8,8 +8,9 @@ import (
 	"maps"
 	"strconv"
 
-	"github.com/yosida95/uritemplate/v3"
 	"net/http"
+
+	"github.com/yosida95/uritemplate/v3"
 )
 
 type MCPMethod string
@@ -859,7 +860,7 @@ type Annotated struct {
 }
 
 type Content interface {
-	isContent()
+	IsContent()
 }
 
 // TextContent represents text provided to or from an LLM.
@@ -871,7 +872,7 @@ type TextContent struct {
 	Text string `json:"text"`
 }
 
-func (TextContent) isContent() {}
+func (TextContent) IsContent() {}
 
 // ImageContent represents an image provided to or from an LLM.
 // It must have Type set to "image".
@@ -884,7 +885,7 @@ type ImageContent struct {
 	MIMEType string `json:"mimeType"`
 }
 
-func (ImageContent) isContent() {}
+func (ImageContent) IsContent() {}
 
 // AudioContent represents the contents of audio, embedded into a prompt or tool call result.
 // It must have Type set to "audio".
@@ -897,7 +898,7 @@ type AudioContent struct {
 	MIMEType string `json:"mimeType"`
 }
 
-func (AudioContent) isContent() {}
+func (AudioContent) IsContent() {}
 
 // ResourceLink represents a link to a resource that the client can access.
 type ResourceLink struct {
@@ -913,7 +914,7 @@ type ResourceLink struct {
 	MIMEType string `json:"mimeType"`
 }
 
-func (ResourceLink) isContent() {}
+func (ResourceLink) IsContent() {}
 
 // EmbeddedResource represents the contents of a resource, embedded into a prompt or tool call result.
 //
@@ -925,7 +926,7 @@ type EmbeddedResource struct {
 	Resource ResourceContents `json:"resource"`
 }
 
-func (EmbeddedResource) isContent() {}
+func (EmbeddedResource) IsContent() {}
 
 // ModelPreferences represents the server's preferences for model selection,
 // requested of the client during sampling.


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->

Features: make pepole easy to customize Cotent interface

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
1. Exposing the IsContent method through the public content interface empowers users to define custom content types, ensuring seamless compatibility with diverse response scenarios.
