### PR TITLE
Fix race condition in stdio.SendRequest with canceled context

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -307,6 +307,13 @@ func (c *Stdio) SendRequest(
 	ctx context.Context,
 	request JSONRPCRequest,
 ) (*JSONRPCResponse, error) {
+	// Check if context is already canceled before doing any work
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
 	if c.stdin == nil {
 		return nil, fmt.Errorf("stdio client not started")
 	}


### PR DESCRIPTION
## Summary
- Fix race condition where `stdio.SendRequest` could return `nil` instead of `context.Canceled` error
- Add early context cancellation check before any I/O operations
- Ensures consistent behavior across different environments (fixes GitHub Actions test failures)

## Test plan
- [x] Run `go test -race -v ./client/transport -run TestStdio/SendRequestWithTimeout`
- [x] Verify test passes locally with race detector enabled
- [x] CI tests should now pass consistently

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling to immediately stop processing if the operation has already been canceled, resulting in more efficient behavior and faster error reporting in canceled scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->