### PR TITLE
feat: add SessionWithParams interface for URL query parameter access

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -48,6 +48,13 @@ type SessionWithClientInfo interface {
 	SetClientInfo(clientInfo mcp.Implementation)
 }
 
+// SessionWithParams is an extension of ClientSession that can store session parameters
+type SessionWithParams interface {
+	ClientSession
+	// Params returns the parameters associated with the session.
+	Params() map[string]string
+}
+
 // SessionWithStreamableHTTPConfig extends ClientSession to support streamable HTTP transport configurations
 type SessionWithStreamableHTTPConfig interface {
 	ClientSession


### PR DESCRIPTION
## Description
- Add SessionWithParams interface to session.go for accessing URL query parameters
- Implement Params() method in SSE and StreamableHTTP sessions to parse query parameters
- Add comprehensive tests for parameter parsing with concurrent access protection
- Support special characters and empty parameter scenarios

This enables server.WithToolFilter and other middleware to access session-specific parameters like tenant_id, user_id, or environment from URL query strings, allowing for fine-grained filtering and context-aware tool execution.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions now capture and expose URL query parameters, making them accessible during tool execution in both SSE and Streamable HTTP endpoints.

* **Bug Fixes**
  * Ensured thread-safe access and copying of session parameters to prevent unintended modifications.

* **Tests**
  * Added comprehensive tests to verify correct parsing, storage, and retrieval of session parameters, including concurrent access and edge cases with special characters or empty parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->