### PR TITLE
Fix SSE transport not properly handling HTTP/2 NO_ERROR disconnections

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,7 @@ For examples, see the [`examples/`](examples/) directory.
 
 ### Transports
 
-MCP-Go supports stdio, SSE and streamable-HTTP transport layers.
+MCP-Go supports stdio, SSE and streamable-HTTP transport layers. For SSE transport, you can use `SetConnectionLostHandler()` to detect and handle HTTP/2 idle timeout disconnections (NO_ERROR) for implementing reconnection logic.
 
 ### Session Management
 

--- a/client/client.go
+++ b/client/client.go
@@ -111,6 +111,17 @@ func (c *Client) OnNotification(
 	c.notifications = append(c.notifications, handler)
 }
 
+// OnConnectionLost registers a handler function to be called when the connection is lost.
+// This is useful for handling HTTP2 idle timeout disconnections that should not be treated as errors.
+func (c *Client) OnConnectionLost(handler func(error)) {
+	type connectionLostSetter interface {
+		SetConnectionLostHandler(func(error))
+	}
+	if setter, ok := c.transport.(connectionLostSetter); ok {
+		setter.SetConnectionLostHandler(handler)
+	}
+}
+
 // sendRequest sends a JSON-RPC request to the server and waits for a response.
 // Returns the raw JSON response message or an error if the request fails.
 func (c *Client) sendRequest(

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +16,39 @@ import (
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// mockReaderWithError is a mock io.ReadCloser that simulates reading some data
+// and then returning a specific error
+type mockReaderWithError struct {
+	data     []byte
+	err      error
+	position int
+	closed   bool
+}
+
+func (m *mockReaderWithError) Read(p []byte) (n int, err error) {
+	if m.closed {
+		return 0, io.EOF
+	}
+	
+	if m.position >= len(m.data) {
+		return 0, m.err
+	}
+	
+	n = copy(p, m.data[m.position:])
+	m.position += n
+	
+	if m.position >= len(m.data) {
+		return n, m.err
+	}
+	
+	return n, nil
+}
+
+func (m *mockReaderWithError) Close() error {
+	m.closed = true
+	return nil
+}
 
 // startMockSSEEchoServer starts a test HTTP server that implements
 // a minimal SSE-based echo server for testing purposes.
@@ -505,6 +540,182 @@ func TestSSE(t *testing.T) {
 
 		if result != "test response without event field" {
 			t.Errorf("Expected 'test response without event field', got '%s'", result)
+		}
+	})
+
+	t.Run("NO_ERROR_ConnectionLost", func(t *testing.T) {
+		// Test that NO_ERROR in HTTP/2 connection loss is properly handled
+		// This test verifies that when a connection is lost in a way that produces
+		// an error message containing "NO_ERROR", the connection lost handler is called
+		
+		var connectionLostCalled bool
+		var connectionLostError error
+		var mu sync.Mutex
+		
+		// Create a mock Reader that simulates connection loss with NO_ERROR
+		mockReader := &mockReaderWithError{
+			data: []byte("event: endpoint\ndata: /message\n\n"),
+			err:  errors.New("http2: stream closed with error code NO_ERROR"),
+		}
+		
+		// Create SSE transport
+		url, closeF := startMockSSEEchoServer()
+		defer closeF()
+		
+		trans, err := NewSSE(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		
+		// Set connection lost handler
+		trans.SetConnectionLostHandler(func(err error) {
+			mu.Lock()
+			defer mu.Unlock()
+			connectionLostCalled = true
+			connectionLostError = err
+		})
+		
+		// Directly test the readSSE method with our mock reader that simulates NO_ERROR
+		go trans.readSSE(mockReader)
+		
+		// Wait for connection lost handler to be called
+		timeout := time.After(1 * time.Second)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		
+		for {
+			select {
+			case <-timeout:
+				t.Fatal("Connection lost handler was not called within timeout for NO_ERROR connection loss")
+			case <-ticker.C:
+				mu.Lock()
+				called := connectionLostCalled
+				err := connectionLostError
+				mu.Unlock()
+				
+				if called {
+					if err == nil {
+						t.Fatal("Expected connection lost error, got nil")
+					}
+					
+					// Verify that the error contains "NO_ERROR" string
+					if !strings.Contains(err.Error(), "NO_ERROR") {
+						t.Errorf("Expected error to contain 'NO_ERROR', got: %v", err)
+					}
+					
+					t.Logf("Connection lost handler called with NO_ERROR: %v", err)
+					return
+				}
+			}
+		}
+	})
+
+	t.Run("NO_ERROR_Handling", func(t *testing.T) {
+		// Test specific NO_ERROR string handling in readSSE method
+		// This tests the code path at line 209 where NO_ERROR is checked
+		
+		// Create a mock Reader that simulates an error containing "NO_ERROR"
+		mockReader := &mockReaderWithError{
+			data: []byte("event: endpoint\ndata: /message\n\n"),
+			err:  errors.New("connection closed: NO_ERROR"),
+		}
+		
+		// Create SSE transport
+		url, closeF := startMockSSEEchoServer()
+		defer closeF()
+		
+		trans, err := NewSSE(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		
+		var connectionLostCalled bool
+		var connectionLostError error
+		var mu sync.Mutex
+		
+		// Set connection lost handler to verify it's called for NO_ERROR
+		trans.SetConnectionLostHandler(func(err error) {
+			mu.Lock()
+			defer mu.Unlock()
+			connectionLostCalled = true
+			connectionLostError = err
+		})
+		
+		// Directly test the readSSE method with our mock reader
+		go trans.readSSE(mockReader)
+		
+		// Wait for connection lost handler to be called
+		timeout := time.After(1 * time.Second)
+		ticker := time.NewTicker(10 * time.Millisecond)
+		defer ticker.Stop()
+		
+		for {
+			select {
+			case <-timeout:
+				t.Fatal("Connection lost handler was not called within timeout for NO_ERROR")
+			case <-ticker.C:
+				mu.Lock()
+				called := connectionLostCalled
+				err := connectionLostError
+				mu.Unlock()
+				
+				if called {
+					if err == nil {
+						t.Fatal("Expected connection lost error with NO_ERROR, got nil")
+					}
+					
+					// Verify that the error contains "NO_ERROR" string
+					if !strings.Contains(err.Error(), "NO_ERROR") {
+						t.Errorf("Expected error to contain 'NO_ERROR', got: %v", err)
+					}
+					
+					t.Logf("Successfully handled NO_ERROR: %v", err)
+					return
+				}
+			}
+		}
+	})
+
+	t.Run("RegularError_DoesNotTriggerConnectionLost", func(t *testing.T) {
+		// Test that regular errors (not containing NO_ERROR) do not trigger connection lost handler
+		
+		// Create a mock Reader that simulates a regular error
+		mockReader := &mockReaderWithError{
+			data: []byte("event: endpoint\ndata: /message\n\n"),
+			err:  errors.New("regular connection error"),
+		}
+		
+		// Create SSE transport
+		url, closeF := startMockSSEEchoServer()
+		defer closeF()
+		
+		trans, err := NewSSE(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		
+		var connectionLostCalled bool
+		var mu sync.Mutex
+		
+		// Set connection lost handler - this should NOT be called for regular errors
+		trans.SetConnectionLostHandler(func(err error) {
+			mu.Lock()
+			defer mu.Unlock()
+			connectionLostCalled = true
+		})
+		
+		// Directly test the readSSE method with our mock reader
+		go trans.readSSE(mockReader)
+		
+		// Wait and verify connection lost handler is NOT called
+		time.Sleep(200 * time.Millisecond)
+		
+		mu.Lock()
+		called := connectionLostCalled
+		mu.Unlock()
+		
+		if called {
+			t.Error("Connection lost handler should not be called for regular errors")
 		}
 	})
 


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->

The current SSE transport implementation does not properly handle HTTP/2 connection terminations that occur due to idle timeouts as specified in RFC 9113. When a connection is closed with the HTTP/2 error code `NO_ERROR`, the client cannot detect that the connection has been lost, as it treats this as a regular error and silently fails without notifying the application. This causes the transport to become non-functional after long periods of inactivity, with no way for the application to detect and recover from these legitimate connection closures.

If a connection containing the error message ‘NO_ERROR’ is closed, change it to call the connection disconnect handler so that you can detect the connection disconnect. Developers using Client can then decide what to do and implement the necessary measures.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Link text](https://www.rfc-editor.org/rfc/rfc9113.html#name-goaway)
- [x] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
