### PR TITLE
chore: remove comments related to JSON-Batching

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -90,7 +90,6 @@ func WithSession(sessionID string) StreamableHTTPCOption {
 // https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
 //
 // The current implementation does not support the following features:
-//   - batching
 //   - resuming stream
 //     (https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery)
 //   - server -> client request
@@ -407,8 +406,6 @@ func (c *StreamableHTTP) handleSSEResponse(ctx context.Context, reader io.ReadCl
 		defer close(responseChan)
 
 		c.readSSE(ctx, reader, func(event, data string) {
-			// (unsupported: batching)
-
 			var message JSONRPCResponse
 			if err := json.Unmarshal([]byte(data), &message); err != nil {
 				c.logger.Errorf("failed to unmarshal message: %v", err)

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -115,7 +115,6 @@ func WithLogger(logger util.Logger) StreamableHTTPOption {
 // or `hooks.onRegisterSession` will not be triggered for POST messages.
 //
 // The current implementation does not support the following features from the specification:
-//   - Batching of requests/notifications/responses in arrays.
 //   - Stream Resumability
 type StreamableHTTPServer struct {
 	server            *MCPServer


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->
For #409 
JSON batching has been removed from the spec in version 2025-06-18, this PR updates the related comments

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [x] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/2025-06-18/changelog#major-changes)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to remove outdated notes about unsupported batching features. No functional changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->