### PR TITLE
Hide error log when it's not useful

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -237,7 +238,7 @@ func (c *Stdio) readResponses() {
 		default:
 			line, err := c.stdout.ReadString('\n')
 			if err != nil {
-				if err != io.EOF {
+				if err != io.EOF && !errors.Is(err, context.Canceled) {
 					fmt.Printf("Error reading response: %v\n", err)
 				}
 				return


### PR DESCRIPTION
## Description

This removes an error log when the context is cancelled while we read responses. It's not an error, more of a valid exit path.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to prevent unnecessary error messages when operations are canceled by the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->