### PR TITLE
fix: remove duplicate methods server.SetPrompts & server.SetResources

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -383,14 +383,6 @@ func (s *MCPServer) DeleteResources(uris ...string) {
 	}
 }
 
-// SetResources replaces all existing resources with the provided list
-func (s *MCPServer) SetResources(resources ...ServerResource) {
-	s.resourcesMu.Lock()
-	s.resources = make(map[string]resourceEntry, len(resources))
-	s.resourcesMu.Unlock()
-	s.AddResources(resources...)
-}
-
 // RemoveResource removes a resource from the server
 func (s *MCPServer) RemoveResource(uri string) {
 	s.resourcesMu.Lock()
@@ -492,15 +484,6 @@ func (s *MCPServer) DeletePrompts(names ...string) {
 		// Send notification to all initialized sessions
 		s.SendNotificationToAllClients(mcp.MethodNotificationPromptsListChanged, nil)
 	}
-}
-
-// SetPrompts replaces all existing prompts with the provided list
-func (s *MCPServer) SetPrompts(prompts ...ServerPrompt) {
-	s.promptsMu.Lock()
-	s.prompts = make(map[string]mcp.Prompt, len(prompts))
-	s.promptHandlers = make(map[string]PromptHandlerFunc, len(prompts))
-	s.promptsMu.Unlock()
-	s.AddPrompts(prompts...)
 }
 
 // AddTool registers a new tool and its handler


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->

remove duplicate methods server.SetPrompts & server.SetResources

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
