### PR TITLE
oauth client example: skip DCR if MCP_CLIENT_ID is set

### DIFF
--- a/examples/oauth_client/main.go
+++ b/examples/oauth_client/main.go
@@ -129,9 +129,11 @@ func maybeAuthorize(err error) {
 			log.Fatalf("Failed to generate state: %v", err)
 		}
 
-		err = oauthHandler.RegisterClient(context.Background(), "mcp-go-oauth-example")
-		if err != nil {
-			log.Fatalf("Failed to register client: %v", err)
+		if oauthHandler.GetClientID() == "" {
+			err = oauthHandler.RegisterClient(context.Background(), "mcp-go-oauth-example")
+			if err != nil {
+				log.Fatalf("Failed to register client: %v", err)
+			}
 		}
 
 		// Get the authorization URL


### PR DESCRIPTION
## Description
If the user has set the MCP_CLIENT_ID environmental variable then they don't want Dynamic Client Registration and it should be skipped.




## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
