### PR TITLE
fix: prevent double-starting stdio transport in client

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -77,9 +77,16 @@ func (c *Client) Start(ctx context.Context) error {
 	if c.transport == nil {
 		return fmt.Errorf("transport is nil")
 	}
-	err := c.transport.Start(ctx)
-	if err != nil {
-		return err
+
+	if _, ok := c.transport.(*transport.Stdio); !ok {
+		// the stdio transport from NewStdioMCPClientWithOptions
+		// is already started, dont start again.
+		//
+		// Start the transport for other transport types
+		err := c.transport.Start(ctx)
+		if err != nil {
+			return err
+		}
 	}
 
 	c.transport.SetNotificationHandler(func(notification mcp.JSONRPCNotification) {

--- a/client/stdio.go
+++ b/client/stdio.go
@@ -28,7 +28,6 @@ func NewStdioMCPClient(
 // such as setting a custom command function.
 //
 // NOTICE: NewStdioMCPClientWithOptions automatically starts the underlying transport.
-// Don't call the Start method manually.
 // This is for backward compatibility.
 func NewStdioMCPClientWithOptions(
 	command string,

--- a/client/stdio.go
+++ b/client/stdio.go
@@ -12,7 +12,7 @@ import (
 // It launches the specified command with given arguments and sets up stdin/stdout pipes for communication.
 // Returns an error if the subprocess cannot be started or the pipes cannot be created.
 //
-// NOTICE: NewStdioMCPClient will start the connection automatically. Don't call the Start method manually.
+// NOTICE: NewStdioMCPClient will start the connection automatically.
 // This is for backward compatibility.
 func NewStdioMCPClient(
 	command string,


### PR DESCRIPTION
## Description

Prevents double-starting of stdio transport in client by adding a type check to only start transport for non-stdio transport types. The stdio transport from `NewStdioMCPClientWithOptions` is already started and doesn't need to be started again.

Fixes #193

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

The `Start` method is only way to register notification handlers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Startup now skips restarting stdio-based connections, avoiding redundant starts and potential errors in stdio setups. No public API changes.
* **Documentation**
  * Updated guidance: stdio-based clients are described as starting automatically; removed outdated instruction to call Start manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->