### PR TITLE
fix(tool): Return the OutputSchema from the tool definition

### DIFF
--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -593,7 +593,7 @@ func TestToolWithOutputSchema(t *testing.T) {
 	)
 
 	// Check that RawOutputSchema was set
-	assert.NotNil(t, tool.RawOutputSchema)
+	assert.NotNil(t, tool.OutputSchema)
 
 	// Marshal and verify structure
 	data, err := json.Marshal(tool)


### PR DESCRIPTION
## Description

This PR returns the `OutputSchema` from the tool definition as per the MCP spec: https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema

The behaviour of `WithOutputSchema()` also changed as `RawOutputSchema` is not longer populated, but `OutputSchema` is from the `T` generic type. The only way now to set `RawOutputSchema` is through the `WithRawOutputSchema()` method.

Fixes #563

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [X] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [X] This PR implements a feature defined in the MCP specification
- [X] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [X] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
