### PR TITLE
fix(oauth): use oauth-authorization-server discovery before default endpoints

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -343,8 +343,13 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		}
 		defer resp.Body.Close()
 
-		// If we can't get the protected resource metadata, fall back to default endpoints
+		// If we can't get the protected resource metadata, try OAuth Authorization Server discovery
 		if resp.StatusCode != http.StatusOK {
+			h.fetchMetadataFromURL(ctx, baseURL+"/.well-known/oauth-authorization-server")
+			if h.serverMetadata != nil {
+				return
+			}
+			// If that also fails, fall back to default endpoints
 			metadata, err := h.getDefaultEndpoints(baseURL)
 			if err != nil {
 				h.metadataFetchErr = fmt.Errorf("failed to get default endpoints: %w", err)

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -2,7 +2,10 @@ package transport
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -391,5 +394,141 @@ func TestOAuthHandler_SetExpectedState_CrossRequestScenario(t *testing.T) {
 	err = handler2.ProcessAuthorizationResponse(context.Background(), "test-code", testState, "test-code-verifier")
 	if !errors.Is(err, ErrInvalidState) {
 		t.Errorf("Expected ErrInvalidState with wrong state, got %v", err)
+	}
+}
+
+func TestOAuthHandler_GetServerMetadata_FallbackToOAuthAuthorizationServer(t *testing.T) {
+	// Test that when protected resource request fails, the handler falls back to
+	// .well-known/oauth-authorization-server instead of getDefaultEndpoints
+	
+	protectedResourceRequested := false
+	authServerRequested := false
+	
+	// Create a test server that simulates the OAuth provider
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			// Simulate failure of protected resource request
+			protectedResourceRequested = true
+			w.WriteHeader(http.StatusNotFound)
+			
+		case "/.well-known/oauth-authorization-server":
+			// Return OAuth Authorization Server metadata
+			authServerRequested = true
+			metadata := AuthServerMetadata{
+				Issuer:                server.URL,
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+				RegistrationEndpoint:  server.URL + "/register",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(metadata)
+			
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	
+	// Create OAuth handler with empty AuthServerMetadataURL to trigger discovery
+	config := OAuthConfig{
+		ClientID:              "test-client",
+		RedirectURI:           server.URL + "/callback",
+		Scopes:                []string{"mcp.read"},
+		TokenStore:            NewMemoryTokenStore(),
+		AuthServerMetadataURL: "", // Empty to trigger discovery
+		PKCEEnabled:           true,
+	}
+	
+	handler := NewOAuthHandler(config)
+	handler.SetBaseURL(server.URL)
+	
+	// Call getServerMetadata which should trigger the fallback behavior
+	metadata, err := handler.GetServerMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	
+	// Verify that both requests were made in the correct order
+	if !protectedResourceRequested {
+		t.Error("Expected protected resource request to be made")
+	}
+	if !authServerRequested {
+		t.Error("Expected OAuth Authorization Server request to be made as fallback")
+	}
+	
+	// Verify the metadata was correctly parsed
+	if metadata.Issuer != server.URL {
+		t.Errorf("Expected issuer to be %s, got %s", server.URL, metadata.Issuer)
+	}
+	if metadata.AuthorizationEndpoint != server.URL+"/authorize" {
+		t.Errorf("Expected authorization endpoint to be %s/authorize, got %s", server.URL, metadata.AuthorizationEndpoint)
+	}
+	if metadata.TokenEndpoint != server.URL+"/token" {
+		t.Errorf("Expected token endpoint to be %s/token, got %s", server.URL, metadata.TokenEndpoint)
+	}
+}
+
+func TestOAuthHandler_GetServerMetadata_FallbackToDefaultEndpoints(t *testing.T) {
+	// Test that when both protected resource and oauth-authorization-server fail,
+	// the handler falls back to default endpoints
+	
+	protectedResourceRequested := false
+	authServerRequested := false
+	
+	// Create a test server that returns 404 for both endpoints
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource":
+			protectedResourceRequested = true
+			w.WriteHeader(http.StatusNotFound)
+			
+		case "/.well-known/oauth-authorization-server":
+			authServerRequested = true
+			w.WriteHeader(http.StatusNotFound)
+			
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+	
+	// Create OAuth handler
+	config := OAuthConfig{
+		ClientID:              "test-client",
+		RedirectURI:           server.URL + "/callback",
+		Scopes:                []string{"mcp.read"},
+		TokenStore:            NewMemoryTokenStore(),
+		AuthServerMetadataURL: "", // Empty to trigger discovery
+		PKCEEnabled:           true,
+	}
+	
+	handler := NewOAuthHandler(config)
+	handler.SetBaseURL(server.URL)
+	
+	// Call getServerMetadata which should fall back to default endpoints
+	metadata, err := handler.GetServerMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+	
+	// Verify that both discovery requests were made
+	if !protectedResourceRequested {
+		t.Error("Expected protected resource request to be made")
+	}
+	if !authServerRequested {
+		t.Error("Expected OAuth Authorization Server request to be made as first fallback")
+	}
+	
+	// Verify the default endpoints were used
+	if metadata.Issuer != server.URL {
+		t.Errorf("Expected issuer to be %s, got %s", server.URL, metadata.Issuer)
+	}
+	if metadata.AuthorizationEndpoint != server.URL+"/authorize" {
+		t.Errorf("Expected authorization endpoint to be %s/authorize, got %s", server.URL, metadata.AuthorizationEndpoint)
+	}
+	if metadata.TokenEndpoint != server.URL+"/token" {
+		t.Errorf("Expected token endpoint to be %s/token, got %s", server.URL, metadata.TokenEndpoint)
 	}
 }


### PR DESCRIPTION


## Description

While the MCP Specification technically describes using `/.well-known/oauth-protected-resource` for discovery, most current MCP clients (including Claude itself) actually look for `/.well-known/oauth-authorization-server` directly at the MCP server’s domain. 

I believe this is how the OAuth dance works in practice today for lots of MCP Servers.

Example: below is screenshot from Cloudflare MCP Server from MCP inspector:


<img width="1242" height="1226" alt="Screenshot 2025-09-12 at 12 19 20" src="https://github.com/user-attachments/assets/652ede08-b3a5-4727-aeef-7b384d1c4f94" />

- Before the PR, Cloudflare MCP Server will return `https://builds.mcp.cloudflare.com/authorize` as authorization url, which will give 404

- With this PR Cloudflare MCP Server will return the correct `authorization_endpoint` value `https://builds.mcp.cloudflare.com/oauth/authorize`

Fixes #<issue_number> (if applicable)

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/draft/basic/authorization#server-metadata-discovery)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth metadata discovery by falling back to the standard well-known Authorization Server endpoint when the primary metadata source is unavailable, then gracefully reverting to default endpoints if needed. This enhances reliability and compatibility with more OAuth providers.

* **Tests**
  * Added tests covering discovery fallback and default-endpoint behavior to ensure consistent OAuth setup across varying provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->