### PR TITLE
feat: extend resource middlewares to resource templates

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -940,7 +940,17 @@ func (s *MCPServer) handleReadResource(
 	s.resourcesMu.RUnlock()
 
 	if matched {
-		contents, err := matchedHandler(ctx, request)
+		// If a match is found, then we have a final handler and can
+		// apply middlewares.
+		s.resourceMiddlewareMu.RLock()
+		finalHandler := ResourceHandlerFunc(matchedHandler)
+		mw := s.resourceHandlerMiddlewares
+		// Apply middlewares in reverse order
+		for i := len(mw) - 1; i >= 0; i-- {
+			finalHandler = mw[i](finalHandler)
+		}
+		s.resourceMiddlewareMu.RUnlock()
+		contents, err := finalHandler(ctx, request)
 		if err != nil {
 			return nil, &requestError{
 				id:   id,


### PR DESCRIPTION
The existing logic for resource middlewares was based heavily off of the
prior art for tool middlewares. Tools, however, don't have the concept
of templates. This change ensures that resource middlewares also get
applied to resource templates.

While they are defined as separate types, both `ResourceHandlerFunc` and
`ResourceTemplateHandlerFunc` have the same function signature, and
therefore satisfy the same underlying type. This seems intentional since
resource templates are only actually executed within the same
`handleReadResource` function, and only when A) no direct resources
match and B) the resource uri matches the template -- executing in the
same function and returning an `mcp.ReadResourceResult` regardless of
direct resource or template.

Since the uri needs to match in order for the template to be executed,
we build the chain of middleware funcs after matching the uri to avoid
wasted cycles. In order to apply the middlewares to the
`ResourceTemplateHandlerFunc`, we explicitly cast to a
`ResourceHandlerFunc`. This is safe, as they point to the same
underlying type. If resource handler funcs ever diverge, this should
also safely surface as a compile time warning, allowing ample time to
address and not have a silent breakage slip through in builds.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resource middlewares are now applied to template-based resource routes, matching the behavior of direct resources.
  * Ensures consistent enforcement of authentication, headers, rate limits, logging, and other policies across all resources.
  * Resolves cases where middleware-driven policies or transformations were previously skipped on templated routes.
  * Improves reliability and observability without changing response content beyond middleware effects.
  * No configuration changes required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->