### PR TITLE
feat: add _meta field to text/blob resource content

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -725,6 +725,8 @@ type TextResourceContents struct {
 	// The text of the item. This must only be set if the item can actually be
 	// represented as text (not binary data).
 	Text string `json:"text"`
+	// Metadata associated with this resource
+	Meta map[string]interface{} `json:"_meta,omitempty"`
 }
 
 func (TextResourceContents) isResourceContents() {}
@@ -738,6 +740,8 @@ type BlobResourceContents struct {
 	MIMEType string `json:"mimeType,omitempty"`
 	// A base64-encoded string representing the binary data of the item.
 	Blob string `json:"blob"`
+	// Metadata associated with this resource
+	Meta map[string]interface{} `json:"_meta,omitempty"`
 }
 
 func (BlobResourceContents) isResourceContents() {}

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -705,11 +705,20 @@ func ParseResourceContents(contentMap map[string]any) (ResourceContents, error) 
 
 	mimeType := ExtractString(contentMap, "mimeType")
 
+	// Extract _meta field if present
+	var meta map[string]interface{}
+	if metaValue, ok := contentMap["_meta"]; ok {
+		if metaMap, ok := metaValue.(map[string]interface{}); ok {
+			meta = metaMap
+		}
+	}
+
 	if text := ExtractString(contentMap, "text"); text != "" {
 		return TextResourceContents{
 			URI:      uri,
 			MIMEType: mimeType,
 			Text:     text,
+			Meta:     meta,
 		}, nil
 	}
 
@@ -718,6 +727,7 @@ func ParseResourceContents(contentMap map[string]any) (ResourceContents, error) 
 			URI:      uri,
 			MIMEType: mimeType,
 			Blob:     blob,
+			Meta:     meta,
 		}, nil
 	}
 


### PR DESCRIPTION
## Description

Adds support for parsing the optional `_meta` field in resource contents. This field is used in server-client interactions and a prime example of that is MCP UI.

    - Parses optional `_meta` field on the text/blob resource contents
    - Adds `TestResourceContentsMetaField` to verify `_meta` field handling
    - Ensures backward compatibility with resources without `_meta`

Fixes #585.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [x] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Resource contents (text and blob) now support an optional _meta metadata field, allowing inclusion of additional structured information.
  - Metadata is preserved during parsing and serialization, enabling round-trip integrity for clients that include _meta.

- Tests
  - Added comprehensive tests covering presence/absence of _meta for both text and blob contents.
  - Verified correct parsing, field population, and round-trip JSON behavior to ensure _meta is retained when provided and omitted when absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->