### PR TITLE
fix: keep empty properties in tool's InputSchema

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -620,7 +620,7 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 type ToolArgumentsSchema struct {
 	Defs       map[string]any `json:"$defs,omitempty"`
 	Type       string         `json:"type"`
-	Properties map[string]any `json:"properties,omitempty"`
+	Properties map[string]any `json:"properties"`
 	Required   []string       `json:"required,omitempty"`
 }
 


### PR DESCRIPTION
OpenAI will report error if InputSchema of "object" type with no "properties" field existing in its JSON representation.

openai.BadRequestError: Error code: 400 - {'error': {'message': "Invalid schema for function 'getCurrentDate': In context=(), object schema missing properties.", 'type': 'invalid_request_error', 'param': 'tools[0].function.parameters', 'code': 'invalid_function_parameters'}, 'user': '{"appkey": "egai-prd-strategyoffice-020029831-workflow-1746045106141", "session_id": "b95e59c0-a570-4f82-9905-05eff7b35eba-1758281506244515510", "user": "", "prompt_truncate": "yes"}'}

## Description
<!-- Provide a concise description of the changes in this PR -->

Fixes #<issue_number> (if applicable)

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->
