### PR TITLE
fix: replace bufio.Scanner with bufio.Reader to support large message…

### DIFF
--- a/testdata/mockstdio_server.go
+++ b/testdata/mockstdio_server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 )
@@ -18,19 +19,26 @@ type JSONRPCRequest struct {
 }
 
 type JSONRPCResponse struct {
-	JSONRPC string         `json:"jsonrpc"`
-	ID      *mcp.RequestId `json:"id,omitempty"`
-	Result  any            `json:"result,omitempty"`
+	JSONRPC string                   `json:"jsonrpc"`
+	ID      *mcp.RequestId           `json:"id,omitempty"`
+	Result  any                      `json:"result,omitempty"`
 	Error   *mcp.JSONRPCErrorDetails `json:"error,omitempty"`
 }
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{}))
 	logger.Info("launch successful")
-	scanner := bufio.NewScanner(os.Stdin)
-	for scanner.Scan() {
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+
 		var request JSONRPCRequest
-		if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
+		if err := json.Unmarshal([]byte(line), &request); err != nil {
 			continue
 		}
 


### PR DESCRIPTION
The bufio.Scanner has a default 64KB token limit which causes 'token too long' errors when MCP servers send large messages (e.g., large tool responses, resource contents, or prompts). This change replaces Scanner with Reader.ReadString('\n') which can handle arbitrarily large lines.

Changes:
- client/transport/stdio.go: Changed stdout from *bufio.Scanner to *bufio.Reader
- testdata/mockstdio_server.go: Applied same fix to mock server
- client/transport/stdio_test.go: Added TestStdio_LargeMessages with tests for messages ranging from 1KB to 5MB to ensure the fix works correctly

The original code (pre-commit 4e353ac8) used bufio.Reader, but was incorrectly changed to Scanner claiming it would avoid panics with long lines. This fix reverts to the Reader approach which actually handles large messages correctly.

Fixes issue where stdio clients fail with 'bufio.Scanner: token too long' error when communicating with servers that send large responses.

## Description
<!-- Provide a concise description of the changes in this PR -->

Fixes #588

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stdio transport to reliably handle very large messages without truncation or read failures.
  * More robust line parsing, including trimming CRLF and clearer error handling for malformed input.

* **Tests**
  * Added large-payload stress tests (up to ~5MB) to verify end-to-end integrity and response correctness across varying sizes.
  * Ensures consistent handling of notifications, requests, and responses under high-volume conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->