### PR TITLE
feat: add HTTP client option to OAuthConfig

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -34,8 +34,8 @@ type OAuthConfig struct {
 	AuthServerMetadataURL string
 	// PKCEEnabled enables PKCE for the OAuth flow (recommended for public clients)
 	PKCEEnabled bool
-	// An optional HTTP client to use for requests.
-	// If not provided, a default HTTP client will be used.
+	// HTTPClient is an optional HTTP client to use for requests.
+	// If nil, a default HTTP client with a 30 second timeout will be used.
 	HTTPClient *http.Client
 }
 


### PR DESCRIPTION
## Description

It's already possible to customize the underlying client used by the SSE
and streamable HTTP transports, but not the OAuth handler. This adds
an option to customize the underlying client used by the OAuth handler.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information

It's a pretty tiny change and I've tested it out locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to configure a custom HTTP client for OAuth operations, enabling advanced networking settings (proxies, retries, transport tweaks). This gives admins finer control over connection behavior in restricted environments.
* **Improvements**
  * When not configured, OAuth requests now use a default client with a 30s timeout, improving reliability and preventing indefinite hangs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->