### PR TITLE
feat(mcp): Add WithAny for flexible tool properties

### DIFF
--- a/examples/typed_tools/main.go
+++ b/examples/typed_tools/main.go
@@ -18,6 +18,7 @@ type GreetingArgs struct {
 		Location string `json:"location"`
 		Timezone string `json:"timezone"`
 	} `json:"metadata"`
+	AnyData any `json:"any_data"`
 }
 
 func main() {
@@ -61,6 +62,9 @@ func main() {
 				},
 			}),
 		),
+		mcp.WithAny("any_data",
+			mcp.Description("Any kind of data, e.g., an integer"),
+		),
 	)
 
 	// Add tool handler using the typed handler
@@ -99,6 +103,10 @@ func typedGreetingHandler(ctx context.Context, request mcp.CallToolRequest, args
 		if args.Metadata.Timezone != "" {
 			greeting += fmt.Sprintf(" Your timezone is %s.", args.Metadata.Timezone)
 		}
+	}
+
+	if args.AnyData != nil {
+		greeting += fmt.Sprintf(" I also received some other data: %v.", args.AnyData)
 	}
 
 	return mcp.NewToolResultText(greeting), nil

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -1113,6 +1113,26 @@ func WithArray(name string, opts ...PropertyOption) ToolOption {
 	}
 }
 
+// WithAny adds a property of any type to the tool schema.
+// It accepts property options to configure the property's behavior and constraints.
+func WithAny(name string, opts ...PropertyOption) ToolOption {
+	return func(t *Tool) {
+		schema := map[string]any{}
+
+		for _, opt := range opts {
+			opt(schema)
+		}
+
+		// Remove required from property schema and add to InputSchema.required
+		if required, ok := schema["required"].(bool); ok && required {
+			delete(schema, "required")
+			t.InputSchema.Required = append(t.InputSchema.Required, name)
+		}
+
+		t.InputSchema.Properties[name] = schema
+	}
+}
+
 // Properties defines the properties for an object schema
 func Properties(props map[string]any) PropertyOption {
 	return func(schema map[string]any) {


### PR DESCRIPTION
## Description

Introduces `mcp.WithAny()`, a new tool option that allows defining a property of `any` Golang type. This is useful for creating tools that can accept a variety of data structures for a given parameter.

Fixes #345 

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Implementation follows the specification exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tool parameters with flexible typing, enabling tools to accept arbitrary data alongside strictly-typed fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->