### PR TITLE
feat: implement RFC9728 OAuth Protected Resource Metadata discovery

### DIFF
--- a/client/oauth_test.go
+++ b/client/oauth_test.go
@@ -119,10 +119,93 @@ func TestIsOAuthAuthorizationRequiredError(t *testing.T) {
 	if IsOAuthAuthorizationRequiredError(err2) {
 		t.Errorf("Expected IsOAuthAuthorizationRequiredError to return false")
 	}
-
 	// Verify GetOAuthHandler returns nil
 	handler = GetOAuthHandler(err2)
 	if handler != nil {
 		t.Errorf("Expected GetOAuthHandler to return nil")
+	}
+}
+
+func TestGetResourceMetadataURL(t *testing.T) {
+	// Test with error containing metadata URL
+	metadataURL := "https://auth.example.com/.well-known/oauth-protected-resource"
+	err := &transport.OAuthAuthorizationRequiredError{
+		Handler: transport.NewOAuthHandler(transport.OAuthConfig{}),
+		AuthorizationRequiredError: transport.AuthorizationRequiredError{
+			ResourceMetadataURL: metadataURL,
+		},
+	}
+
+	// Verify GetResourceMetadataURL returns the correct URL
+	result := GetResourceMetadataURL(err)
+	if result != metadataURL {
+		t.Errorf("Expected GetResourceMetadataURL to return %q, got %q", metadataURL, result)
+	}
+
+	// Test with error containing no metadata URL
+	err2 := &transport.OAuthAuthorizationRequiredError{
+		Handler: transport.NewOAuthHandler(transport.OAuthConfig{}),
+		AuthorizationRequiredError: transport.AuthorizationRequiredError{
+			ResourceMetadataURL: "",
+		},
+	}
+
+	result2 := GetResourceMetadataURL(err2)
+	if result2 != "" {
+		t.Errorf("Expected GetResourceMetadataURL to return empty string, got %q", result2)
+	}
+
+	// Test with non-OAuth error
+	err3 := fmt.Errorf("some other error")
+
+	result3 := GetResourceMetadataURL(err3)
+	if result3 != "" {
+		t.Errorf("Expected GetResourceMetadataURL to return empty string for non-OAuth error, got %q", result3)
+	}
+}
+
+func TestIsAuthorizationRequiredError(t *testing.T) {
+	// Test with base AuthorizationRequiredError (401 without OAuth handler)
+	metadataURL := "https://auth.example.com/.well-known/oauth-protected-resource"
+	err := &transport.AuthorizationRequiredError{
+		ResourceMetadataURL: metadataURL,
+	}
+
+	// Verify IsAuthorizationRequiredError returns true
+	if !IsAuthorizationRequiredError(err) {
+		t.Errorf("Expected IsAuthorizationRequiredError to return true for AuthorizationRequiredError")
+	}
+
+	// Verify GetResourceMetadataURL returns the correct URL
+	result := GetResourceMetadataURL(err)
+	if result != metadataURL {
+		t.Errorf("Expected GetResourceMetadataURL to return %q, got %q", metadataURL, result)
+	}
+
+	// Test with OAuthAuthorizationRequiredError (different type)
+	oauthErr := &transport.OAuthAuthorizationRequiredError{
+		Handler: transport.NewOAuthHandler(transport.OAuthConfig{}),
+		AuthorizationRequiredError: transport.AuthorizationRequiredError{
+			ResourceMetadataURL: metadataURL,
+		},
+	}
+
+	// Verify IsOAuthAuthorizationRequiredError returns true
+	if !IsOAuthAuthorizationRequiredError(oauthErr) {
+		t.Errorf("Expected IsOAuthAuthorizationRequiredError to return true for OAuthAuthorizationRequiredError")
+	}
+
+	// Verify GetResourceMetadataURL works with OAuth error too
+	result2 := GetResourceMetadataURL(oauthErr)
+	if result2 != metadataURL {
+		t.Errorf("Expected GetResourceMetadataURL to return %q, got %q", metadataURL, result2)
+	}
+
+	// Test with non-authorization error
+	err3 := fmt.Errorf("some other error")
+
+	// Verify IsAuthorizationRequiredError returns false
+	if IsAuthorizationRequiredError(err3) {
+		t.Errorf("Expected IsAuthorizationRequiredError to return false for non-authorization error")
 	}
 }

--- a/client/transport/sse_oauth_test.go
+++ b/client/transport/sse_oauth_test.go
@@ -239,3 +239,66 @@ func TestSSE_IsOAuthEnabled(t *testing.T) {
 		t.Errorf("Expected IsOAuthEnabled() to return true")
 	}
 }
+
+func TestSSE_OAuthMetadataDiscovery(t *testing.T) {
+	// Test that we correctly extract resource_metadata URL from WWW-Authenticate header per RFC9728
+	const expectedMetadataURL = "https://auth.example.com/.well-known/oauth-protected-resource"
+
+	// Create a test server that returns 401 with WWW-Authenticate header
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 401 with WWW-Authenticate header containing resource_metadata
+		w.Header().Set("WWW-Authenticate", `Bearer resource_metadata="`+expectedMetadataURL+`"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	// Create a token store with a valid token so the request reaches the server
+	// The server will still return 401 to simulate token rejection
+	tokenStore := NewMemoryTokenStore()
+	validToken := &Token{
+		AccessToken:  "test-token",
+		TokenType:    "Bearer",
+		RefreshToken: "refresh-token",
+		ExpiresIn:    3600,
+		ExpiresAt:    time.Now().Add(1 * time.Hour), // Valid for 1 hour
+	}
+	if err := tokenStore.SaveToken(context.Background(), validToken); err != nil {
+		t.Fatalf("Failed to save token: %v", err)
+	}
+
+	// Create OAuth config
+	oauthConfig := OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost:8085/callback",
+		Scopes:      []string{"mcp.read", "mcp.write"},
+		TokenStore:  tokenStore,
+		PKCEEnabled: true,
+	}
+
+	// Create SSE with OAuth
+	transport, err := NewSSE(server.URL, WithOAuth(oauthConfig))
+	if err != nil {
+		t.Fatalf("Failed to create SSE: %v", err)
+	}
+
+	// Start SSE which will trigger 401
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = transport.Start(ctx)
+
+	// Verify the error is an OAuthAuthorizationRequiredError
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+
+	var oauthErr *OAuthAuthorizationRequiredError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("Expected OAuthAuthorizationRequiredError, got %T: %v", err, err)
+	}
+
+	// Verify the discovered metadata URL was extracted from WWW-Authenticate header
+	if oauthErr.ResourceMetadataURL != expectedMetadataURL {
+		t.Errorf("Expected ResourceMetadataURL to be %q, got %q",
+			expectedMetadataURL, oauthErr.ResourceMetadataURL)
+	}
+}

--- a/examples/oauth_client/README.md
+++ b/examples/oauth_client/README.md
@@ -5,6 +5,7 @@ This example demonstrates how to use the OAuth capabilities of the MCP Go client
 ## Features
 
 - OAuth 2.1 authentication with PKCE support
+- **RFC9728 OAuth Protected Resource Metadata discovery** - Automatically discovers OAuth server metadata from `WWW-Authenticate` headers
 - Dynamic client registration
 - Authorization code flow
 - Token refresh
@@ -25,16 +26,19 @@ go run main.go
 
 1. The client attempts to initialize a connection to the MCP server
 2. If the server requires OAuth authentication, it will return a 401 Unauthorized response
-3. The client detects this and starts the OAuth flow:
+3. **The client automatically extracts the OAuth metadata URL from the `WWW-Authenticate` header** (per [RFC9728](https://datatracker.ietf.org/doc/html/rfc9728))
+   - Example header: `WWW-Authenticate: Bearer resource_metadata="https://auth.example.com/.well-known/oauth-protected-resource"`
+   - This URL tells the client where to find the OAuth authorization server configuration
+4. The client detects the OAuth requirement and starts the OAuth flow:
    - Generates PKCE code verifier and challenge
    - Generates a state parameter for security
    - Opens a browser to the authorization URL
    - Starts a local server to handle the callback
-4. The user authorizes the application in their browser
-5. The authorization server redirects back to the local callback server
-6. The client exchanges the authorization code for an access token
-7. The client retries the initialization with the access token
-8. The client can now make authenticated requests to the MCP server
+5. The user authorizes the application in their browser
+6. The authorization server redirects back to the local callback server
+7. The client exchanges the authorization code for an access token
+8. The client retries the initialization with the access token
+9. The client can now make authenticated requests to the MCP server
 
 ## Configuration
 
@@ -57,3 +61,18 @@ The example requests the following scopes:
 - `mcp.write` - Write access to MCP resources
 
 You can modify the scopes in the `oauthConfig` to match the requirements of your MCP server.
+
+## RFC9728 OAuth Protected Resource Metadata
+
+This example demonstrates automatic OAuth metadata discovery per [RFC9728](https://datatracker.ietf.org/doc/html/rfc9728). When the MCP server returns a 401 Unauthorized response with a `WWW-Authenticate` header containing the `resource_metadata` parameter, the client automatically extracts and uses this URL to discover the OAuth authorization server configuration.
+
+The example code demonstrates this with:
+
+```go
+// Check if server provided OAuth metadata URL via WWW-Authenticate header (RFC9728)
+if metadataURL := client.GetDiscoveredMetadataURL(err); metadataURL != "" {
+    fmt.Printf("Server provided OAuth metadata URL: %s\n", metadataURL)
+}
+```
+
+This makes the OAuth flow more robust and standards-compliant, as the server explicitly tells clients where to find OAuth configuration rather than relying on well-known locations.

--- a/examples/oauth_client/main.go
+++ b/examples/oauth_client/main.go
@@ -108,6 +108,12 @@ func maybeAuthorize(err error) {
 	if client.IsOAuthAuthorizationRequiredError(err) {
 		fmt.Println("OAuth authorization required. Starting authorization flow...")
 
+		// Check if server provided OAuth metadata URL via WWW-Authenticate header (RFC9728)
+		if metadataURL := client.GetResourceMetadataURL(err); metadataURL != "" {
+			fmt.Printf("Server provided OAuth metadata URL: %s\n", metadataURL)
+			fmt.Println("The client will automatically use this URL for OAuth configuration.")
+		}
+
 		// Get the OAuth handler from the error
 		oauthHandler := client.GetOAuthHandler(err)
 


### PR DESCRIPTION
## Description

Add support for discovering OAuth authorization server metadata from WWW-Authenticate headers per RFC9728 Section 5.1.

The MCP spec indicates that servers should return a 401 Unauthorized response with a WWW-Authenticate header containing the resource_metadata parameter. This parameter is used to discover the OAuth authorization server metadata.

This change adds support for this discovery, allowing clients to automatically extract the OAuth metadata URL from the WWW-Authenticate header and use it to discover the OAuth authorization server configuration, rather than relying on it being on the /.well-known path of the base URL, which is not always the case (for example,
https://mcp.linear.app/mcp/.well-known/oauth-protected-resource vs https://mcp.honeycomb.io/.well-known/oauth-protected-resource - note the lack of /mcp in one of these, even though both servers expect the /mcp path in the base URL).

Changes:
- Add AuthorizationRequiredError base error type with ResourceMetadataURL field
- Add OAuthAuthorizationRequiredError that embeds AuthorizationRequiredError
- Add ProtectedResourceMetadataURL to OAuthConfig for explicit configuration
- Extract resource_metadata parameter from WWW-Authenticate headers in both streamable_http and sse transports
- Update getServerMetadata() to use ProtectedResourceMetadataURL when provided
- Add helper functions: IsAuthorizationRequiredError(), GetResourceMetadataURL()
- Add comprehensive tests for metadata URL extraction and usage
- Update OAuth example to demonstrate RFC9728 discovery

This allows clients to properly discover OAuth endpoints when servers return 401 responses with WWW-Authenticate headers containing resource_metadata URLs, enabling correct OAuth flows without requiring well-known URL assumptions.

RFC9728: https://datatracker.ietf.org/doc/html/rfc9728

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Authorization server location](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization#authorization-server-location)
- [x] Implementation follows the specification exactly

## Additional Information

I'm using this fork locally, will mark as ready-for-review once I'm sure it works correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - RFC9728 OAuth Protected Resource Metadata discovery support
  - Automatic extraction and propagation of OAuth metadata URLs from server WWW-Authenticate headers
  - New client helpers to detect authorization-required errors and retrieve discovered metadata
  - New config option to explicitly specify protected resource metadata URL

* **Tests**
  - Added tests covering OAuth metadata discovery and related error paths

* **Documentation**
  - Updated example README and sample to show automatic metadata discovery and usage

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->