### PR TITLE
feat: defer tool loading to enable Anthropic's "Tool Search" pattern

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -571,6 +571,8 @@ type Tool struct {
 	RawOutputSchema json.RawMessage `json:"-"` // Hide this from JSON marshaling
 	// Optional properties describing tool behavior
 	Annotations ToolAnnotation `json:"annotations"`
+	// Support for deferred loading
+	DeferLoading bool `json:"defer_loading,omitempty"`
 }
 
 // GetName returns the name of the tool.
@@ -612,6 +614,10 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 	}
 
 	m["annotations"] = t.Annotations
+
+	if t.DeferLoading {
+		m["defer_loading"] = t.DeferLoading
+	}
 
 	// Marshal Meta if present
 	if t.Meta != nil {
@@ -727,6 +733,14 @@ func NewToolWithRawSchema(name, description string, schema json.RawMessage) Tool
 func WithDescription(description string) ToolOption {
 	return func(t *Tool) {
 		t.Description = description
+	}
+}
+
+// WithDeferLoading sets the defer_loading flag for the tool.
+// This is used to implement dynamic tool loading/searching patterns.
+func WithDeferLoading(deferLoading bool) ToolOption {
+	return func(t *Tool) {
+		t.DeferLoading = deferLoading
 	}
 }
 

--- a/mcp/tools_defer_loading_test.go
+++ b/mcp/tools_defer_loading_test.go
@@ -1,0 +1,40 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestToolWithDeferLoading(t *testing.T) {
+	tool := NewTool("deferred-tool",
+		WithDescription("A tool with deferred loading"),
+		WithDeferLoading(true),
+	)
+
+	data, err := json.Marshal(tool)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+
+	assert.Equal(t, true, result["defer_loading"])
+}
+
+func TestToolWithoutDeferLoading(t *testing.T) {
+	tool := NewTool("regular-tool",
+		WithDescription("A regular tool"),
+	)
+
+	data, err := json.Marshal(tool)
+	assert.NoError(t, err)
+
+	var result map[string]any
+	err = json.Unmarshal(data, &result)
+	assert.NoError(t, err)
+
+	_, exists := result["defer_loading"]
+	assert.False(t, exists)
+}


### PR DESCRIPTION
The Model Context Protocol (MCP) allows servers to expose tools to clients. Anthropic has introduced a beta feature where tools can be marked with `defer_loading: true`. When a client sees this, it displays the tool to the model but does not include the full schema in the context window until the model explicitly searches for or requests it.

For more information see [Anthropic Advanced Tool Use Documentation](https://www.anthropic.com/engineering/advanced-tool-use).

For background I work on https://github.com/buildkite/buildkite-mcp-server and we have been following the dynamic toolsets feature in the GitHub MCP server https://github.com/github/github-mcp-server/blob/main/pkg/github/tools.go however we really wanted something standardised, hence being keen on the Anthropic implementation.

This change is purely additive and backward compatible, hence me putting up a PR, keen to hear what others think.

## Description
<!-- Provide a concise description of the changes in this PR -->

Fixes #<issue_number> (if applicable)

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tools now include an optional deferred loading feature, enabling on-demand resource initialization. This enhancement improves performance and resource efficiency, particularly beneficial when working with resource-intensive tool configurations.

* **Tests**
  * Added test coverage validating deferred loading functionality and JSON serialization behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->