### PR TITLE
fix for nil resources slice

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -880,7 +880,7 @@ func (s *MCPServer) handleListResources(
 	}
 
 	if resourcesToReturn == nil {
-		resourceToReturn = []mcp.Resource{}
+		resourcesToReturn = []mcp.Resource{}
 	}
 
 	result := mcp.ListResourcesResult{


### PR DESCRIPTION
## Description
ListResources can return null when provided with no MCP resources.  Certain MCP clients will fail in this case.  This PR returns an empty slice instead, which should be safer.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented an error when listing resources by ensuring empty results are handled safely, improving stability when processing empty or missing data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->