### PR TITLE
Add AdditionalProperties to ToolInputSchema

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -635,10 +635,11 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 
 // ToolArgumentsSchema represents a JSON Schema for tool arguments.
 type ToolArgumentsSchema struct {
-	Defs       map[string]any `json:"$defs,omitempty"`
-	Type       string         `json:"type"`
-	Properties map[string]any `json:"properties,omitempty"`
-	Required   []string       `json:"required,omitempty"`
+	Defs                 map[string]any `json:"$defs,omitempty"`
+	Type                 string         `json:"type"`
+	Properties           map[string]any `json:"properties,omitempty"`
+	Required             []string       `json:"required,omitempty"`
+	AdditionalProperties any            `json:"additionalProperties,omitempty"`
 }
 
 type ToolInputSchema ToolArgumentsSchema // For retro-compatibility
@@ -660,6 +661,10 @@ func (tis ToolArgumentsSchema) MarshalJSON() ([]byte, error) {
 
 	if len(tis.Required) > 0 {
 		m["required"] = tis.Required
+	}
+
+	if tis.AdditionalProperties != nil {
+		m["additionalProperties"] = tis.AdditionalProperties
 	}
 
 	return json.Marshal(m)
@@ -916,6 +921,15 @@ func WithIdempotentHintAnnotation(value bool) ToolOption {
 func WithOpenWorldHintAnnotation(value bool) ToolOption {
 	return func(t *Tool) {
 		t.Annotations.OpenWorldHint = &value
+	}
+}
+
+// WithSchemaAdditionalProperties sets the additionalProperties field on the tool's input schema.
+// It accepts false (disallow extra properties), true (allow any), or a schema map
+// to validate additional properties against.
+func WithSchemaAdditionalProperties(schema any) ToolOption {
+	return func(t *Tool) {
+		t.InputSchema.AdditionalProperties = schema
 	}
 }
 


### PR DESCRIPTION
## Summary
Add support for `additionalProperties` field in the `ToolInputSchema` (alias `ToolArgumentsSchema`) struct, allowing tools to specify whether additional properties are allowed in their input schema.

## Changes
- Add `AdditionalProperties` field to `ToolArgumentsSchema` struct
- Update `MarshalJSON` to include `additionalProperties` in output when set
- Add `WithSchemaAdditionalProperties` ToolOption function
- Add tests for marshal/unmarshal and ToolOption

## Example Usage

```go
// Strict tool - no extra properties allowed
tool := mcp.NewTool("strict-tool",
    mcp.WithDescription("Only accepts defined properties"),
    mcp.WithString("name", mcp.Required()),
    mcp.WithSchemaAdditionalProperties(false),
)
```

## Notes
- Uses `any` type to support `false`, `true`, or schema object values per JSON Schema spec
- Field is omitted from JSON when nil (default behavior allows additional properties per JSON Schema)
- Named `WithSchemaAdditionalProperties` to distinguish from existing `AdditionalProperties` PropertyOption

Fixes #672

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool argument schemas now support an additional properties field for extended configuration options.
  * New configuration option available for setting additional properties on tool input schemas during construction.

* **Tests**
  * Comprehensive test coverage added for schema properties handling, including marshaling, unmarshaling, and integration scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->