### PR TITLE
fix: fix TestSSE_SendRequest_Timeout flaky test

### DIFF
--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -1263,7 +1263,10 @@ func TestSSE_SendRequest_Timeout(t *testing.T) {
 		duration := time.Since(startTime)
 
 		require.Error(t, err, "Expected timeout error")
-		require.Contains(t, err.Error(), "timeout", "Error should mention timeout")
+		errMsg := err.Error()
+		require.True(t,
+			strings.Contains(errMsg, "timeout") || strings.Contains(errMsg, "deadline exceeded"),
+			"Error should mention timeout or deadline, got: %v", err)
 		expectedTimeout := 2 * time.Second
 		require.GreaterOrEqual(t, duration, expectedTimeout*7/10) // 70% of expected
 		require.LessOrEqual(t, duration, expectedTimeout*13/10)   // 130% of expected


### PR DESCRIPTION
## Description
Fixes the flaky test `TestSSE_SendRequest_Timeout/TimeoutWhenServerNeverResponds` that fails when the context deadline fires before the internal timer.

Fixes #682 

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced timeout error assertion in SSE transport tests to handle multiple error message formats for improved test robustness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->