### PR TITLE
fix: low mcp version been selected by mcp server, mcp server may also raise 'unsupported protocol version 2025-11-25' error

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -213,6 +213,11 @@ func (c *Client) Initialize(
 		Capabilities:    capabilities,
 	}
 
+	// By default, use client supported lastest protocol version if version not specified
+	if params.ProtocolVersion == "" {
+		params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	}
+
 	response, err := c.sendRequest(ctx, "initialize", params, request.Header)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Description
If dose not specify the 'ProtocolVersion' in 'mcp.InitializeParams', the MCP server will specify the low version during initialization phase. 

For example, the mcp server dose support '2025-06-18' version. But if client dose not specify the version, the mcp server will return '2025-03-26' version during initialization. 

The other case is that the mcp client dose not need the latest '2025-11-25' version MCP features. But when client do initialization with MCP server, the server select '2025-11-25' version during negotiation and raised "unsupported protocol version 2025-11-25" error. Since mcp-go library dose not implement the '2025-11-25' version mcp features temporary. 

According to the [version negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation) section. "the client **MUST** send a protocol version it supports. This SHOULD be the **latest** version supported by the client."

Fixes #650

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance


- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Version Negotiation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle#version-negotiation)
- [x] Implementation follows the specification exactly

## Additional Information
I had made test with follow code and verified the fixing code.
	_initRequest := mcp.InitializeRequest{
		Params: mcp.InitializeParams{
			Capabilities:    mcp.ClientCapabilities{ 
			},
			ClientInfo: mcp.Implementation{
				Name:    "ai-client",
				Version: "1.0.0",
			},
		},
	}
	a.serverInfo, err = a.client.Initialize(a.ctx, initRequest)
	if err != nil {
		log.Fatalf("Failed to initialize MCP session: %v", err)
	}_
