### PR TITLE
fix: return 404 instead of 400 for invalid session IDs

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -345,7 +345,7 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 		sessionID = r.Header.Get(HeaderKeySessionID)
 		isTerminated, err := sessionIdManager.Validate(sessionID)
 		if err != nil {
-			http.Error(w, "Invalid session ID", http.StatusBadRequest)
+			http.Error(w, "Invalid session ID", http.StatusNotFound)
 			return
 		}
 		if isTerminated {
@@ -734,7 +734,7 @@ func (s *StreamableHTTPServer) handleSamplingResponse(w http.ResponseWriter, r *
 	sessionIdManager := s.sessionIdManagerResolver.ResolveSessionIdManager(r)
 	isTerminated, err := sessionIdManager.Validate(sessionID)
 	if err != nil {
-		http.Error(w, "Invalid session ID", http.StatusBadRequest)
+		http.Error(w, "Invalid session ID", http.StatusNotFound)
 		return err
 	}
 	if isTerminated {

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -255,8 +255,8 @@ func TestStreamableHTTP_POST_SendAndReceive(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode != 400 {
-			t.Errorf("Expected status 400, got %d", resp.StatusCode)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected status 404, got %d", resp.StatusCode)
 		}
 	})
 
@@ -1458,8 +1458,8 @@ func TestStreamableHTTP_SessionValidation(t *testing.T) {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode != http.StatusBadRequest {
-			t.Errorf("Expected status 400, got %d", resp.StatusCode)
+		if resp.StatusCode != http.StatusNotFound {
+			t.Errorf("Expected status 404, got %d", resp.StatusCode)
 		}
 
 		body, _ := io.ReadAll(resp.Body)


### PR DESCRIPTION
Per MCP specification, invalid/expired session IDs should return HTTP 404 Not Found so clients can detect and re-initialize sessions.

# PR: fix: return 404 instead of 400 for invalid/expired session IDs

## MCP Specification Reference

From [MCP Transports Specification - Session Management](https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#session-management) (Protocol Revision: **2025-11-25**, current version):

> ### Session Management
>
> ...
>
> 3. The server **MAY** terminate the session at any time, after which it **MUST** respond to requests containing that session ID with **HTTP 404 Not Found**.
>
> 4. When a client receives **HTTP 404** in response to a request containing an `MCP-Session-Id`, it **MUST** start a new session by sending a new `InitializeRequest` without a session ID attached.

**Key point**: The specification explicitly requires **404 Not Found** for invalid/expired sessions, not 400 Bad Request. The 400 status code is reserved for requests missing a required session ID header:

> 2. ... Servers that require a session ID **SHOULD** respond to requests without an `MCP-Session-Id` header (other than initialization) with **HTTP 400 Bad Request**.

## Problem

Currently, `StreamableHTTPServer` returns **400 Bad Request** when `SessionIdManager.Validate()` returns an error. This includes:
- Session not found (server restart, session expired)
- Invalid session ID format

This prevents clients (Cursor, VSCode, Cherry Studio, Claude Code, etc.) from correctly detecting session expiration and re-initializing.

### Real-world Scenario

When using MCP clients like Cherry Studio or Cursor to connect to a Streamable HTTP MCP server:

1. **Initial connection works fine** - client connects, receives `MCP-Session-Id`, and can list tools
2. **Network interruption occurs** - client temporarily loses connection (e.g., WiFi disconnect, sleep mode)
3. **Client attempts to reconnect** - uses the cached `MCP-Session-Id` from previous session
4. **Server returns 400 Bad Request** - because the session no longer exists (server may have restarted, or session expired)
5. **Client fails to recover** - receives 400, doesn't know it should re-initialize, shows error like:
   ```
   Error invoking remote method 'mcp:list-tools':
   McpError: MCP error -32001: Request timed out
   ```

**With the fix (returning 404):**
- Client receives 404, recognizes this means "session invalid"
- Client automatically sends a new `InitializeRequest` without session ID
- Connection is re-established seamlessly

## Solution

Change the status code from `http.StatusBadRequest` (400) to `http.StatusNotFound` (404) for invalid session ID errors.

## Changes

### server/streamable_http.go

**Line ~348:**
```diff
 isTerminated, err := sessionIdManager.Validate(sessionID)
 if err != nil {
-    http.Error(w, "Invalid session ID", http.StatusBadRequest)
+    http.Error(w, "Invalid session ID", http.StatusNotFound)
     return
 }
```

**Line ~709:**
```diff
 isTerminated, err := sessionIdManager.Validate(sessionID)
 if err != nil {
-    http.Error(w, "Invalid session ID", http.StatusBadRequest)
+    http.Error(w, "Invalid session ID", http.StatusNotFound)
     return err
 }
```

## Testing

1. Create a stateful MCP server
2. Initialize a session and get `MCP-Session-Id`
3. Restart the server (session data lost)
4. Send a request with the old session ID
5. Expected: HTTP 404 Not Found
6. Actual (before fix): HTTP 400 Bad Request

## Related Issues

- TypeScript SDK had the same issue: https://github.com/modelcontextprotocol/typescript-sdk/issues/389
- Multiple clients (Cursor, VSCode, Claude) have issues handling session expiration due to this

## Impact

This is a breaking change for clients that specifically check for 400 status code, but it aligns with the MCP specification and enables proper session recovery behavior.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or malformed session IDs now return HTTP 404 (Not Found) instead of HTTP 400 (Bad Request), providing more semantically correct error responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->