### PR TITLE
fix: rename NewToolResultAudio second parameter from imageData to aud…

### DIFF
--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -353,7 +353,7 @@ func NewToolResultImage(text, imageData, mimeType string) *CallToolResult {
 }
 
 // NewToolResultAudio creates a new CallToolResult with both text and audio content
-func NewToolResultAudio(text, imageData, mimeType string) *CallToolResult {
+func NewToolResultAudio(text, audioData, mimeType string) *CallToolResult {
 	return &CallToolResult{
 		Content: []Content{
 			TextContent{
@@ -362,7 +362,7 @@ func NewToolResultAudio(text, imageData, mimeType string) *CallToolResult {
 			},
 			AudioContent{
 				Type:     ContentTypeAudio,
-				Data:     imageData,
+				Data:     audioData,
 				MIMEType: mimeType,
 			},
 		},


### PR DESCRIPTION
### Background
The second parameter of the function `NewToolResultAudio` was incorrectly named `imageData`, 
but it actually represents audio data. This misleading name can confuse developers 
and reduces code readability.

### Changes
- Renamed the second parameter from `imageData` to `audioData`
- Updated all references inside the function; logic remains unchanged

### Impact
- Improves code readability
- Avoids potential confusion for developers
- Does not affect the function behavior or existing calls


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed misleading parameter naming in audio result functionality to accurately reflect the type of data being processed.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->