### PR TITLE
fix: ToolInputSchema inherits MarshalJSON from ToolArgumentsSchema

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -642,8 +642,8 @@ type ToolArgumentsSchema struct {
 	AdditionalProperties any            `json:"additionalProperties,omitempty"`
 }
 
-type ToolInputSchema ToolArgumentsSchema // For retro-compatibility
-type ToolOutputSchema ToolArgumentsSchema
+type ToolInputSchema = ToolArgumentsSchema // For retro-compatibility (true alias, inherits methods)
+type ToolOutputSchema = ToolArgumentsSchema
 
 // MarshalJSON implements the json.Marshaler interface for ToolInputSchema.
 func (tis ToolArgumentsSchema) MarshalJSON() ([]byte, error) {

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -1765,3 +1765,37 @@ func TestWithSchemaAdditionalProperties(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), `"additionalProperties":false`)
 }
+
+// TestToolInputSchema_MarshalJSON_EmptyProperties verifies that ToolInputSchema
+// inherits the MarshalJSON method from ToolArgumentsSchema, ensuring that
+// the 'properties' field is included in JSON output even when empty.
+// This fixes issue #694.
+func TestToolInputSchema_MarshalJSON_EmptyProperties(t *testing.T) {
+	schema := ToolInputSchema{
+		Type:       "object",
+		Properties: map[string]any{}, // empty but not nil
+	}
+
+	b, err := json.Marshal(schema)
+	assert.NoError(t, err)
+
+	result := string(b)
+	// Ensure 'properties' field is present in JSON output
+	assert.Contains(t, result, `"properties"`, "Expected properties field in JSON output")
+	// Verify the full expected output
+	assert.Contains(t, result, `"properties":{}`, "Expected empty properties object in JSON output")
+}
+
+// TestToolOutputSchema_MarshalJSON_EmptyProperties verifies the same for ToolOutputSchema.
+func TestToolOutputSchema_MarshalJSON_EmptyProperties(t *testing.T) {
+	schema := ToolOutputSchema{
+		Type:       "object",
+		Properties: map[string]any{}, // empty but not nil
+	}
+
+	b, err := json.Marshal(schema)
+	assert.NoError(t, err)
+
+	result := string(b)
+	assert.Contains(t, result, `"properties":{}`, "Expected empty properties object in JSON output")
+}


### PR DESCRIPTION
## Summary

- Changed `ToolInputSchema` and `ToolOutputSchema` from type definitions to type aliases
- This ensures they properly inherit the `MarshalJSON` method from `ToolArgumentsSchema`
- The `properties` field is now always included in JSON output, even when empty

Fixes #694

## Problem

`ToolInputSchema` was defined as:
```go
type ToolInputSchema ToolArgumentsSchema // type definition
```

This meant it didn't inherit `MarshalJSON`, causing `properties` to be omitted when empty.

## Solution

Changed to a type alias:
```go
type ToolInputSchema = ToolArgumentsSchema // type alias, inherits methods
```

## Test plan

- [x] Added `TestToolInputSchema_MarshalJSON_EmptyProperties` test
- [x] Added `TestToolOutputSchema_MarshalJSON_EmptyProperties` test
- [x] All existing tests pass (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified internal type structure for improved code consistency and maintainability.

* **Tests**
  * Added test coverage to verify proper JSON serialization behavior with empty data structures, enhancing system reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->