### PR TITLE
refactor: simplify tests with the usetesting linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,12 @@ version: "2"
 linters:
   enable:
     - modernize
+    - usetesting
+  settings:
+    usetesting:
+      context-background: true
+      context-todo: true
+      os-temp-dir: true
   exclusions:
     presets:
       - std-error-handling

--- a/client/issue583_test.go
+++ b/client/issue583_test.go
@@ -3,7 +3,6 @@ package client
 import (
 	"context"
 	"os"
-	"runtime"
 	"testing"
 	"time"
 
@@ -15,22 +14,16 @@ import (
 // where using transport.NewStdioWithOptions directly followed by client.Start()
 // would fail with "stdio client not started" error
 func TestDirectTransportCreation(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath)
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	// This is the pattern from issue #583 that was broken
 	tport := transport.NewStdioWithOptions(mockServerPath, nil, nil)
@@ -68,22 +61,16 @@ func TestDirectTransportCreation(t *testing.T) {
 
 // TestNewStdioMCPClientWithOptions tests that the old pattern still works
 func TestNewStdioMCPClientWithOptions(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath)
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	// This pattern was already working
 	cli, err := NewStdioMCPClientWithOptions(mockServerPath, nil, nil)
@@ -123,22 +110,16 @@ func TestNewStdioMCPClientWithOptions(t *testing.T) {
 
 // TestMultipleClientStartCalls tests that calling client.Start() multiple times is safe
 func TestMultipleClientStartCalls(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath)
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	tport := transport.NewStdioWithOptions(mockServerPath, nil, nil)
 	cli := NewClient(tport)

--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -42,23 +41,16 @@ func compileTestServer(outputPath string) error {
 
 func TestStdioMCPClient(t *testing.T) {
 	// Create a temporary file for the mock server
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	// Add .exe suffix on Windows
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath) // Remove the empty file first
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	client, err := NewStdioMCPClient(mockServerPath, []string{})
 	if err != nil {

--- a/client/transport/stdio_idempotent_test.go
+++ b/client/transport/stdio_idempotent_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"os/exec"
-	"runtime"
 	"testing"
 	"time"
 
@@ -13,22 +12,16 @@ import (
 
 // TestStdio_StartIdempotency tests that calling Start() multiple times is safe
 func TestStdio_StartIdempotency(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath)
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	stdio := NewStdio(mockServerPath, nil)
 
@@ -96,22 +89,16 @@ func TestStdio_StartFailureReset(t *testing.T) {
 
 // TestStdio_StartWithOptions_Idempotent tests idempotency with custom options
 func TestStdio_StartWithOptions_Idempotent(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath)
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	cmdFuncCallCount := 0
 	cmdFunc := func(ctx context.Context, command string, env []string, args []string) (*exec.Cmd, error) {

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -44,23 +44,16 @@ func compileTestServer(outputPath string) error {
 
 func TestStdio(t *testing.T) {
 	// Create a temporary file for the mock server
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	// Add .exe suffix on Windows
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath) // Remove the empty file first
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	// Create a new Stdio transport
 	stdio := NewStdio(mockServerPath, nil)
@@ -425,7 +418,7 @@ func TestStdioErrors(t *testing.T) {
 
 	t.Run("RequestBeforeStart", func(t *testing.T) {
 		// Create a temporary file for the mock server
-		tempFile, err := os.CreateTemp("", "mockstdio_server")
+		tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 		if err != nil {
 			t.Fatalf("Failed to create temp file: %v", err)
 		}
@@ -441,7 +434,6 @@ func TestStdioErrors(t *testing.T) {
 		if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 			t.Fatalf("Failed to compile mock server: %v", compileErr)
 		}
-		defer os.Remove(mockServerPath)
 
 		uninitiatedStdio := NewStdio(mockServerPath, nil)
 
@@ -464,23 +456,16 @@ func TestStdioErrors(t *testing.T) {
 
 	t.Run("RequestAfterClose", func(t *testing.T) {
 		// Create a temporary file for the mock server
-		tempFile, err := os.CreateTemp("", "mockstdio_server")
+		tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 		if err != nil {
 			t.Fatalf("Failed to create temp file: %v", err)
 		}
 		tempFile.Close()
-		mockServerPath := tempFile.Name()
-
-		// Add .exe suffix on Windows
-		if runtime.GOOS == "windows" {
-			os.Remove(mockServerPath) // Remove the empty file first
-			mockServerPath += ".exe"
-		}
+		mockServerPath := tempFile.Name() + ".exe"
 
 		if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 			t.Fatalf("Failed to compile mock server: %v", compileErr)
 		}
-		defer os.Remove(mockServerPath)
 
 		// Create a new Stdio transport
 		stdio := NewStdio(mockServerPath, nil)
@@ -705,22 +690,16 @@ func TestStdio_NewStdioWithOptions_AppliesOptions(t *testing.T) {
 }
 
 func TestStdio_LargeMessages(t *testing.T) {
-	tempFile, err := os.CreateTemp("", "mockstdio_server")
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	tempFile.Close()
-	mockServerPath := tempFile.Name()
-
-	if runtime.GOOS == "windows" {
-		os.Remove(mockServerPath)
-		mockServerPath += ".exe"
-	}
+	mockServerPath := tempFile.Name() + ".exe"
 
 	if compileErr := compileTestServer(mockServerPath); compileErr != nil {
 		t.Fatalf("Failed to compile mock server: %v", compileErr)
 	}
-	defer os.Remove(mockServerPath)
 
 	stdio := NewStdio(mockServerPath, nil)
 


### PR DESCRIPTION
## Description

The PR enables the [`usetesting`](https://golangci-lint.run/docs/linters/configuration/#usetesting) linter and simplifies tests according to the linter's suggestions. 

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [x] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information

```console
$ golangci-lint run
client/issue583_test.go:18:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestDirectTransportCreation (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
client/issue583_test.go:71:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestNewStdioMCPClientWithOptions (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
client/issue583_test.go:126:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestMultipleClientStartCalls (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
client/stdio_test.go:45:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestStdioMCPClient (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
client/transport/stdio_idempotent_test.go:16:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestStdio_StartIdempotency (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
client/transport/stdio_idempotent_test.go:99:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestStdio_StartWithOptions_Idempotent (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
client/transport/stdio_test.go:47:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestStdio (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
client/transport/stdio_test.go:428:20: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestStdioErrors (usetesting)
                tempFile, err := os.CreateTemp("", "mockstdio_server")
                                 ^
client/transport/stdio_test.go:467:20: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestStdioErrors (usetesting)
                tempFile, err := os.CreateTemp("", "mockstdio_server")
                                 ^
client/transport/stdio_test.go:708:19: os.CreateTemp("", ...) could be replaced by os.CreateTemp(t.TempDir(), ...) in TestStdio_LargeMessages (usetesting)
        tempFile, err := os.CreateTemp("", "mockstdio_server")
                         ^
10 issues:
* usetesting: 10
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to use per-test temporary directories for improved isolation.
  * Standardized executable path naming across all test cases.
  * Simplified test cleanup by relying on automatic directory cleanup.

* **Chores**
  * Enabled "usetesting" linter with additional configuration settings to enhance code quality checks.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->