### PR TITLE
Fix no way to detect connection closure in non-NO_ERROR cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ For examples, see the [`examples/`](examples/) directory.
 
 ### Transports
 
-MCP-Go supports stdio, SSE and streamable-HTTP transport layers. For SSE transport, you can use `SetConnectionLostHandler()` to detect and handle HTTP/2 idle timeout disconnections (NO_ERROR) for implementing reconnection logic.
+MCP-Go supports stdio, SSE and streamable-HTTP transport layers. For SSE transport, you can use `SetConnectionLostHandler()` to detect and handle disconnections for implementing reconnection logic.
 
 ### Session Management
 


### PR DESCRIPTION
## Description
<!-- Provide a concise description of the changes in this PR -->
When attempting to use **SetConnectionLostHandler** to handle connection closures, I found that it only handles the NO_ERROR case, which greatly limits its applicability.

However, in situations such as SSE server restarts or connection timeouts, the error usually does not include NO_ERROR. Once the connection is closed, the SSE server destroys the Session ID, causing subsequent requests to fail with an "Invalid Session ID" error.

This means there is no way to actively listen for connection closures caused by errors other than NO_ERROR.

Additionally, the name **SetConnectionLostHandler** is misleading, as it may give users the false impression that it handles all connection closure cases. I believe that determining the specific error type should be left to the implementer rather than handled by the framework. This would improve the flexibility of error handling.

## Type of Change
<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist
<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance
<!-- If this PR implements a feature from the MCP specification, please answer the following -->
<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [x] Implementation follows the specification exactly

## Additional Information
<!-- Any additional information that might be useful for reviewers -->
<!-- If not applicable, remove this section -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for Server-Sent Events (SSE) connections—connection loss handlers are now consistently invoked when disconnections occur, improving reliability.

* **Documentation**
  * Simplified and clarified SSE disconnection handling documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->