### PR TITLE
fix: SendRequest hangs forever when server process dies

### DIFF
--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -299,6 +301,396 @@ func TestStdioMCPClient(t *testing.T) {
 			t.Errorf("Expected log message 'launch successful', got '%s'", msg)
 		}
 	})
+}
+
+func TestStdio_SendRequestReturnsWhenTransportCloses(t *testing.T) {
+	// This test verifies that SendRequest unblocks automatically when the
+	// server process dies (EOF on stdout). Before the fix, SendRequest only
+	// selected on ctx.Done() and responseChan — it would hang forever because
+	// readResponses exited silently without signaling the done channel.
+	//
+	// The fix has two parts:
+	//   1. readResponses calls closeDone() on unexpected exit (EOF/error),
+	//      so in-flight requests unblock without external intervention.
+	//   2. SendRequest's select includes <-c.done so it returns immediately
+	//      when the done channel is closed.
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+	defer serverRead.Close()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+
+	c := NewClient(stdioTransport)
+	defer c.Close()
+
+	// Drain serverRead so the write doesn't block
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := serverRead.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	// SendRequest in a goroutine — it will write the request (succeeds)
+	// then block waiting for a response that will never come.
+	errChan := make(chan error, 1)
+	go func() {
+		req := mcp.InitializeRequest{}
+		req.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+		req.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "1.0"}
+		_, err := c.Initialize(context.Background(), req)
+		errChan <- err
+	}()
+
+	// Give SendRequest time to send the request and enter the response-wait select
+	time.Sleep(50 * time.Millisecond)
+
+	// Simulate server death: close the server's write end → EOF on client read.
+	// readResponses should detect EOF, call closeDone(), and SendRequest should
+	// unblock automatically — no explicit Close() needed.
+	serverWrite.Close()
+
+	select {
+	case err := <-errChan:
+		require.ErrorIs(t, err, transport.ErrTransportClosed)
+	case <-time.After(5 * time.Second):
+		t.Fatal("SendRequest hung for 5s — deadlock not fixed")
+	}
+}
+
+func TestStdio_SendRequestReturnsImmediatelyWhenAlreadyClosed(t *testing.T) {
+	// Verify the pre-check in SendRequest catches an already-closed transport
+	// before doing any work (no write attempted).
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+	defer serverRead.Close()
+	defer serverWrite.Close()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+
+	c := NewClient(stdioTransport)
+	c.Close()
+
+	req := mcp.InitializeRequest{}
+	req.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	req.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "1.0"}
+	_, err := c.Initialize(context.Background(), req)
+	require.ErrorIs(t, err, transport.ErrTransportClosed)
+}
+
+func TestStdio_SendNotificationReturnsWhenTransportClosed(t *testing.T) {
+	// Verify SendNotification returns ErrTransportClosed after Close().
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+	defer serverRead.Close()
+	defer serverWrite.Close()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+
+	c := NewClient(stdioTransport)
+	c.Close()
+
+	notification := mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+	}
+	notification.Method = "notifications/initialized"
+
+	err := stdioTransport.SendNotification(context.Background(), notification)
+	require.ErrorIs(t, err, transport.ErrTransportClosed)
+}
+
+func TestStdio_SendNotificationReturnsWhenContextCancelled(t *testing.T) {
+	// Verify SendNotification returns ctx.Err() when context is already cancelled.
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+	defer serverRead.Close()
+	defer serverWrite.Close()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+
+	defer stdioTransport.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	notification := mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+	}
+	notification.Method = "notifications/initialized"
+
+	err := stdioTransport.SendNotification(ctx, notification)
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStdio_ConcurrentCloseDoesNotPanic(t *testing.T) {
+	// Verify that calling Close() concurrently from multiple goroutines
+	// does not panic (sync.Once protects the done channel close).
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+	defer serverRead.Close()
+	defer serverWrite.Close()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+
+	c := NewClient(stdioTransport)
+
+	var wg sync.WaitGroup
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			c.Close()
+		}()
+	}
+	wg.Wait()
+	// If we get here without a panic, sync.Once is working correctly.
+}
+
+func TestStdio_CloseCleanupRunsAfterReadResponsesCloseDone(t *testing.T) {
+	// Verify that Close() still performs resource cleanup (stdin, stderr)
+	// even when readResponses has already called closeDone() on EOF.
+	// Before the fix, Close() had an early-return guard on <-c.done that
+	// would skip cleanup entirely, leaking FDs and creating zombie processes.
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+
+	// Drain writes so nothing blocks
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, err := serverRead.Read(buf); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Simulate server death — readResponses will call closeDone()
+	serverWrite.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	// Close() should still run cleanup without error, even though done is
+	// already closed. If the old early-return guard were still present,
+	// Close() would return nil immediately and skip stdin cleanup.
+	err := stdioTransport.Close()
+	// stdin (clientWrite) should now be closed by cleanup
+	require.NoError(t, err)
+
+	// Verify stdin is actually closed by trying to write to it
+	_, writeErr := clientWrite.Write([]byte("test\n"))
+	require.Error(t, writeErr, "stdin should be closed after Close()")
+}
+
+func TestStdio_ConcurrentRequestsAllReceiveResponses(t *testing.T) {
+	// Stress test: fire N concurrent requests through the transport and verify
+	// every request receives its matching response. This tests for race conditions
+	// in the response routing (map access, channel delivery) and concurrent
+	// stdin writes. If any response is dropped or misrouted, the test fails.
+	//
+	// This is a regression test for issue #65 (MCP server hang after rapid tool
+	// calls) — the theory is that concurrent requests can trigger a race in the
+	// transport that causes a response to be lost.
+	const numRequests = 50
+
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+	defer stdioTransport.Close()
+
+	// Mock server: read JSON-RPC requests, respond with matching IDs after
+	// a small random delay to simulate real-world server behavior.
+	go func() {
+		defer serverWrite.Close()
+		scanner := json.NewDecoder(serverRead)
+		for {
+			var req map[string]any
+			if err := scanner.Decode(&req); err != nil {
+				return
+			}
+
+			id := req["id"]
+			method, _ := req["method"].(string)
+
+			// Only respond to non-notification messages (those with an id)
+			if id == nil {
+				continue
+			}
+
+			// Simulate varying server response times (0-5ms)
+			if idNum, ok := id.(float64); ok {
+				time.Sleep(time.Duration(int(idNum)%5) * time.Millisecond)
+			}
+
+			var resp map[string]any
+			if method == "initialize" {
+				resp = map[string]any{
+					"jsonrpc": "2.0",
+					"id":      id,
+					"result": map[string]any{
+						"protocolVersion": "2024-11-05",
+						"capabilities":    map[string]any{},
+						"serverInfo": map[string]any{
+							"name":    "stress-test-server",
+							"version": "1.0.0",
+						},
+					},
+				}
+			} else {
+				resp = map[string]any{
+					"jsonrpc": "2.0",
+					"id":      id,
+					"result": map[string]any{
+						"tools": []any{},
+					},
+				}
+			}
+
+			respBytes, _ := json.Marshal(resp)
+			respBytes = append(respBytes, '\n')
+			if _, err := serverWrite.Write(respBytes); err != nil {
+				return
+			}
+		}
+	}()
+
+	c := NewClient(stdioTransport)
+	defer c.Close()
+
+	// Initialize first (required before other requests)
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "stress-test", Version: "1.0"}
+	_, err := c.Initialize(context.Background(), initReq)
+	require.NoError(t, err)
+
+	// Fire N concurrent ListTools requests
+	var wg sync.WaitGroup
+	errCh := make(chan error, numRequests)
+
+	for i := range numRequests {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+			if err != nil {
+				errCh <- fmt.Errorf("request %d failed: %w", i, err)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+	require.Empty(t, errs, "Some concurrent requests failed: %v", errs)
+}
+
+func TestStdio_ConcurrentRequestsUnblockOnServerDeath(t *testing.T) {
+	// Stress test: fire N concurrent requests, then kill the server mid-flight.
+	// Every in-flight request must unblock with an error (not hang). This tests
+	// that readResponses calling closeDone() on EOF correctly unblocks all
+	// pending SendRequest calls, not just one.
+	const numRequests = 20
+
+	clientRead, serverWrite := io.Pipe()
+	serverRead, clientWrite := io.Pipe()
+
+	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
+	require.NoError(t, stdioTransport.Start(context.Background()))
+	defer stdioTransport.Close()
+
+	// Mock server: read requests but only respond to "initialize", then
+	// stop responding (simulating a slow/hanging server).
+	go func() {
+		scanner := json.NewDecoder(serverRead)
+		for {
+			var req map[string]any
+			if err := scanner.Decode(&req); err != nil {
+				return
+			}
+
+			id := req["id"]
+			method, _ := req["method"].(string)
+			if id == nil {
+				continue
+			}
+
+			if method == "initialize" {
+				resp := map[string]any{
+					"jsonrpc": "2.0",
+					"id":      id,
+					"result": map[string]any{
+						"protocolVersion": "2024-11-05",
+						"capabilities":    map[string]any{},
+						"serverInfo": map[string]any{
+							"name":    "death-test-server",
+							"version": "1.0.0",
+						},
+					},
+				}
+				respBytes, _ := json.Marshal(resp)
+				respBytes = append(respBytes, '\n')
+				_, _ = serverWrite.Write(respBytes)
+			}
+			// Non-initialize requests: no response (simulates hang)
+		}
+	}()
+
+	c := NewClient(stdioTransport)
+	defer c.Close()
+
+	// Initialize first
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "death-test", Version: "1.0"}
+	_, err := c.Initialize(context.Background(), initReq)
+	require.NoError(t, err)
+
+	// Fire N concurrent requests that will never get a response
+	var wg sync.WaitGroup
+	errCh := make(chan error, numRequests)
+
+	for i := range numRequests {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_, err := c.ListTools(ctx, mcp.ListToolsRequest{})
+			errCh <- err
+		}(i)
+	}
+
+	// Let all requests enter the response-wait select
+	time.Sleep(50 * time.Millisecond)
+
+	// Kill the server
+	serverWrite.Close()
+
+	// All requests must unblock within the timeout
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		require.Error(t, err, "Expected error from server death, got nil")
+	}
 }
 
 func TestStdio_NewStdioMCPClientWithOptions_CreatesAndStartsClient(t *testing.T) {


### PR DESCRIPTION
## Description

`SendRequest` hangs forever when the server process dies (crash, pipe break, startup failure). The reader goroutine exits on EOF but never signals the `done` channel, so in-flight requests block indefinitely waiting for a response that will never come. This causes MCP clients using the stdio transport to become permanently unresponsive.

**Root cause:** `readResponses` exited silently on EOF/error without closing the `done` channel, and `SendRequest`'s `select` only watched `ctx.Done()` and `responseChan` — it had no way to know the server was gone.

### Changes (`client/transport/stdio.go`)

1. **`closeDone()` with `sync.Once`** — safely closes the `done` channel from multiple goroutines without panicking on double-close.
2. **`readResponses` calls `closeDone()` on exit** — EOF or read error now immediately unblocks all in-flight `SendRequest` calls.
3. **`SendRequest` selects on `<-c.done`** — both in the pre-check and in the response-wait `select`, returning `ErrTransportClosed` immediately when the server dies. Drains `responseChan` first to avoid dropping a valid response delivered just before the `done` channel closed.
4. **`SendNotification` gets matching `done`/`ctx` pre-check** — consistency with `SendRequest`.
5. **`Close()` uses `closeCleanupOnce`** — always performs resource cleanup (stdin, stderr, `cmd.Wait`) even when `readResponses` already called `closeDone()`, preventing FD leaks and zombie processes. The old early-return guard on `<-c.done` would skip cleanup entirely.
6. **Export `ErrTransportClosed` sentinel** — enables callers to use `errors.Is(err, transport.ErrTransportClosed)` for proper error handling.

### Tests (`client/stdio_test.go`) — 8 new test functions

| Test | What it verifies |
|------|-----------------|
| `TestStdio_SendRequestReturnsWhenTransportCloses` | SendRequest unblocks automatically on server death (EOF) |
| `TestStdio_SendRequestReturnsImmediatelyWhenAlreadyClosed` | Pre-check returns `ErrTransportClosed` immediately |
| `TestStdio_SendNotificationReturnsWhenTransportClosed` | SendNotification returns `ErrTransportClosed` after Close() |
| `TestStdio_SendNotificationReturnsWhenContextCancelled` | SendNotification returns `ctx.Err()` when context cancelled |
| `TestStdio_ConcurrentCloseDoesNotPanic` | 10 concurrent Close() calls don't panic (`sync.Once` safety) |
| `TestStdio_CloseCleanupRunsAfterReadResponsesCloseDone` | Close() still cleans up FDs after readResponses already called closeDone() |
| `TestStdio_ConcurrentRequestsAllReceiveResponses` | 50 parallel requests all get correct responses (response routing stress test) |
| `TestStdio_ConcurrentRequestsUnblockOnServerDeath` | 20 parallel in-flight requests all unblock on server death |

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

**Reproducing the bug:** Any `SendRequest` call through the stdio transport will hang indefinitely if the server process exits before responding. This is easy to trigger with short-lived or crashing servers, and there's no workaround other than using a context with a timeout (which still leaks the goroutine).

**Backward compatibility:** The only new public symbol is `ErrTransportClosed`. All behavioral changes are strictly bug fixes — the transport now correctly reports errors instead of silently hanging. Existing callers using context timeouts will see the faster `ErrTransportClosed` error instead of waiting for the deadline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced `ErrTransportClosed` error to signal operations on closed transports.

* **Bug Fixes**
  * Enhanced transport closure handling to safely manage concurrent Close calls and prevent deadlocks.
  * Improved server disconnection handling to properly unblock in-flight requests.
  * Added protection against resource leaks during cleanup.

* **Tests**
  * Comprehensive test suite covering transport closure, context cancellation, concurrent scenarios, and server disconnection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->