### PR TITLE
added empty `properties` property to InputSchema to placate OpenAI mo…

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -662,7 +662,7 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 type ToolArgumentsSchema struct {
 	Defs                 map[string]any `json:"$defs,omitempty"`
 	Type                 string         `json:"type"`
-	Properties           map[string]any `json:"properties,omitempty"`
+	Properties           map[string]any `json:"properties"` // certain models (currently verified: GPT-5x-Codex) requires this to be present, even if empty
 	Required             []string       `json:"required,omitempty"`
 	AdditionalProperties any            `json:"additionalProperties,omitempty"`
 }

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -1742,6 +1742,18 @@ func TestToolArgumentsSchema_MarshalWithAdditionalProperties(t *testing.T) {
 	assert.Contains(t, string(data), `"additionalProperties":false`)
 }
 
+func TestToolArgumentsSchema_EmptyProperties(t *testing.T) {
+	schema := ToolArgumentsSchema{
+		Type:                 "object",
+		AdditionalProperties: nil,
+	}
+
+	data, err := json.Marshal(schema)
+	assert.NoError(t, err)
+	assert.Contains(t, string(data), `"properties":{}`)
+
+}
+
 func TestToolArgumentsSchema_MarshalOmitsNilAdditionalProperties(t *testing.T) {
 	schema := ToolArgumentsSchema{
 		Type:                 "object",


### PR DESCRIPTION
added empty `properties` property to InputSchema to placate OpenAI models (#719)

## Description

removed `omitempty` json encoding tag to leaves empty `properties` property in `ToolArgumentsSchema` and test this behavior.

Fixes #719

## Type of Change

- [x ] Bug fix (non-breaking change that fixes an issue)

- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly (code comment + issue + PR)

## Additional Information

This feature adds an explicit `properties` property where it is not strictly necessary (nor forbidden). I don't have an overview of where this library is used downstream or have the possibility to test those implementations. The change seems rather innocuous, though (famous last words)...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON serialization to always include the properties field in output, even when empty, improving compatibility with certain AI models.
* **Tests**
  * Added test coverage for empty properties serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->