### PR TITLE
Add RFC 7591 client_uri support in dynamic client registration

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -21,6 +21,8 @@ var ErrNoToken = errors.New("no token available")
 type OAuthConfig struct {
 	// ClientID is the OAuth client ID
 	ClientID string
+	// ClientURI is the URI of the client
+	ClientURI string
 	// ClientSecret is the OAuth client secret (for confidential clients)
 	ClientSecret string
 	// RedirectURI is the redirect URI for the OAuth flow
@@ -559,6 +561,10 @@ func (h *OAuthHandler) RegisterClient(ctx context.Context, clientName string) er
 		"grant_types":                []string{"authorization_code", "refresh_token"},
 		"response_types":             []string{"code"},
 		"scope":                      strings.Join(h.config.Scopes, " "),
+	}
+
+	if h.config.ClientURI != "" {
+		regRequest["client_uri"] = h.config.ClientURI
 	}
 
 	// Add client_secret if this is a confidential client


### PR DESCRIPTION
## Description

Add client_uri support to dynamic client registration per [RFC 7591 Section 2](https://datatracker.ietf.org/doc/html/rfc7591#section-2).

When ClientURI is set in OAuthConfig, it is included in the registration request body. This allows authorization servers to display client information to end users during the consent flow.

## Type of Change

<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

<!-- If this PR implements a feature from the MCP specification, please answer the following -->

<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [RFC 7591 - OAuth 2.0 Dynamic Client Registration](https://datatracker.ietf.org/doc/html/rfc7591#section-2)
- [x] Implementation follows the specification exactly

## Additional Information

<!-- Any additional information that might be useful for reviewers -->

<!-- If not applicable, remove this section -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a Client URI in OAuth settings, which is now included in client registration requests when specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->