### PR TITLE
fix: deliver server-initiated requests (elicitation, sampling, roots) via POST response SSE

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -428,40 +428,61 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	done := make(chan struct{})
 
 	ctx = context.WithValue(ctx, requestHeader, r.Header)
+
+	// writeSSEToResponse writes an SSE event to the POST response stream, upgrading
+	// the response to text/event-stream on first use. This enables delivery of
+	// server-initiated requests (elicitation, sampling, roots) on the same POST
+	// connection that triggered them, per MCP spec recommendation.
+	writeSSEToResponse := func(data any) {
+		mu.Lock()
+		defer mu.Unlock()
+		select {
+		case <-done:
+			return
+		default:
+		}
+		defer func() {
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}()
+		if !upgradedHeader {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.WriteHeader(http.StatusOK)
+			upgradedHeader = true
+		}
+		if err := writeSSEEvent(w, data); err != nil {
+			s.logger.Errorf("Failed to write SSE event: %v", err)
+		}
+	}
+
 	go func() {
 		for {
 			select {
 			case nt := <-session.notificationChannel:
-				func() {
-					mu.Lock()
-					defer mu.Unlock()
-					// if the done chan is closed, as the request is terminated, just return
-					select {
-					case <-done:
-						return
-					default:
-					}
-					defer func() {
-						flusher, ok := w.(http.Flusher)
-						if ok {
-							flusher.Flush()
-						}
-					}()
-
-					// if there's notifications, upgradedHeader to SSE response
-					if !upgradedHeader {
-						w.Header().Set("Content-Type", "text/event-stream")
-						w.Header().Set("Connection", "keep-alive")
-						w.Header().Set("Cache-Control", "no-cache")
-						w.WriteHeader(http.StatusOK)
-						upgradedHeader = true
-					}
-					err := writeSSEEvent(w, nt)
-					if err != nil {
-						s.logger.Errorf("Failed to write SSE event: %v", err)
-						return
-					}
-				}()
+				writeSSEToResponse(&nt)
+			case samplingReq := <-session.samplingRequestChan:
+				writeSSEToResponse(mcp.JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(samplingReq.requestID),
+					Request: mcp.Request{Method: string(mcp.MethodSamplingCreateMessage)},
+					Params:  samplingReq.request.CreateMessageParams,
+				})
+			case elicitationReq := <-session.elicitationRequestChan:
+				writeSSEToResponse(mcp.JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(elicitationReq.requestID),
+					Request: mcp.Request{Method: string(mcp.MethodElicitationCreate)},
+					Params:  elicitationReq.request.Params,
+				})
+			case rootsReq := <-session.rootsRequestChan:
+				writeSSEToResponse(mcp.JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(rootsReq.requestID),
+					Request: mcp.Request{Method: string(mcp.MethodListRoots)},
+				})
 			case <-done:
 				return
 			case <-ctx.Done():


### PR DESCRIPTION
## Problem

Server-initiated requests (elicitation, sampling, roots/list) are only delivered via the GET/SSE listener in `handleGet()`. They are **not** delivered on the POST response SSE stream in `handlePost()`.

The POST handler's background goroutine only reads from `session.notificationChannel`. It does not read from `elicitationRequestChan`, `samplingRequestChan`, or `rootsRequestChan`:

```go
// BEFORE (handlePost goroutine)
select {
case nt := <-session.notificationChannel:
    // write SSE...
case <-done:
    return
case <-ctx.Done():
    return
}
```

This means clients that do not establish a separate GET/SSE listener connection — which is an **optional** part of the Streamable HTTP transport — never receive elicitation, sampling, or roots requests. These requests time out silently.

### MCP Spec Reference

From the [MCP Streamable HTTP specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http):

> *"The server SHOULD attempt to deliver JSON-RPC requests and responses that relate to a specific client request on the POST response stream for that request."*

### Real-World Impact

Many MCP clients (e.g., [MCPJam Inspector](https://github.com/nicholasgriffintn/mcp-inspector/issues/809)) only use POST requests and do not open a GET/SSE listener. For these clients:

- `RequestElicitation()` always times out
- `RequestSampling()` always times out
- `RequestRoots()` always times out

Even though the client advertises `elicitation: {}` capability in `initialize`.

## Fix

Add `elicitationRequestChan`, `samplingRequestChan`, and `rootsRequestChan` to the POST handler's goroutine `select` statement. Extract the SSE write logic into a shared `writeSSEToResponse` closure to avoid duplication.

```go
// AFTER (handlePost goroutine)
select {
case nt := <-session.notificationChannel:
    writeSSEToResponse(&nt)
case samplingReq := <-session.samplingRequestChan:
    writeSSEToResponse(mcp.JSONRPCRequest{...MethodSamplingCreateMessage...})
case elicitationReq := <-session.elicitationRequestChan:
    writeSSEToResponse(mcp.JSONRPCRequest{...MethodElicitationCreate...})
case rootsReq := <-session.rootsRequestChan:
    writeSSEToResponse(mcp.JSONRPCRequest{...MethodListRoots...})
case <-done:
    return
case <-ctx.Done():
    return
}
```

### Channel Safety

The channels are buffered (size 10) and use non-blocking sends, so adding readers in both `handleGet` and `handlePost` does not cause double-delivery — whichever goroutine reads first gets the message.

## Testing

- All existing `mcp-go` tests pass
- Verified end-to-end with MCPJam Inspector: elicitation requests are now delivered on the POST response and the client receives them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for three new real-time streaming event types via POST connections, enabling faster server-to-client communication for specific operations.
* **Improvements**
  * Enhanced streaming response handling with optimized event synchronization and header management for more reliable real-time data delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->