### PR TITLE
feat: add Description and WebsiteURL fields to Implementation struct

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -585,9 +585,11 @@ type Icon struct {
 
 // Implementation describes the name and version of an MCP implementation.
 type Implementation struct {
-	Name    string `json:"name"`
-	Version string `json:"version"`
-	Title   string `json:"title,omitempty"`
+	Name        string `json:"name"`
+	Version     string `json:"version"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	WebsiteURL  string `json:"websiteUrl,omitempty"`
 	// Icons provides visual identifiers for the implementation
 	Icons []Icon `json:"icons,omitempty"`
 }


### PR DESCRIPTION
## Description

Add missing `description` and `websiteUrl` optional fields to the `Implementation` struct,
aligning with the MCP spec (2025-11-25).

In our use case, we rely on `description` in `serverInfo` to provide LLMs with a
first-pass identification of the server's purpose during initialization, before
diving into specific tools and resources.

Both fields use `omitempty` tags, fully backward compatible.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Lifecycle - Implementation](https://modelcontextprotocol.io/specification/2025-11-25/basic/lifecycle)
- [x] Implementation follows the specification exactly