### PR TITLE
feat(transport): make SSE endpoint and response timeouts configurable

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -89,7 +89,9 @@ func WithOAuth(config OAuthConfig) ClientOption {
 // deadline, the shorter value is used.
 func WithEndpointTimeout(d time.Duration) ClientOption {
 	return func(sc *SSE) {
-		sc.endpointTimeout = d
+		if d > 0 {
+			sc.endpointTimeout = d
+		}
 	}
 }
 
@@ -98,7 +100,9 @@ func WithEndpointTimeout(d time.Duration) ClientOption {
 // deadline, the shorter value is used.
 func WithResponseTimeout(d time.Duration) ClientOption {
 	return func(sc *SSE) {
-		sc.responseTimeout = d
+		if d > 0 {
+			sc.responseTimeout = d
+		}
 	}
 }
 

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -827,6 +827,23 @@ func TestSSE_Start_CustomEndpointTimeout(t *testing.T) {
 	require.LessOrEqual(t, elapsed, customTimeout*2)
 }
 
+func TestSSE_NonPositiveTimeoutsKeepDefaults(t *testing.T) {
+	sse, err := NewSSE("http://localhost:8080")
+	require.NoError(t, err)
+
+	WithEndpointTimeout(0)(sse)
+	require.Equal(t, 30*time.Second, sse.endpointTimeout, "zero should keep default")
+
+	WithEndpointTimeout(-1 * time.Second)(sse)
+	require.Equal(t, 30*time.Second, sse.endpointTimeout, "negative should keep default")
+
+	WithResponseTimeout(0)(sse)
+	require.Equal(t, 60*time.Second, sse.responseTimeout, "zero should keep default")
+
+	WithResponseTimeout(-5 * time.Second)(sse)
+	require.Equal(t, 60*time.Second, sse.responseTimeout, "negative should keep default")
+}
+
 func TestSSE_Start_Unauthorized_StaticToken(t *testing.T) {
 	// Create a test server that always returns 401
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- Adds `WithEndpointTimeout` and `WithResponseTimeout` `ClientOption` functions to the SSE transport, allowing callers to override the hardcoded 30s/60s timeouts introduced in #668.
- Defaults are unchanged — this is a non-breaking addition.
- The `min(remaining_context, configured_timeout)` capping behavior is preserved.

## Motivation

PR #668 fixed #649 (SSE client blocking indefinitely on unresponsive servers) by adding hardcoded timeouts. However, the 60s response timeout is too low for legitimate slow queries — for example, Loki scanning weeks of logs can take 2–5 minutes. This makes the fix configurable so users can raise the cap when needed:

```go
transport, _ := transport.NewSSE(url,
    transport.WithResponseTimeout(5 * time.Minute),
)
```

## Test plan

- [x] Existing SSE transport tests pass (`go test ./client/transport/ -run SSE`)
- [x] Project builds cleanly (`go build ./...`)
- [x] Verify custom timeouts are respected in integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable timeout options for Server-Sent Events (SSE): endpoint timeout (default 30s) and response timeout (default 60s), both customizable.
* **Bug Fixes / Reliability**
  * SSE start and request handling now respect configured timeouts and context deadlines instead of hardcoded values.
* **Tests**
  * Added tests verifying custom timeouts, default behavior for non-positive values, and timeout enforcement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->