### PR TITLE
fix(oauth): Handle token_type case-insensitively per RFC 6749

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -171,9 +171,10 @@ func (h *OAuthHandler) GetAuthorizationHeader(ctx context.Context) (string, erro
 		return "", err
 	}
 
-	// Some auth implementations are strict about token type
+	// Per RFC 6749 §5.1, token_type is case-insensitive.
+	// Normalize to "Bearer" for strict implementations.
 	tokenType := token.TokenType
-	if tokenType == "bearer" {
+	if strings.EqualFold(tokenType, "bearer") {
 		tokenType = "Bearer"
 	}
 


### PR DESCRIPTION
## PR Description
 
Per RFC 6749 §5.1, the `token_type` field in OAuth token responses is case-insensitive. This PR updates the token type normalization to handle all case variants (e.g., `"bearer"`, `"BEARER"`, `"BeArEr"`) correctly.
 
## Type of Change
 
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):
 
## Checklist
 
- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly
 
## MCP Spec Compliance
 
- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [RFC 6749 §5.1](https://datatracker.ietf.org/doc/html/rfc6749#section-5.1)
- [x] Implementation follows the specification exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth authentication robustness by enhancing token type validation to handle variations in format while maintaining compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->