### PR TITLE
Upgrade to go 1.25.5

### DIFF
--- a/client/client_edge_cases_test.go
+++ b/client/client_edge_cases_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -21,7 +20,7 @@ func TestClient_UnsupportedProtocolVersionResponse(t *testing.T) {
 		transport: mockTrans,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := client.Start(ctx)
 	require.NoError(t, err)
 
@@ -61,7 +60,7 @@ func TestClient_OperationsBeforeInitialize(t *testing.T) {
 		transport: mockTrans,
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := client.Start(ctx)
 	require.NoError(t, err)
 
@@ -89,7 +88,7 @@ func TestClient_NotificationHandlers(t *testing.T) {
 			transport: mockTrans,
 		}
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err := client.Start(ctx)
 		require.NoError(t, err)
 
@@ -155,7 +154,7 @@ func TestClient_IsInitialized(t *testing.T) {
 	// Should not be initialized initially
 	assert.False(t, client.IsInitialized())
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := client.Start(ctx)
 	require.NoError(t, err)
 

--- a/client/elicitation_test.go
+++ b/client/elicitation_test.go
@@ -96,7 +96,7 @@ func TestClient_HandleElicitationRequest(t *testing.T) {
 				},
 			}
 
-			result, err := client.handleElicitationRequestTransport(context.Background(), request)
+			result, err := client.handleElicitationRequestTransport(t.Context(), request)
 
 			if tt.expectedError != "" {
 				if err == nil {
@@ -165,12 +165,12 @@ func TestClient_Initialize_WithElicitationHandler(t *testing.T) {
 	handler := &mockElicitationHandler{}
 	client := NewClient(mockTransport, WithElicitationHandler(handler))
 
-	err := client.Start(context.Background())
+	err := client.Start(t.Context())
 	if err != nil {
 		t.Fatalf("failed to start client: %v", err)
 	}
 
-	_, err = client.Initialize(context.Background(), mcp.InitializeRequest{
+	_, err = client.Initialize(t.Context(), mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 			ClientInfo: mcp.Implementation{

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -104,7 +104,7 @@ func TestHTTPClient(t *testing.T) {
 			notificationNum.Increment(notification.Method)
 		})
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		if err := client.Start(ctx); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
@@ -162,7 +162,7 @@ func TestHTTPClient(t *testing.T) {
 				notificationNum.Increment(notification.Method)
 			})
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			if err := client.Start(ctx); err != nil {
 				t.Fatalf("Failed to start client: %v", err)

--- a/client/inprocess_elicitation_test.go
+++ b/client/inprocess_elicitation_test.go
@@ -111,12 +111,12 @@ func TestInProcessElicitation(t *testing.T) {
 	defer client.Close()
 
 	// Start the client
-	if err := client.Start(context.Background()); err != nil {
+	if err := client.Start(t.Context()); err != nil {
 		t.Fatalf("Failed to start client: %v", err)
 	}
 
 	// Initialize the client
-	_, err := client.Initialize(context.Background(), mcp.InitializeRequest{
+	_, err := client.Initialize(t.Context(), mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 			ClientInfo: mcp.Implementation{
@@ -133,7 +133,7 @@ func TestInProcessElicitation(t *testing.T) {
 	}
 
 	// Call the tool that triggers elicitation
-	result, err := client.CallTool(context.Background(), mcp.CallToolRequest{
+	result, err := client.CallTool(t.Context(), mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "test_elicitation",
 			Arguments: map[string]any{

--- a/client/inprocess_sampling_test.go
+++ b/client/inprocess_sampling_test.go
@@ -100,7 +100,7 @@ func TestInProcessSampling(t *testing.T) {
 	defer client.Close()
 
 	// Start the client
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := client.Start(ctx); err != nil {
 		t.Fatalf("Failed to start client: %v", err)
 	}

--- a/client/inprocess_test.go
+++ b/client/inprocess_test.go
@@ -126,13 +126,13 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 
 		// Test Ping
-		if err := client.Ping(context.Background()); err != nil {
+		if err := client.Ping(t.Context()); err != nil {
 			t.Errorf("Ping failed: %v", err)
 		}
 
 		// Test ListTools
 		toolsRequest := mcp.ListToolsRequest{}
-		toolListResult, err := client.ListTools(context.Background(), toolsRequest)
+		toolListResult, err := client.ListTools(t.Context(), toolsRequest)
 		if err != nil {
 			t.Errorf("ListTools failed: %v", err)
 		}
@@ -156,13 +156,13 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
 		// Try to make a request without initializing
 		toolsRequest := mcp.ListToolsRequest{}
-		_, err = client.ListTools(context.Background(), toolsRequest)
+		_, err = client.ListTools(t.Context(), toolsRequest)
 		if err == nil {
 			t.Error("Expected error when making request before initialization")
 		}

--- a/client/inprocess_test.go
+++ b/client/inprocess_test.go
@@ -101,7 +101,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		defer client.Close()
 
 		// Start the client
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -113,7 +113,7 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		result, err := client.Initialize(context.Background(), initRequest)
+		result, err := client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}

--- a/client/inprocess_test.go
+++ b/client/inprocess_test.go
@@ -175,7 +175,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -187,7 +187,7 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		_, err = client.Initialize(context.Background(), initRequest)
+		_, err = client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}
@@ -198,7 +198,7 @@ func TestInProcessMCPClient(t *testing.T) {
 			"parameter-1": "value1",
 		}
 
-		result, err := client.CallTool(context.Background(), request)
+		result, err := client.CallTool(t.Context(), request)
 		if err != nil {
 			t.Fatalf("CallTool failed: %v", err)
 		}

--- a/client/inprocess_test.go
+++ b/client/inprocess_test.go
@@ -215,7 +215,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -227,12 +227,12 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		_, err = client.Initialize(context.Background(), initRequest)
+		_, err = client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}
 
-		err = client.Ping(context.Background())
+		err = client.Ping(t.Context())
 		if err != nil {
 			t.Errorf("Ping failed: %v", err)
 		}
@@ -245,7 +245,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -257,13 +257,13 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		_, err = client.Initialize(context.Background(), initRequest)
+		_, err = client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}
 
 		request := mcp.ListResourcesRequest{}
-		result, err := client.ListResources(context.Background(), request)
+		result, err := client.ListResources(t.Context(), request)
 		if err != nil {
 			t.Errorf("ListResources failed: %v", err)
 		}
@@ -280,7 +280,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -292,7 +292,7 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		_, err = client.Initialize(context.Background(), initRequest)
+		_, err = client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}
@@ -300,7 +300,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		request := mcp.ReadResourceRequest{}
 		request.Params.URI = "resource://testresource"
 
-		result, err := client.ReadResource(context.Background(), request)
+		result, err := client.ReadResource(t.Context(), request)
 		if err != nil {
 			t.Errorf("ReadResource failed: %v", err)
 		}
@@ -317,7 +317,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -329,12 +329,12 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		_, err = client.Initialize(context.Background(), initRequest)
+		_, err = client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}
 		request := mcp.ListPromptsRequest{}
-		result, err := client.ListPrompts(context.Background(), request)
+		result, err := client.ListPrompts(t.Context(), request)
 		if err != nil {
 			t.Errorf("ListPrompts failed: %v", err)
 		}
@@ -351,7 +351,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -363,7 +363,7 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		_, err = client.Initialize(context.Background(), initRequest)
+		_, err = client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}
@@ -374,7 +374,7 @@ func TestInProcessMCPClient(t *testing.T) {
 			"arg1": "arg1 value",
 		}
 
-		result, err := client.GetPrompt(context.Background(), request)
+		result, err := client.GetPrompt(t.Context(), request)
 		if err != nil {
 			t.Errorf("GetPrompt failed: %v", err)
 		}
@@ -391,7 +391,7 @@ func TestInProcessMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		if err := client.Start(context.Background()); err != nil {
+		if err := client.Start(t.Context()); err != nil {
 			t.Fatalf("Failed to start client: %v", err)
 		}
 
@@ -403,13 +403,13 @@ func TestInProcessMCPClient(t *testing.T) {
 			Version: "1.0.0",
 		}
 
-		_, err = client.Initialize(context.Background(), initRequest)
+		_, err = client.Initialize(t.Context(), initRequest)
 		if err != nil {
 			t.Fatalf("Failed to initialize: %v", err)
 		}
 
 		request := mcp.ListToolsRequest{}
-		result, err := client.ListTools(context.Background(), request)
+		result, err := client.ListTools(t.Context(), request)
 		if err != nil {
 			t.Errorf("ListTools failed: %v", err)
 		}

--- a/client/issue583_test.go
+++ b/client/issue583_test.go
@@ -29,7 +29,7 @@ func TestDirectTransportCreation(t *testing.T) {
 	tport := transport.NewStdioWithOptions(mockServerPath, nil, nil)
 	cli := NewClient(tport)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// This should work now (was failing before fix)
@@ -39,7 +39,7 @@ func TestDirectTransportCreation(t *testing.T) {
 	defer cli.Close()
 
 	// Verify Initialize works (was failing with "stdio client not started")
-	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	initCtx, initCancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer initCancel()
 
 	request := mcp.InitializeRequest{}
@@ -80,7 +80,7 @@ func TestNewStdioMCPClientWithOptions(t *testing.T) {
 	defer cli.Close()
 
 	// Calling Start() again should be idempotent (no error)
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	if err := cli.Start(ctx); err != nil {
@@ -88,7 +88,7 @@ func TestNewStdioMCPClientWithOptions(t *testing.T) {
 	}
 
 	// Verify Initialize works
-	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	initCtx, initCancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer initCancel()
 
 	request := mcp.InitializeRequest{}
@@ -124,7 +124,7 @@ func TestMultipleClientStartCalls(t *testing.T) {
 	tport := transport.NewStdioWithOptions(mockServerPath, nil, nil)
 	cli := NewClient(tport)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// First Start()
@@ -144,7 +144,7 @@ func TestMultipleClientStartCalls(t *testing.T) {
 	}
 
 	// Verify client still works
-	initCtx, initCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	initCtx, initCancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer initCancel()
 
 	request := mcp.InitializeRequest{}

--- a/client/oauth_test.go
+++ b/client/oauth_test.go
@@ -1,7 +1,6 @@
 package client
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestNewOAuthStreamableHttpClient(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Create a test server
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Check for Authorization header
@@ -72,7 +71,7 @@ func TestNewOAuthStreamableHttpClient(t *testing.T) {
 	}
 
 	// Start the client
-	if err := client.Start(context.Background()); err != nil {
+	if err := client.Start(t.Context()); err != nil {
 		t.Fatalf("Failed to start client: %v", err)
 	}
 	defer client.Close()

--- a/client/protocol_negotiation_test.go
+++ b/client/protocol_negotiation_test.go
@@ -125,7 +125,7 @@ func TestProtocolVersionNegotiation(t *testing.T) {
 
 			client := NewClient(mockTransport)
 
-			_, err := client.Initialize(context.Background(), mcp.InitializeRequest{
+			_, err := client.Initialize(t.Context(), mcp.InitializeRequest{
 				Params: mcp.InitializeParams{
 					ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 					ClientInfo:      mcp.Implementation{Name: "test-client", Version: "1.0"},
@@ -182,7 +182,7 @@ func TestProtocolVersionHeaderSetting(t *testing.T) {
 
 	client := NewClient(mockTransport)
 
-	_, err := client.Initialize(context.Background(), mcp.InitializeRequest{
+	_, err := client.Initialize(t.Context(), mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 			ClientInfo:      mcp.Implementation{Name: "test-client", Version: "1.0"},

--- a/client/sampling_test.go
+++ b/client/sampling_test.go
@@ -67,7 +67,7 @@ func TestClient_HandleSamplingRequest(t *testing.T) {
 				},
 			}
 
-			result, err := client.handleIncomingRequest(context.Background(), mockJSONRPCRequest(request))
+			result, err := client.handleIncomingRequest(t.Context(), mockJSONRPCRequest(request))
 
 			if tt.expectedError != "" {
 				if err == nil {
@@ -168,7 +168,7 @@ func TestClient_Initialize_WithSampling(t *testing.T) {
 	}
 
 	// Start the client
-	ctx := context.Background()
+	ctx := t.Context()
 	err := client.Start(ctx)
 	if err != nil {
 		t.Fatalf("Failed to start client: %v", err)

--- a/client/sse_test.go
+++ b/client/sse_test.go
@@ -94,7 +94,7 @@ func TestSSEMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		// Start the client
@@ -158,7 +158,7 @@ func TestSSEMCPClient(t *testing.T) {
 	// 		notificationReceived <- notification
 	// 	})
 
-	// 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	// 	defer cancel()
 
 	// 	if err := client.Start(ctx); err != nil {
@@ -200,7 +200,7 @@ func TestSSEMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		if err := client.Start(ctx); err != nil {
@@ -243,7 +243,7 @@ func TestSSEMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		if err := client.Start(ctx); err != nil {
@@ -295,7 +295,7 @@ func TestSSEMCPClient(t *testing.T) {
 		}
 		defer client.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		if err := client.Start(ctx); err != nil {

--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -61,10 +61,7 @@ func TestStdioMCPClient(t *testing.T) {
 	var logRecords []map[string]any
 	var logRecordsMu sync.RWMutex
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		stderr, ok := GetStderr(client)
 		if !ok {
 			return
@@ -80,7 +77,7 @@ func TestStdioMCPClient(t *testing.T) {
 			logRecords = append(logRecords, record)
 			logRecordsMu.Unlock()
 		}
-	}()
+	})
 
 	t.Run("Initialize", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -444,11 +441,9 @@ func TestStdio_ConcurrentCloseDoesNotPanic(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 10 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			c.Close()
-		}()
+		})
 	}
 	wg.Wait()
 	// If we get here without a panic, sync.Once is working correctly.

--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -80,7 +80,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("Initialize", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.InitializeRequest{}
@@ -111,7 +111,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("Ping", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err := client.Ping(ctx)
@@ -121,7 +121,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("ListResources", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.ListResourcesRequest{}
@@ -136,7 +136,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("ReadResource", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.ReadResourceRequest{}
@@ -153,7 +153,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("Subscribe and Unsubscribe", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		// Test Subscribe
@@ -174,7 +174,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("ListPrompts", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.ListPromptsRequest{}
@@ -189,7 +189,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("GetPrompt", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.GetPromptRequest{}
@@ -206,7 +206,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("ListTools", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.ListToolsRequest{}
@@ -221,7 +221,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("CallTool", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.CallToolRequest{}
@@ -241,7 +241,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("SetLevel", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.SetLevelRequest{}
@@ -254,7 +254,7 @@ func TestStdioMCPClient(t *testing.T) {
 	})
 
 	t.Run("Complete", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := mcp.CompleteRequest{}
@@ -316,7 +316,7 @@ func TestStdio_SendRequestReturnsWhenTransportCloses(t *testing.T) {
 	defer serverRead.Close()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 
 	c := NewClient(stdioTransport)
 	defer c.Close()
@@ -338,7 +338,7 @@ func TestStdio_SendRequestReturnsWhenTransportCloses(t *testing.T) {
 		req := mcp.InitializeRequest{}
 		req.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 		req.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "1.0"}
-		_, err := c.Initialize(context.Background(), req)
+		_, err := c.Initialize(t.Context(), req)
 		errChan <- err
 	}()
 
@@ -367,7 +367,7 @@ func TestStdio_SendRequestReturnsImmediatelyWhenAlreadyClosed(t *testing.T) {
 	defer serverWrite.Close()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 
 	c := NewClient(stdioTransport)
 	c.Close()
@@ -375,7 +375,7 @@ func TestStdio_SendRequestReturnsImmediatelyWhenAlreadyClosed(t *testing.T) {
 	req := mcp.InitializeRequest{}
 	req.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	req.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "1.0"}
-	_, err := c.Initialize(context.Background(), req)
+	_, err := c.Initialize(t.Context(), req)
 	require.ErrorIs(t, err, transport.ErrTransportClosed)
 }
 
@@ -387,7 +387,7 @@ func TestStdio_SendNotificationReturnsWhenTransportClosed(t *testing.T) {
 	defer serverWrite.Close()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 
 	c := NewClient(stdioTransport)
 	c.Close()
@@ -397,7 +397,7 @@ func TestStdio_SendNotificationReturnsWhenTransportClosed(t *testing.T) {
 	}
 	notification.Method = "notifications/initialized"
 
-	err := stdioTransport.SendNotification(context.Background(), notification)
+	err := stdioTransport.SendNotification(t.Context(), notification)
 	require.ErrorIs(t, err, transport.ErrTransportClosed)
 }
 
@@ -409,11 +409,11 @@ func TestStdio_SendNotificationReturnsWhenContextCancelled(t *testing.T) {
 	defer serverWrite.Close()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 
 	defer stdioTransport.Close()
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	cancel() // cancel immediately
 
 	notification := mcp.JSONRPCNotification{
@@ -435,7 +435,7 @@ func TestStdio_ConcurrentCloseDoesNotPanic(t *testing.T) {
 	defer serverWrite.Close()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 
 	c := NewClient(stdioTransport)
 
@@ -458,7 +458,7 @@ func TestStdio_CloseCleanupRunsAfterReadResponsesCloseDone(t *testing.T) {
 	serverRead, clientWrite := io.Pipe()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 
 	// Drain writes so nothing blocks
 	go func() {
@@ -501,7 +501,7 @@ func TestStdio_ConcurrentRequestsAllReceiveResponses(t *testing.T) {
 	serverRead, clientWrite := io.Pipe()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 	defer stdioTransport.Close()
 
 	// Mock server: read JSON-RPC requests, respond with matching IDs after
@@ -578,7 +578,7 @@ func TestStdio_ConcurrentRequestsAllReceiveResponses(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
 			_, err := c.ListTools(ctx, mcp.ListToolsRequest{})
 			if err != nil {
@@ -608,7 +608,7 @@ func TestStdio_ConcurrentRequestsUnblockOnServerDeath(t *testing.T) {
 	serverRead, clientWrite := io.Pipe()
 
 	stdioTransport := transport.NewIO(clientRead, clientWrite, io.NopCloser(strings.NewReader("")))
-	require.NoError(t, stdioTransport.Start(context.Background()))
+	require.NoError(t, stdioTransport.Start(t.Context()))
 	defer stdioTransport.Close()
 
 	// Mock server: read requests but only respond to "initialize", then
@@ -666,7 +666,7 @@ func TestStdio_ConcurrentRequestsUnblockOnServerDeath(t *testing.T) {
 		wg.Add(1)
 		go func(i int) {
 			defer wg.Done()
-			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 			defer cancel()
 			_, err := c.ListTools(ctx, mcp.ListToolsRequest{})
 			errCh <- err

--- a/client/stdio_test.go
+++ b/client/stdio_test.go
@@ -567,7 +567,7 @@ func TestStdio_ConcurrentRequestsAllReceiveResponses(t *testing.T) {
 	initReq := mcp.InitializeRequest{}
 	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	initReq.Params.ClientInfo = mcp.Implementation{Name: "stress-test", Version: "1.0"}
-	_, err := c.Initialize(context.Background(), initReq)
+	_, err := c.Initialize(t.Context(), initReq)
 	require.NoError(t, err)
 
 	// Fire N concurrent ListTools requests
@@ -655,7 +655,7 @@ func TestStdio_ConcurrentRequestsUnblockOnServerDeath(t *testing.T) {
 	initReq := mcp.InitializeRequest{}
 	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	initReq.Params.ClientInfo = mcp.Implementation{Name: "death-test", Version: "1.0"}
-	_, err := c.Initialize(context.Background(), initReq)
+	_, err := c.Initialize(t.Context(), initReq)
 	require.NoError(t, err)
 
 	// Fire N concurrent requests that will never get a response

--- a/client/transport/idempotent_all_transports_test.go
+++ b/client/transport/idempotent_all_transports_test.go
@@ -20,7 +20,7 @@ func TestStreamableHTTP_StartIdempotency(t *testing.T) {
 		t.Fatalf("Failed to create StreamableHTTP client: %v", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	// First Start() - should succeed
@@ -52,7 +52,7 @@ func TestInProcessTransport_StartIdempotency(t *testing.T) {
 
 	transport := NewInProcessTransport(mcpServer)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	// First Start() - should succeed
@@ -90,7 +90,7 @@ func TestInProcessTransport_StartFailureReset(t *testing.T) {
 
 	transport := NewInProcessTransport(mcpServer)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 
 	// Should be able to start successfully

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -76,7 +76,7 @@ type Token struct {
 	// Scope is the scope of the token
 	Scope string `json:"scope,omitempty"`
 	// ExpiresAt is the time when the token expires
-	ExpiresAt time.Time `json:"expires_at,omitempty"`
+	ExpiresAt time.Time `json:"expires_at,omitzero"`
 }
 
 // IsExpired returns true if the token is expired

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -408,7 +408,7 @@ func TestMemoryTokenStore_ContextCancellation(t *testing.T) {
 
 	t.Run("GetToken with canceled context", func(t *testing.T) {
 		// Create a canceled context
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		// Attempt to get token with canceled context
@@ -422,7 +422,7 @@ func TestMemoryTokenStore_ContextCancellation(t *testing.T) {
 
 	t.Run("SaveToken with canceled context", func(t *testing.T) {
 		// Create a canceled context
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		token := &Token{
@@ -441,7 +441,7 @@ func TestMemoryTokenStore_ContextCancellation(t *testing.T) {
 
 	t.Run("GetToken with deadline exceeded", func(t *testing.T) {
 		// Create a context with past deadline
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
 		defer cancel()
 
 		// Attempt to get token with expired context
@@ -455,7 +455,7 @@ func TestMemoryTokenStore_ContextCancellation(t *testing.T) {
 
 	t.Run("SaveToken with deadline exceeded", func(t *testing.T) {
 		// Create a context with past deadline
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
 		defer cancel()
 
 		token := &Token{
@@ -485,7 +485,7 @@ func TestOAuthHandler_GetAuthorizationHeader_ContextCancellation(t *testing.T) {
 	}
 
 	// Save the token with a valid context
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := tokenStore.SaveToken(ctx, validToken); err != nil {
 		t.Fatalf("Failed to save token: %v", err)
 	}
@@ -502,7 +502,7 @@ func TestOAuthHandler_GetAuthorizationHeader_ContextCancellation(t *testing.T) {
 
 	t.Run("GetAuthorizationHeader with canceled context", func(t *testing.T) {
 		// Create a canceled context
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		// Attempt to get authorization header with canceled context
@@ -516,7 +516,7 @@ func TestOAuthHandler_GetAuthorizationHeader_ContextCancellation(t *testing.T) {
 
 	t.Run("GetAuthorizationHeader with deadline exceeded", func(t *testing.T) {
 		// Create a context with past deadline
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
 		defer cancel()
 
 		// Attempt to get authorization header with expired context
@@ -545,7 +545,7 @@ func TestOAuthHandler_getValidToken_ContextCancellation(t *testing.T) {
 
 	t.Run("Context canceled during initial token retrieval", func(t *testing.T) {
 		// Create a canceled context
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		// This will call getValidToken internally
@@ -559,7 +559,7 @@ func TestOAuthHandler_getValidToken_ContextCancellation(t *testing.T) {
 
 	t.Run("Context deadline exceeded during token retrieval", func(t *testing.T) {
 		// Create a context with past deadline
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
 		defer cancel()
 
 		// This will call getValidToken internally
@@ -580,14 +580,14 @@ func TestOAuthHandler_getValidToken_ContextCancellation(t *testing.T) {
 			ExpiresAt:    time.Now().Add(-1 * time.Hour), // Expired
 		}
 
-		validCtx := context.Background()
+		validCtx := t.Context()
 		if err := tokenStore.SaveToken(validCtx, expiredToken); err != nil {
 			t.Fatalf("Failed to save expired token: %v", err)
 		}
 
 		// Now try to get authorization header with canceled context
 		// This should detect the canceled context during the refresh attempt
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		_, err := handler.GetAuthorizationHeader(ctx)
@@ -616,7 +616,7 @@ func TestOAuthHandler_RefreshToken_ContextCancellation(t *testing.T) {
 		ExpiresAt:    time.Now().Add(-1 * time.Hour), // Expired access token
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := tokenStore.SaveToken(ctx, tokenWithRefresh); err != nil {
 		t.Fatalf("Failed to save token with refresh: %v", err)
 	}
@@ -635,7 +635,7 @@ func TestOAuthHandler_RefreshToken_ContextCancellation(t *testing.T) {
 
 	t.Run("RefreshToken with canceled context", func(t *testing.T) {
 		// Create a canceled context
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		// Attempt to refresh token with canceled context
@@ -649,7 +649,7 @@ func TestOAuthHandler_RefreshToken_ContextCancellation(t *testing.T) {
 
 	t.Run("RefreshToken with deadline exceeded", func(t *testing.T) {
 		// Create a context with past deadline
-		ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
 		defer cancel()
 
 		// Attempt to refresh token with expired context
@@ -681,7 +681,7 @@ func TestOAuthHandler_CachedClientContextScenario(t *testing.T) {
 		}
 
 		// Save token with initial valid context
-		initialCtx := context.Background()
+		initialCtx := t.Context()
 		if err := tokenStore.SaveToken(initialCtx, validToken); err != nil {
 			t.Fatalf("Failed to save initial token: %v", err)
 		}
@@ -708,7 +708,7 @@ func TestOAuthHandler_CachedClientContextScenario(t *testing.T) {
 
 		// Step 2: Simulate production scenario - context gets canceled
 		// (this could happen due to request timeout, user cancellation, etc.)
-		staleCancelableCtx, cancel := context.WithCancel(context.Background())
+		staleCancelableCtx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately to simulate stale context
 
 		// Step 3: Try to use cached client with canceled context
@@ -732,7 +732,7 @@ func TestOAuthHandler_CachedClientContextScenario(t *testing.T) {
 		}
 
 		// Save token with valid context
-		validCtx := context.Background()
+		validCtx := t.Context()
 		if err := tokenStore.SaveToken(validCtx, validToken); err != nil {
 			t.Fatalf("Failed to save token: %v", err)
 		}
@@ -746,7 +746,7 @@ func TestOAuthHandler_CachedClientContextScenario(t *testing.T) {
 		handler := NewOAuthHandler(config)
 
 		// Create context with past deadline (simulating expired request context)
-		expiredCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		expiredCtx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
 		defer cancel()
 
 		// Try to use cached client with expired context
@@ -772,7 +772,7 @@ func TestOAuthHandler_CachedClientContextScenario(t *testing.T) {
 		}
 
 		// Save expired token
-		validCtx := context.Background()
+		validCtx := t.Context()
 		if err := tokenStore.SaveToken(validCtx, expiredToken); err != nil {
 			t.Fatalf("Failed to save expired token: %v", err)
 		}
@@ -788,7 +788,7 @@ func TestOAuthHandler_CachedClientContextScenario(t *testing.T) {
 		handler := NewOAuthHandler(config)
 
 		// Create a context that's already canceled (simulating race condition)
-		canceledCtx, cancel := context.WithCancel(context.Background())
+		canceledCtx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel before the operation
 
 		// This should detect the canceled context early in the refresh process
@@ -857,7 +857,7 @@ func TestOAuthHandler_GetServerMetadata_FallbackToOAuthAuthorizationServer(t *te
 	handler.SetBaseURL(server.URL)
 
 	// Call getServerMetadata which should trigger the fallback behavior
-	metadata, err := handler.GetServerMetadata(context.Background())
+	metadata, err := handler.GetServerMetadata(t.Context())
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -920,7 +920,7 @@ func TestOAuthHandler_GetServerMetadata_FallbackToDefaultEndpoints(t *testing.T)
 	handler.SetBaseURL(server.URL)
 
 	// Call getServerMetadata which should fall back to default endpoints
-	metadata, err := handler.GetServerMetadata(context.Background())
+	metadata, err := handler.GetServerMetadata(t.Context())
 	if err != nil {
 		t.Fatalf("Expected no error, got %v", err)
 	}
@@ -988,7 +988,7 @@ func TestOAuthHandler_RefreshToken_GitHubErrorIn200Response(t *testing.T) {
 	handler := NewOAuthHandler(config)
 
 	// Attempt to refresh with a "bad" token
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := handler.RefreshToken(ctx, "bad-refresh-token")
 
 	// Should detect the error even though status code is 200
@@ -1046,7 +1046,7 @@ func TestOAuthHandler_RefreshToken_EmptyAccessToken(t *testing.T) {
 
 	handler := NewOAuthHandler(config)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	token, err := handler.RefreshToken(ctx, "test-refresh-token")
 
 	// mcp-go doesn't validate empty tokens - it just parses the response
@@ -1112,7 +1112,7 @@ func TestOAuthHandler_RefreshToken_RefreshTokenRotation(t *testing.T) {
 	}
 
 	handler := NewOAuthHandler(config)
-	ctx := context.Background()
+	ctx := t.Context()
 	token1, err := handler.RefreshToken(ctx, "ghr_original")
 	require.NoError(t, err, "First refresh should succeed")
 	assert.Equal(t, "ghr_refresh_1", token1.RefreshToken, "Should receive new refresh token")
@@ -1190,7 +1190,7 @@ func TestOAuthHandler_RefreshToken_SingleUseRefreshToken(t *testing.T) {
 	}
 
 	handler := NewOAuthHandler(config)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// First use of refresh token - should succeed
 	token1, err := handler.RefreshToken(ctx, "ghr_original")
@@ -1254,7 +1254,7 @@ func TestOAuthHandler_ProcessAuthorizationResponse_ErrorIn200(t *testing.T) {
 	}
 
 	handler := NewOAuthHandler(config)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Set expected state
 	handler.SetExpectedState("test-state")
@@ -1313,7 +1313,7 @@ func TestOAuthHandler_RefreshToken_KeepsOldRefreshToken(t *testing.T) {
 	}
 
 	handler := NewOAuthHandler(config)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	originalRefreshToken := "ghr_original_refresh_token"
 
@@ -1368,7 +1368,7 @@ func TestOAuthHandler_RefreshToken_ProperHTTP400Error(t *testing.T) {
 	}
 
 	handler := NewOAuthHandler(config)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Attempt refresh
 	_, err := handler.RefreshToken(ctx, "invalid-token")

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -61,7 +61,7 @@ func TestToken_IsExpired(t *testing.T) {
 func TestMemoryTokenStore(t *testing.T) {
 	// Create a token store
 	store := NewMemoryTokenStore()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Test getting token from empty store
 	_, err := store.GetToken(ctx)
@@ -166,7 +166,7 @@ func TestValidateRedirectURI(t *testing.T) {
 
 func TestOAuthHandler_GetAuthorizationHeader_EmptyAccessToken(t *testing.T) {
 	// Create a token store with a token that has an empty access token
-	ctx := context.Background()
+	ctx := t.Context()
 	tokenStore := NewMemoryTokenStore()
 	invalidToken := &Token{
 		AccessToken:  "", // Empty access token
@@ -191,7 +191,7 @@ func TestOAuthHandler_GetAuthorizationHeader_EmptyAccessToken(t *testing.T) {
 	handler := NewOAuthHandler(config)
 
 	// Test getting authorization header with empty access token
-	_, err := handler.GetAuthorizationHeader(context.Background())
+	_, err := handler.GetAuthorizationHeader(t.Context())
 	if err == nil {
 		t.Fatalf("Expected error when getting authorization header with empty access token")
 	}
@@ -216,7 +216,7 @@ func TestOAuthHandler_GetServerMetadata_EmptyURL(t *testing.T) {
 	handler := NewOAuthHandler(config)
 
 	// Test getting server metadata with empty URL
-	_, err := handler.GetServerMetadata(context.Background())
+	_, err := handler.GetServerMetadata(t.Context())
 	if err == nil {
 		t.Fatalf("Expected error when getting server metadata with empty URL")
 	}
@@ -294,14 +294,14 @@ func TestOAuthHandler_ProcessAuthorizationResponse_StateValidation(t *testing.T)
 
 	// Test with non-matching state - this should fail immediately with ErrInvalidState
 	// before trying to connect to any server
-	err := handler.ProcessAuthorizationResponse(context.Background(), "test-code", "wrong-state", "test-code-verifier")
+	err := handler.ProcessAuthorizationResponse(t.Context(), "test-code", "wrong-state", "test-code-verifier")
 	if !errors.Is(err, ErrInvalidState) {
 		t.Errorf("Expected ErrInvalidState, got %v", err)
 	}
 
 	// Test with empty expected state
 	handler.expectedState = ""
-	err = handler.ProcessAuthorizationResponse(context.Background(), "test-code", expectedState, "test-code-verifier")
+	err = handler.ProcessAuthorizationResponse(t.Context(), "test-code", expectedState, "test-code-verifier")
 	if err == nil {
 		t.Errorf("Expected error with empty expected state, got nil")
 	}
@@ -336,7 +336,7 @@ func TestOAuthHandler_SetExpectedState_CrossRequestScenario(t *testing.T) {
 
 	// Generate state and get authorization URL (this would typically be done in the init handler)
 	testState := "generated-state-value-123"
-	_, err := handler1.GetAuthorizationURL(context.Background(), testState, "test-code-challenge")
+	_, err := handler1.GetAuthorizationURL(t.Context(), testState, "test-code-challenge")
 	if err != nil {
 		// We expect this to fail since we're not actually connecting to a server,
 		// but it should still store the expected state
@@ -381,7 +381,7 @@ func TestOAuthHandler_SetExpectedState_CrossRequestScenario(t *testing.T) {
 
 	// Test with correct state - should pass validation but fail at token exchange
 	// (since we're not actually running a real OAuth server)
-	err = handler2.ProcessAuthorizationResponse(context.Background(), "test-code", testState, "test-code-verifier")
+	err = handler2.ProcessAuthorizationResponse(t.Context(), "test-code", testState, "test-code-verifier")
 	if err == nil {
 		t.Errorf("Expected error due to token exchange failure, got nil")
 	}
@@ -397,7 +397,7 @@ func TestOAuthHandler_SetExpectedState_CrossRequestScenario(t *testing.T) {
 
 	// Step 5: Test with wrong state after resetting
 	handler2.SetExpectedState("different-state-value")
-	err = handler2.ProcessAuthorizationResponse(context.Background(), "test-code", testState, "test-code-verifier")
+	err = handler2.ProcessAuthorizationResponse(t.Context(), "test-code", testState, "test-code-verifier")
 	if !errors.Is(err, ErrInvalidState) {
 		t.Errorf("Expected ErrInvalidState with wrong state, got %v", err)
 	}

--- a/client/transport/sse_oauth_test.go
+++ b/client/transport/sse_oauth_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSSE_WithOAuth(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Track request count to simulate 401 on first request, then success
 	requestCount := 0
 	authHeaderReceived := ""
@@ -112,7 +112,7 @@ func TestSSE_WithOAuth(t *testing.T) {
 
 	// First start attempt should fail with OAuthAuthorizationRequiredError
 	// Use a context with a short timeout to avoid hanging
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	err = transport.Start(ctx)
 
@@ -138,7 +138,7 @@ func TestSSE_WithOAuth(t *testing.T) {
 
 	// Second start attempt should succeed
 	// Use a context with a short timeout to avoid hanging
-	ctx2, cancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx2, cancel2 := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel2()
 	err = transport.Start(ctx2)
 	if err != nil {
@@ -194,7 +194,7 @@ func TestSSE_WithOAuth_Unauthorized(t *testing.T) {
 
 	// Start should fail with OAuthAuthorizationRequiredError
 	// Use a context with a short timeout to avoid hanging
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	err = transport.Start(ctx)
 

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -650,7 +650,7 @@ func TestSSEErrors(t *testing.T) {
 		}
 
 		// Start should fail
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
 
 		err = sse.Start(ctx)
@@ -673,7 +673,7 @@ func TestSSEErrors(t *testing.T) {
 		}
 
 		// Starting should immediately error due to timeout
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 		err = trans.Start(ctx)
 		if err == nil {
@@ -702,7 +702,7 @@ func TestSSEErrors(t *testing.T) {
 			Method:  "ping",
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 		defer cancel()
 
 		_, err = sse.SendRequest(ctx, request)
@@ -723,7 +723,7 @@ func TestSSEErrors(t *testing.T) {
 		}
 
 		// Start the transport
-		ctx := context.Background()
+		ctx := t.Context()
 		if err := sse.Start(ctx); err != nil {
 			t.Fatalf("Failed to start SSE transport: %v", err)
 		}
@@ -775,7 +775,7 @@ func TestSSEErrors(t *testing.T) {
 		require.NoError(t, err)
 
 		// Start the transport
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		t.Cleanup(cancel)
 
 		err = trans.Start(ctx)
@@ -816,7 +816,7 @@ func TestSSE_Start_Unauthorized_StaticToken(t *testing.T) {
 	}
 
 	// Start should fail with ErrUnauthorized
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	err = transport.Start(ctx)
 
@@ -865,7 +865,7 @@ func TestSSE_SendRequest_Unauthorized_StaticToken(t *testing.T) {
 	}
 
 	// Start the transport
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	err = transport.Start(ctx)
 	if err != nil {
@@ -878,7 +878,7 @@ func TestSSE_SendRequest_Unauthorized_StaticToken(t *testing.T) {
 	}
 
 	// Send a request
-	_, err = transport.SendRequest(context.Background(), JSONRPCRequest{
+	_, err = transport.SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0",
 		ID:      mcp.NewRequestId(1),
 		Method:  "test",
@@ -927,7 +927,7 @@ func TestSSE_SendNotification_Unauthorized_StaticToken(t *testing.T) {
 	}
 
 	// Start the transport
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 	err = transport.Start(ctx)
 	if err != nil {
@@ -940,7 +940,7 @@ func TestSSE_SendNotification_Unauthorized_StaticToken(t *testing.T) {
 	}
 
 	// Send a notification
-	err = transport.SendNotification(context.Background(), mcp.JSONRPCNotification{
+	err = transport.SendNotification(t.Context(), mcp.JSONRPCNotification{
 		JSONRPC: "2.0",
 		Notification: mcp.Notification{
 			Method: "test/notification",
@@ -1021,7 +1021,7 @@ func TestSSEHostOverride(t *testing.T) {
 		trans, err := NewSSE(testServer.URL)
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = trans.Start(ctx)
@@ -1041,7 +1041,7 @@ func TestSSEHostOverride(t *testing.T) {
 		trans, err := NewSSE(testServer.URL, WithHTTPHost(customHost))
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = trans.Start(ctx)
@@ -1062,7 +1062,7 @@ func TestSSEHostOverride(t *testing.T) {
 		trans, err := NewSSE(testServer.URL, WithHTTPHost(customHost))
 		require.NoError(t, err)
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = trans.Start(ctx)
@@ -1124,13 +1124,13 @@ func TestSSE_SendRequest_Timeout(t *testing.T) {
 		require.NoError(t, err)
 		defer transport.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = transport.Start(ctx)
 		require.NoError(t, err)
 
-		requestCtx, requestCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		requestCtx, requestCancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer requestCancel()
 
 		request := JSONRPCRequest{
@@ -1176,13 +1176,13 @@ func TestSSE_SendRequest_Timeout(t *testing.T) {
 		require.NoError(t, err)
 		defer transport.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = transport.Start(ctx)
 		require.NoError(t, err)
 
-		requestCtx, requestCancel := context.WithTimeout(context.Background(), 1*time.Second)
+		requestCtx, requestCancel := context.WithTimeout(t.Context(), 1*time.Second)
 		defer requestCancel()
 
 		request := JSONRPCRequest{

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"internal/synctest"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -290,9 +291,7 @@ func TestSSE(t *testing.T) {
 			t.Fatalf("SendNotification failed: %v", err)
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			select {
 			case nt := <-notificationChan:
 				// We received a notification
@@ -305,7 +304,7 @@ func TestSSE(t *testing.T) {
 			case <-time.After(1 * time.Second):
 				t.Errorf("Expected notification, got none")
 			}
-		}()
+		})
 
 		wg.Wait()
 	})
@@ -560,15 +559,10 @@ func TestSSE(t *testing.T) {
 
 		// DO NOT set connection lost handler to test backward compatibility
 
-		// Capture stderr to verify the error is printed (backward compatible behavior)
-		// Since we can't easily capture fmt.Printf output in tests, we'll just verify
-		// that the readSSE method returns without calling any handler
-
-		// Directly test the readSSE method with our mock reader
-		go trans.readSSE(mockReader)
-
-		// Wait for readSSE to complete
-		time.Sleep(100 * time.Millisecond)
+		synctest.Test(t, func(t *testing.T) {
+			go trans.readSSE(mockReader)
+			synctest.Wait() // Wait for all goroutines to block (readSSE completes)
+		})
 
 		// The test passes if readSSE completes without panicking or hanging
 		// In backward compatibility mode, ERROR should be treated as a regular error

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -175,7 +175,7 @@ func TestSSE(t *testing.T) {
 	}
 
 	// Start the transport
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
 	defer cancel()
 
 	err = trans.Start(ctx)
@@ -185,7 +185,7 @@ func TestSSE(t *testing.T) {
 	defer trans.Close()
 
 	t.Run("SendRequest", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		params := map[string]any{
@@ -243,7 +243,7 @@ func TestSSE(t *testing.T) {
 
 	t.Run("SendRequestWithTimeout", func(t *testing.T) {
 		// Create a context that's already canceled
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel the context immediately
 
 		// Prepare a request
@@ -273,7 +273,7 @@ func TestSSE(t *testing.T) {
 
 		// Send a notification
 		// This would trigger a notification from the server
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
 
 		notification := mcp.JSONRPCNotification{
@@ -321,7 +321,7 @@ func TestSSE(t *testing.T) {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 				defer cancel()
 
 				// Each request has a unique ID and payload

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"internal/synctest"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -559,10 +558,15 @@ func TestSSE(t *testing.T) {
 
 		// DO NOT set connection lost handler to test backward compatibility
 
-		synctest.Test(t, func(t *testing.T) {
-			go trans.readSSE(mockReader)
-			synctest.Wait() // Wait for all goroutines to block (readSSE completes)
-		})
+		// Capture stderr to verify the error is printed (backward compatible behavior)
+		// Since we can't easily capture fmt.Printf output in tests, we'll just verify
+		// that the readSSE method returns without calling any handler
+
+		// Directly test the readSSE method with our mock reader
+		go trans.readSSE(mockReader)
+
+		// Wait for readSSE to complete
+		time.Sleep(100 * time.Millisecond)
 
 		// The test passes if readSSE completes without panicking or hanging
 		// In backward compatibility mode, ERROR should be treated as a regular error

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -502,7 +502,7 @@ func TestSSE(t *testing.T) {
 		}
 
 		// Start the transport
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = trans.Start(ctx)
@@ -1226,7 +1226,7 @@ func TestSSE_SendRequest_Timeout(t *testing.T) {
 		require.NoError(t, err)
 		defer transport.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = transport.Start(ctx)
@@ -1237,7 +1237,7 @@ func TestSSE_SendRequest_Timeout(t *testing.T) {
 		transport.mu.RUnlock()
 		require.Equal(t, 0, initialCount)
 
-		requestCtx, requestCancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		requestCtx, requestCancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		defer requestCancel()
 
 		request := JSONRPCRequest{
@@ -1281,13 +1281,13 @@ func TestSSE_SendRequest_Timeout(t *testing.T) {
 		require.NoError(t, err)
 		defer transport.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		err = transport.Start(ctx)
 		require.NoError(t, err)
 
-		expiredCtx, expiredCancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
+		expiredCtx, expiredCancel := context.WithDeadline(t.Context(), time.Now().Add(-1*time.Second))
 		defer expiredCancel()
 
 		request := JSONRPCRequest{

--- a/client/transport/stdio_idempotent_test.go
+++ b/client/transport/stdio_idempotent_test.go
@@ -25,7 +25,7 @@ func TestStdio_StartIdempotency(t *testing.T) {
 
 	stdio := NewStdio(mockServerPath, nil)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// First Start() - should succeed
@@ -65,7 +65,7 @@ func TestStdio_StartFailureReset(t *testing.T) {
 	// First attempt with invalid command - should fail
 	stdio := NewStdio("nonexistent_command_xyz", nil)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err := stdio.Start(ctx)
 	if err == nil {
 		t.Fatal("Expected Start() to fail with invalid command")
@@ -110,7 +110,7 @@ func TestStdio_StartWithOptions_Idempotent(t *testing.T) {
 
 	stdio := NewStdioWithOptions(mockServerPath, nil, nil, WithCommandFunc(cmdFunc))
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// First Start()

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -59,7 +59,7 @@ func TestStdio(t *testing.T) {
 	stdio := NewStdio(mockServerPath, nil)
 
 	// Start the transport
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	startErr := stdio.Start(ctx)
@@ -69,7 +69,7 @@ func TestStdio(t *testing.T) {
 	defer stdio.Close()
 
 	t.Run("SendRequest", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		params := map[string]any{
@@ -127,7 +127,7 @@ func TestStdio(t *testing.T) {
 
 	t.Run("SendRequestWithTimeout", func(t *testing.T) {
 		// Create a context that's already canceled
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel the context immediately
 
 		// Prepare a request
@@ -226,7 +226,7 @@ func TestStdio(t *testing.T) {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 				defer cancel()
 
 				// Each request has a unique ID and payload
@@ -342,7 +342,7 @@ func TestStdio(t *testing.T) {
 	})
 
 	t.Run("SendRequestWithStringID", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		params := map[string]any{
@@ -406,7 +406,7 @@ func TestStdioErrors(t *testing.T) {
 		stdio := NewStdio("non_existent_command", nil)
 
 		// Start should fail
-		ctx := context.Background()
+		ctx := t.Context()
 		err := stdio.Start(ctx)
 		if err == nil {
 			t.Errorf("Expected error when starting with invalid command, got nil")
@@ -442,7 +442,7 @@ func TestStdioErrors(t *testing.T) {
 			Method:  "ping",
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
 		defer cancel()
 		_, reqErr := uninitiatedStdio.SendRequest(ctx, request)
 		if reqErr == nil {
@@ -469,7 +469,7 @@ func TestStdioErrors(t *testing.T) {
 		stdio := NewStdio(mockServerPath, nil)
 
 		// Start the transport
-		ctx := context.Background()
+		ctx := t.Context()
 		if startErr := stdio.Start(ctx); startErr != nil {
 			t.Fatalf("Failed to start Stdio transport: %v", startErr)
 		}
@@ -701,7 +701,7 @@ func TestStdio_LargeMessages(t *testing.T) {
 
 	stdio := NewStdio(mockServerPath, nil)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
 	defer cancel()
 
 	startErr := stdio.Start(ctx)
@@ -726,7 +726,7 @@ func TestStdio_LargeMessages(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 			defer cancel()
 
 			largeString := generateRandomString(tc.dataSize)

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -174,9 +174,7 @@ func TestStdio(t *testing.T) {
 			t.Fatalf("SendNotification failed: %v", err)
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			select {
 			case nt := <-notificationChan:
 				// We received a notification from the mock server
@@ -211,7 +209,7 @@ func TestStdio(t *testing.T) {
 			case <-time.After(1 * time.Second):
 				t.Errorf("Expected notification, got none")
 			}
-		}()
+		})
 
 		wg.Wait()
 	})

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -609,7 +609,7 @@ func TestStdio_WithCommandFunc(t *testing.T) {
 }
 
 func TestStdio_SpawnCommand(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Setenv("TEST_ENVIRON_VAR", "true")
 
 	// Explicitly not passing any environment, so we can see if it
@@ -630,7 +630,7 @@ func TestStdio_SpawnCommand(t *testing.T) {
 }
 
 func TestStdio_SpawnCommand_UsesCommandFunc(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	t.Setenv("TEST_ENVIRON_VAR", "true")
 
 	stdio := NewStdioWithOptions(
@@ -659,7 +659,7 @@ func TestStdio_SpawnCommand_UsesCommandFunc(t *testing.T) {
 }
 
 func TestStdio_SpawnCommand_UsesCommandFunc_Error(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	stdio := NewStdioWithOptions(
 		"echo",

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -157,7 +157,7 @@ func TestStdio(t *testing.T) {
 
 		// Send a notification
 		// This would trigger a notification from the server
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
 
 		notification := mcp.JSONRPCNotification{
@@ -509,7 +509,7 @@ func TestStdioErrors(t *testing.T) {
 		stdio := NewIO(stdoutReader, stdinWriter, stderrReader)
 		stdio.logger = testLogger
 
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		t.Cleanup(cancel)
 
 		err := stdio.Start(ctx)
@@ -592,7 +592,7 @@ func TestStdio_WithCommandFunc(t *testing.T) {
 	require.NotNil(t, stdio.cmdFunc)
 
 	// Manually call the cmdFunc passing the same values as in spawnCommand.
-	cmd, err := stdio.cmdFunc(context.Background(), "echo", nil, []string{"hello"})
+	cmd, err := stdio.cmdFunc(t.Context(), "echo", nil, []string{"hello"})
 	require.NoError(t, err)
 	require.True(t, called)
 	require.NotNil(t, cmd)

--- a/client/transport/streamable_http_oauth_test.go
+++ b/client/transport/streamable_http_oauth_test.go
@@ -1,7 +1,6 @@
 package transport
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -14,7 +13,7 @@ import (
 )
 
 func TestStreamableHTTP_WithOAuth(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 	// Track request count to simulate 401 on first request, then success
 	var requestCount int32
 	authHeaderReceived := ""
@@ -91,7 +90,7 @@ func TestStreamableHTTP_WithOAuth(t *testing.T) {
 	}
 
 	// First request should fail with OAuthAuthorizationRequiredError
-	_, err = transport.SendRequest(context.Background(), JSONRPCRequest{
+	_, err = transport.SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0",
 		ID:      mcp.NewRequestId(1),
 		Method:  "test",
@@ -118,7 +117,7 @@ func TestStreamableHTTP_WithOAuth(t *testing.T) {
 	}
 
 	// Second request should succeed
-	response, err := transport.SendRequest(context.Background(), JSONRPCRequest{
+	response, err := transport.SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0",
 		ID:      mcp.NewRequestId(2),
 		Method:  "test",
@@ -171,7 +170,7 @@ func TestStreamableHTTP_WithOAuth_Unauthorized(t *testing.T) {
 	}
 
 	// Send a request
-	_, err = transport.SendRequest(context.Background(), JSONRPCRequest{
+	_, err = transport.SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0",
 		ID:      mcp.NewRequestId(1),
 		Method:  "test",

--- a/client/transport/streamable_http_sampling_test.go
+++ b/client/transport/streamable_http_sampling_test.go
@@ -54,7 +54,7 @@ func TestStreamableHTTP_SamplingFlow(t *testing.T) {
 	})
 
 	// Start the client
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	err = client.Start(ctx)
@@ -141,7 +141,7 @@ func TestStreamableHTTP_SamplingErrorHandling(t *testing.T) {
 	})
 
 	// Start the client
-	ctx := context.Background()
+	ctx := t.Context()
 	err = client.Start(ctx)
 	if err != nil {
 		t.Fatalf("Failed to start client: %v", err)
@@ -200,7 +200,7 @@ func TestStreamableHTTP_NoSamplingHandler(t *testing.T) {
 
 	// Don't set any request handler
 
-	ctx := context.Background()
+	ctx := t.Context()
 	err = client.Start(ctx)
 	if err != nil {
 		t.Fatalf("Failed to start client: %v", err)
@@ -254,7 +254,7 @@ func TestStreamableHTTP_BidirectionalInterface(t *testing.T) {
 	})
 
 	// Verify handler was set by triggering it
-	ctx := context.Background()
+	ctx := t.Context()
 	client.handleIncomingRequest(ctx, JSONRPCRequest{
 		JSONRPC: "2.0",
 		ID:      mcp.NewRequestId(1),
@@ -360,7 +360,7 @@ func TestStreamableHTTP_ConcurrentSamplingRequests(t *testing.T) {
 	})
 
 	// Start the client
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	err = client.Start(ctx)

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -1000,11 +1000,11 @@ func TestStreamableHTTP_SendNotification_Accepts204NoContent(t *testing.T) {
 		t.Fatalf("Failed to create StreamableHTTP: %v", err)
 	}
 
-	if err := transport.Start(context.Background()); err != nil {
+	if err := transport.Start(t.Context()); err != nil {
 		t.Fatalf("Failed to start transport: %v", err)
 	}
 
-	err = transport.SendNotification(context.Background(), mcp.JSONRPCNotification{
+	err = transport.SendNotification(t.Context(), mcp.JSONRPCNotification{
 		JSONRPC: "2.0",
 		Notification: mcp.Notification{
 			Method: "notifications/initialized",
@@ -1080,7 +1080,7 @@ func TestStreamableHTTPHostOverride(t *testing.T) {
 		require.NoError(t, err)
 		defer trans.Close()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err = trans.Start(ctx)
 		require.NoError(t, err)
 
@@ -1108,7 +1108,7 @@ func TestStreamableHTTPHostOverride(t *testing.T) {
 		require.NoError(t, err)
 		defer trans.Close()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err = trans.Start(ctx)
 		require.NoError(t, err)
 
@@ -1137,7 +1137,7 @@ func TestStreamableHTTPHostOverride(t *testing.T) {
 		require.NoError(t, err)
 		defer trans.Close()
 
-		ctx := context.Background()
+		ctx := t.Context()
 		err = trans.Start(ctx)
 		require.NoError(t, err)
 

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -164,7 +164,7 @@ func TestStreamableHTTP(t *testing.T) {
 	defer trans.Close()
 
 	// Initialize the transport first
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	initRequest := JSONRPCRequest{
@@ -180,7 +180,7 @@ func TestStreamableHTTP(t *testing.T) {
 
 	// Now run the tests
 	t.Run("SendRequest", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		params := map[string]any{
@@ -237,7 +237,7 @@ func TestStreamableHTTP(t *testing.T) {
 	})
 
 	t.Run("SendRequestWithHeader", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		params := map[string]any{
@@ -307,7 +307,7 @@ func TestStreamableHTTP(t *testing.T) {
 		})
 
 		// Send a request that triggers a notification
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
 
 		request := JSONRPCRequest{
@@ -359,7 +359,7 @@ func TestStreamableHTTP(t *testing.T) {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()
-				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 				defer cancel()
 
 				// Each request has a unique ID and payload
@@ -435,7 +435,7 @@ func TestStreamableHTTP(t *testing.T) {
 	})
 
 	t.Run("ResponseError", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		// Prepare a request
@@ -520,7 +520,7 @@ func TestStreamableHTTP(t *testing.T) {
 		defer trans.Close()
 
 		// Send a request
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 		defer cancel()
 
 		request := JSONRPCRequest{
@@ -566,7 +566,7 @@ func TestStreamableHTTPErrors(t *testing.T) {
 		}
 
 		// Send request should fail
-		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
 
 		request := JSONRPCRequest{
@@ -783,12 +783,12 @@ func TestContinuousListening(t *testing.T) {
 	})
 
 	// Start the transport - this will launch listenForever in a goroutine
-	if err := trans.Start(context.Background()); err != nil {
+	if err := trans.Start(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 
 	// Initialize the transport first
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	initRequest := JSONRPCRequest{
@@ -861,11 +861,11 @@ func TestContinuousListeningMethodNotAllowed(t *testing.T) {
 	}()
 
 	// Initialize the transport first
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	// Start the transport
-	if err := trans.Start(context.Background()); err != nil {
+	if err := trans.Start(t.Context()); err != nil {
 		t.Fatal(err)
 	}
 
@@ -926,7 +926,7 @@ func TestStreamableHTTP_Unauthorized_StaticToken(t *testing.T) {
 	}
 
 	// Send a request
-	_, err = transport.SendRequest(context.Background(), JSONRPCRequest{
+	_, err = transport.SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0",
 		ID:      mcp.NewRequestId(1),
 		Method:  "test",
@@ -964,12 +964,12 @@ func TestStreamableHTTP_SendNotification_Unauthorized_StaticToken(t *testing.T) 
 	}
 
 	// Start the transport (needed for session initialization)
-	if err := transport.Start(context.Background()); err != nil {
+	if err := transport.Start(t.Context()); err != nil {
 		t.Fatalf("Failed to start transport: %v", err)
 	}
 
 	// Send a notification
-	err = transport.SendNotification(context.Background(), mcp.JSONRPCNotification{
+	err = transport.SendNotification(t.Context(), mcp.JSONRPCNotification{
 		JSONRPC: "2.0",
 		Notification: mcp.Notification{
 			Method: "test/notification",

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -278,7 +278,7 @@ func TestStreamableHTTP(t *testing.T) {
 
 	t.Run("SendRequestWithTimeout", func(t *testing.T) {
 		// Create a context that's already canceled
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel the context immediately
 
 		// Prepare a request

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -321,9 +321,7 @@ func TestStreamableHTTP(t *testing.T) {
 			t.Fatalf("SendRequest failed: %v", err)
 		}
 
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			select {
 			case notification := <-notificationChan:
 				// We received a notification
@@ -343,7 +341,7 @@ func TestStreamableHTTP(t *testing.T) {
 			case <-time.After(1 * time.Second):
 				t.Errorf("Expected notification, got none")
 			}
-		}()
+		})
 
 		wg.Wait()
 	})

--- a/e2e/sampling_http_test.go
+++ b/e2e/sampling_http_test.go
@@ -248,7 +248,7 @@ func TestSamplingHTTPE2E(t *testing.T) {
 	defer httpClient.Close()
 
 	// Start the HTTP client
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := httpClient.Start(ctx); err != nil {
 		t.Fatalf("Failed to start HTTP client: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestSamplingHTTPE2E(t *testing.T) {
 	// Cleanup
 	httpClient.Close()
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {
@@ -464,7 +464,7 @@ func TestSamplingHTTPBasic(t *testing.T) {
 	mcpClient := client.NewClient(httpTransport)
 
 	// Start client
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	defer cancel()
 
 	err = mcpClient.Start(ctx)
@@ -527,7 +527,7 @@ func TestSamplingHTTPBasic(t *testing.T) {
 	// Cleanup
 	mcpClient.Close()
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
 	defer cancel()
 
 	if err := httpServer.Shutdown(shutdownCtx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mark3labs/mcp-go
 
-go 1.23.0
+go 1.25.5
 
 require (
 	github.com/google/uuid v1.6.0

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -585,7 +585,7 @@ type Tool struct {
 	// Alternative to InputSchema - allows arbitrary JSON Schema to be provided
 	RawInputSchema json.RawMessage `json:"-"` // Hide this from JSON marshaling
 	// A JSON Schema object defining the expected output returned by the tool .
-	OutputSchema ToolOutputSchema `json:"outputSchema,omitempty"`
+	OutputSchema ToolOutputSchema `json:"outputSchema,omitzero"`
 	// Optional JSON Schema defining expected output structure
 	RawOutputSchema json.RawMessage `json:"-"` // Hide this from JSON marshaling
 	// Optional properties describing tool behavior

--- a/mcp/typed_tools_additional_test.go
+++ b/mcp/typed_tools_additional_test.go
@@ -100,7 +100,7 @@ func TestNewTypedToolHandler(t *testing.T) {
 			"nested":  map[string]any{"value": 42},
 		}
 
-		result, err := typedHandler(context.Background(), req)
+		result, err := typedHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 	})
@@ -214,7 +214,7 @@ func TestNewStructuredToolHandler(t *testing.T) {
 			"limit": 10,
 		}
 
-		result, err := structuredHandler(context.Background(), req)
+		result, err := structuredHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
@@ -240,7 +240,7 @@ func TestNewStructuredToolHandler(t *testing.T) {
 			"limit": 10,
 		}
 
-		result, err := structuredHandler(context.Background(), req)
+		result, err := structuredHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
@@ -262,7 +262,7 @@ func TestNewStructuredToolHandler(t *testing.T) {
 		req := CallToolRequest{}
 		req.Params.Arguments = map[string]any{}
 
-		result, err := structuredHandler(context.Background(), req)
+		result, err := structuredHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 	})

--- a/mcp/typed_tools_additional_test.go
+++ b/mcp/typed_tools_additional_test.go
@@ -133,7 +133,7 @@ func TestNewStructuredToolHandler(t *testing.T) {
 			"limit": 10,
 		}
 
-		result, err := structuredHandler(context.Background(), req)
+		result, err := structuredHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
@@ -165,7 +165,7 @@ func TestNewStructuredToolHandler(t *testing.T) {
 		req := CallToolRequest{}
 		req.Params.Arguments = "invalid" // Not a map
 
-		result, err := structuredHandler(context.Background(), req)
+		result, err := structuredHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
@@ -189,7 +189,7 @@ func TestNewStructuredToolHandler(t *testing.T) {
 			"limit": 10,
 		}
 
-		result, err := structuredHandler(context.Background(), req)
+		result, err := structuredHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
@@ -293,7 +293,7 @@ func TestTypedToolHandler_ContextPropagation(t *testing.T) {
 		req := CallToolRequest{}
 		req.Params.Arguments = map[string]any{"value": "test"}
 
-		ctx := context.WithValue(context.Background(), ctxKey, ctxValue)
+		ctx := context.WithValue(t.Context(), ctxKey, ctxValue)
 		result, err := typedHandler(ctx, req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
@@ -319,7 +319,7 @@ func TestTypedToolHandler_ContextPropagation(t *testing.T) {
 		req := CallToolRequest{}
 		req.Params.Arguments = map[string]any{"value": "test"}
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		cancel() // Cancel immediately
 
 		result, err := typedHandler(ctx, req)

--- a/mcp/typed_tools_additional_test.go
+++ b/mcp/typed_tools_additional_test.go
@@ -29,7 +29,7 @@ func TestNewTypedToolHandler(t *testing.T) {
 			"count": 5,
 		}
 
-		result, err := typedHandler(context.Background(), req)
+		result, err := typedHandler(t.Context(), req)
 		require.NoError(t, err)
 		require.NotNil(t, result)
 
@@ -49,7 +49,7 @@ func TestNewTypedToolHandler(t *testing.T) {
 		req := CallToolRequest{}
 		req.Params.Arguments = "invalid arguments" // Not a map
 
-		result, err := typedHandler(context.Background(), req)
+		result, err := typedHandler(t.Context(), req)
 		require.NoError(t, err) // Handler returns result, not error
 		require.NotNil(t, result)
 
@@ -73,7 +73,7 @@ func TestNewTypedToolHandler(t *testing.T) {
 			"count": 5,
 		}
 
-		result, err := typedHandler(context.Background(), req)
+		result, err := typedHandler(t.Context(), req)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 	})

--- a/mcp/typed_tools_test.go
+++ b/mcp/typed_tools_test.go
@@ -265,7 +265,7 @@ func TestTypedToolHandlerWithComplexObjects(t *testing.T) {
 		},
 	}
 
-	result, err = wrappedHandler(context.Background(), req)
+	result, err = wrappedHandler(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Contains(t, result.Content[0].(TextContent).Text, "Jane Smith")
@@ -294,7 +294,7 @@ func TestTypedToolHandlerWithComplexObjects(t *testing.T) {
 	}`
 
 	req.Params.Arguments = json.RawMessage(jsonInput)
-	result, err = wrappedHandler(context.Background(), req)
+	result, err = wrappedHandler(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Contains(t, result.Content[0].(TextContent).Text, "Bob Johnson")

--- a/mcp/typed_tools_test.go
+++ b/mcp/typed_tools_test.go
@@ -35,7 +35,7 @@ func TestTypedToolHandler(t *testing.T) {
 	}
 
 	// Call the wrapped handler
-	result, err := wrappedHandler(context.Background(), req)
+	result, err := wrappedHandler(t.Context(), req)
 
 	// Verify results
 	assert.NoError(t, err)
@@ -50,7 +50,7 @@ func TestTypedToolHandler(t *testing.T) {
 	}
 
 	// This should still work because of type conversion
-	result, err = wrappedHandler(context.Background(), req)
+	result, err = wrappedHandler(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 
@@ -62,14 +62,14 @@ func TestTypedToolHandler(t *testing.T) {
 	}
 
 	// This should still work but name will be empty
-	result, err = wrappedHandler(context.Background(), req)
+	result, err = wrappedHandler(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.Equal(t, "", result.Content[0].(TextContent).Text)
 
 	// Test with completely invalid arguments
 	req.Params.Arguments = "not a map"
-	result, err = wrappedHandler(context.Background(), req)
+	result, err = wrappedHandler(t.Context(), req)
 	assert.NoError(t, err) // Error is wrapped in the result
 	assert.NotNil(t, result)
 	assert.True(t, result.IsError)
@@ -123,7 +123,7 @@ func TestTypedToolHandlerWithValidation(t *testing.T) {
 	}
 
 	// Call the wrapped handler
-	result, err := wrappedHandler(context.Background(), req)
+	result, err := wrappedHandler(t.Context(), req)
 
 	// Verify results
 	assert.NoError(t, err)
@@ -137,7 +137,7 @@ func TestTypedToolHandlerWithValidation(t *testing.T) {
 		"y":         0.0,
 	}
 
-	result, err = wrappedHandler(context.Background(), req)
+	result, err = wrappedHandler(t.Context(), req)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 	assert.True(t, result.IsError)
@@ -239,7 +239,7 @@ func TestTypedToolHandlerWithComplexObjects(t *testing.T) {
 	}
 
 	// Call the wrapped handler
-	result, err := wrappedHandler(context.Background(), req)
+	result, err := wrappedHandler(t.Context(), req)
 
 	// Verify results
 	assert.NoError(t, err)

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -206,7 +206,7 @@ func NewMetaFromMap(m map[string]any) *Meta {
 
 type Request struct {
 	Method string        `json:"method"`
-	Params RequestParams `json:"params,omitempty"`
+	Params RequestParams `json:"params,omitzero"`
 }
 
 type RequestParams struct {

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -217,7 +217,7 @@ type Params map[string]any
 
 type Notification struct {
 	Method string             `json:"method"`
-	Params NotificationParams `json:"params,omitempty"`
+	Params NotificationParams `json:"params,omitzero"`
 }
 
 type NotificationParams struct {
@@ -631,7 +631,7 @@ type ProgressNotificationParams struct {
 
 type PaginatedRequest struct {
 	Request
-	Params PaginatedParams `json:"params,omitempty"`
+	Params PaginatedParams `json:"params,omitzero"`
 }
 
 type PaginatedParams struct {

--- a/mcptest/mcptest.go
+++ b/mcptest/mcptest.go
@@ -42,11 +42,13 @@ type Server struct {
 }
 
 // NewServer starts a new MCP server with the provided tools and returns the server instance.
+// The server's lifetime is managed by Close(), not by the test context, so it can be
+// safely created in setup helpers and used across multiple subtests.
 func NewServer(t *testing.T, tools ...server.ServerTool) (*Server, error) {
 	server := NewUnstartedServer(t)
 	server.AddTools(tools...)
 
-	if err := server.Start(t.Context()); err != nil {
+	if err := server.Start(context.Background()); err != nil {
 		return nil, err
 	}
 

--- a/mcptest/mcptest.go
+++ b/mcptest/mcptest.go
@@ -46,8 +46,7 @@ func NewServer(t *testing.T, tools ...server.ServerTool) (*Server, error) {
 	server := NewUnstartedServer(t)
 	server.AddTools(tools...)
 
-	// TODO: use t.Context() once go.mod is upgraded to go 1.24+
-	if err := server.Start(context.TODO()); err != nil {
+	if err := server.Start(t.Context()); err != nil {
 		return nil, err
 	}
 

--- a/mcptest/mcptest.go
+++ b/mcptest/mcptest.go
@@ -48,7 +48,7 @@ func NewServer(t *testing.T, tools ...server.ServerTool) (*Server, error) {
 	server := NewUnstartedServer(t)
 	server.AddTools(tools...)
 
-	if err := server.Start(context.Background()); err != nil {
+	if err := server.Start(t.Context()); err != nil {
 		return nil, err
 	}
 

--- a/mcptest/mcptest_test.go
+++ b/mcptest/mcptest_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestServerWithTool(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	srv, err := mcptest.NewServer(t, server.ServerTool{
 		Tool: mcp.NewTool("hello",
@@ -81,7 +81,7 @@ func resultToString(result *mcp.CallToolResult) (string, error) {
 }
 
 func TestServerWithToolStructuredContent(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	srv, err := mcptest.NewServer(t, server.ServerTool{
 		Tool: mcp.NewTool("get_user",
@@ -170,7 +170,7 @@ func structuredContentHandler(ctx context.Context, request mcp.CallToolRequest) 
 }
 
 func TestServerWithPrompt(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	srv := mcptest.NewUnstartedServer(t)
 	defer srv.Close()
@@ -231,7 +231,7 @@ func TestServerWithPrompt(t *testing.T) {
 }
 
 func TestServerWithResource(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	srv := mcptest.NewUnstartedServer(t)
 	defer srv.Close()
@@ -280,7 +280,7 @@ func TestServerWithResource(t *testing.T) {
 }
 
 func TestServerWithResourceTemplate(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	srv := mcptest.NewUnstartedServer(t)
 	defer srv.Close()
@@ -390,7 +390,7 @@ func TestListToolsWithHeader(t *testing.T) {
 		t.Fatalf("Create client failed %v", err)
 		return
 	}
-	ctx := context.Background()
+	ctx := t.Context()
 	if err := client.Start(ctx); err != nil {
 		t.Fatalf("Failed to start client: %v", err)
 		return
@@ -403,7 +403,7 @@ func TestListToolsWithHeader(t *testing.T) {
 	}
 
 	req := mcp.ListToolsRequest{Header: http.Header{"X-Test-Header": {expectedHeaderValue}}}
-	_, err = client.ListToolsByPage(context.Background(), req)
+	_, err = client.ListToolsByPage(t.Context(), req)
 	if err != nil {
 		t.Fatalf("Failed to ListTools: %v\n", err)
 	}
@@ -413,7 +413,7 @@ func TestListToolsWithHeader(t *testing.T) {
 }
 
 func TestSimulateClientInfo(t *testing.T) {
-	ctx := context.Background()
+	ctx := t.Context()
 
 	srv := mcptest.NewUnstartedServer(t)
 	defer srv.Close()

--- a/server/elicitation_test.go
+++ b/server/elicitation_test.go
@@ -296,7 +296,7 @@ func TestSendElicitationComplete_NoPriorRequest(t *testing.T) {
 
 	// Call SendElicitationComplete directly without any prior request state
 	// This verifies the server can send completion notifications independently
-	err := s.SendElicitationComplete(context.Background(), mockSession, "independent-id-999")
+	err := s.SendElicitationComplete(t.Context(), mockSession, "independent-id-999")
 	require.NoError(t, err)
 
 	select {

--- a/server/elicitation_test.go
+++ b/server/elicitation_test.go
@@ -78,7 +78,7 @@ func TestMCPServer_RequestElicitation_NoSession(t *testing.T) {
 		},
 	}
 
-	_, err := server.RequestElicitation(context.Background(), request)
+	_, err := server.RequestElicitation(t.Context(), request)
 
 	require.Error(t, err)
 	assert.True(t, errors.Is(err, ErrNoActiveSession), "expected ErrNoActiveSession, got %v", err)
@@ -90,7 +90,7 @@ func TestMCPServer_RequestElicitation_SessionDoesNotSupportElicitation(t *testin
 	// Use a regular session that doesn't implement SessionWithElicitation
 	mockSession := &mockBasicSession{sessionID: "test-session"}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = server.WithContext(ctx, mockSession)
 
 	request := mcp.ElicitationRequest{
@@ -126,7 +126,7 @@ func TestMCPServer_RequestElicitation_Success(t *testing.T) {
 	}
 
 	// Create context with session
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = server.WithContext(ctx, mockSession)
 
 	request := mcp.ElicitationRequest{
@@ -223,7 +223,7 @@ func TestRequestElicitation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := NewMCPServer("test", "1.0", WithElicitation())
-			ctx := server.WithContext(context.Background(), tt.session)
+			ctx := server.WithContext(t.Context(), tt.session)
 
 			result, err := server.RequestElicitation(ctx, tt.request)
 
@@ -256,7 +256,7 @@ func TestRequestURLElicitation(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := s.RequestURLElicitation(ctx, mockSession, "id-123", "https://example.com/auth", "Please auth")
 	require.NoError(t, err)
 

--- a/server/resource_test.go
+++ b/server/resource_test.go
@@ -59,7 +59,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 				)
 
 				// First, verify we have two resources
-				response := server.HandleMessage(context.Background(), []byte(`{
+				response := server.HandleMessage(t.Context(), []byte(`{
 					"jsonrpc": "2.0",
 					"id": 1,
 					"method": "resources/list"
@@ -71,7 +71,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 				assert.Len(t, result.Resources, 2)
 
 				// Now register session to receive notifications
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -120,7 +120,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 				)
 
 				// Register session to receive notifications
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -176,7 +176,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 				)
 
 				// Register session to receive notifications
-				err := noListChangedServer.RegisterSession(context.TODO(), &fakeSession{
+				err := noListChangedServer.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -199,7 +199,7 @@ func TestMCPServer_RemoveResource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			server := NewMCPServer(
 				"test-server",
 				"1.0.0",

--- a/server/roots_test.go
+++ b/server/roots_test.go
@@ -67,7 +67,7 @@ func TestMCPServer_RequestRoots_NoSession(t *testing.T) {
 		},
 	}
 
-	_, err := server.RequestRoots(context.Background(), request)
+	_, err := server.RequestRoots(t.Context(), request)
 
 	if err == nil {
 		t.Error("expected error when no session available")
@@ -84,7 +84,7 @@ func TestMCPServer_RequestRoots_SessionDoesNotSupportRoots(t *testing.T) {
 	// Use a regular session that doesn't implement SessionWithRoots
 	mockSession := &mockBasicRootsSession{sessionID: "test-session"}
 
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = server.WithContext(ctx, mockSession)
 
 	request := mcp.ListRootsRequest{
@@ -128,7 +128,7 @@ func TestMCPServer_RequestRoots_Success(t *testing.T) {
 	}
 
 	// Create context with session
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = server.WithContext(ctx, mockSession)
 
 	request := mcp.ListRootsRequest{
@@ -222,7 +222,7 @@ func TestRequestRoots(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := NewMCPServer("test", "1.0", WithRoots())
-			ctx := server.WithContext(context.Background(), tt.session)
+			ctx := server.WithContext(t.Context(), tt.session)
 
 			result, err := server.RequestRoots(ctx, tt.request)
 

--- a/server/sampling_test.go
+++ b/server/sampling_test.go
@@ -20,7 +20,7 @@ func TestMCPServer_RequestSampling_NoSession(t *testing.T) {
 		},
 	}
 
-	_, err := server.RequestSampling(context.Background(), request)
+	_, err := server.RequestSampling(t.Context(), request)
 
 	if err == nil {
 		t.Error("expected error when no session available")
@@ -86,7 +86,7 @@ func TestMCPServer_RequestSampling_Success(t *testing.T) {
 	}
 
 	// Create context with session
-	ctx := context.Background()
+	ctx := t.Context()
 	ctx = server.WithContext(ctx, mockSession)
 
 	request := mcp.CreateMessageRequest{
@@ -118,7 +118,7 @@ func TestMCPServer_EnableSampling_SetsCapability(t *testing.T) {
 	server := NewMCPServer("test", "1.0.0")
 
 	// Verify sampling capability is not set initially
-	ctx := context.Background()
+	ctx := t.Context()
 	initRequest := mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ProtocolVersion: "2025-03-26",

--- a/server/server_additional_test.go
+++ b/server/server_additional_test.go
@@ -787,9 +787,7 @@ func TestMCPServer_ConcurrentCapabilityChecks(t *testing.T) {
 	errorCount := atomic.Int32{}
 
 	// Goroutine that adds tools (triggers capability registration)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		i := 0
 		for {
 			select {
@@ -801,13 +799,11 @@ func TestMCPServer_ConcurrentCapabilityChecks(t *testing.T) {
 				time.Sleep(1 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Goroutines that check capabilities
 	for range 5 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			for {
 				select {
 				case <-stopCh:
@@ -819,7 +815,7 @@ func TestMCPServer_ConcurrentCapabilityChecks(t *testing.T) {
 					time.Sleep(1 * time.Millisecond)
 				}
 			}
-		}()
+		})
 	}
 
 	// Let it run for a bit

--- a/server/server_additional_test.go
+++ b/server/server_additional_test.go
@@ -363,9 +363,7 @@ func TestMCPServer_SessionUnregistrationDuringNotification(t *testing.T) {
 	stopCh := make(chan struct{})
 
 	// Goroutine that continuously sends notifications
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stopCh:
@@ -377,17 +375,15 @@ func TestMCPServer_SessionUnregistrationDuringNotification(t *testing.T) {
 				time.Sleep(1 * time.Millisecond)
 			}
 		}
-	}()
+	})
 
 	// Goroutine that unregisters sessions
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for i := range numSessions {
 			time.Sleep(5 * time.Millisecond)
 			server.UnregisterSession(context.Background(), sessions[i].SessionID())
 		}
-	}()
+	})
 
 	// Let it run for a bit
 	time.Sleep(100 * time.Millisecond)

--- a/server/server_additional_test.go
+++ b/server/server_additional_test.go
@@ -27,7 +27,7 @@ func TestMCPServer_MiddlewarePanicRecovery(t *testing.T) {
 			},
 		)
 
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -56,7 +56,7 @@ func TestMCPServer_MiddlewarePanicRecovery(t *testing.T) {
 			},
 		)
 
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "resources/read",
@@ -220,7 +220,7 @@ func TestMCPServer_PaginationEdgeCases(t *testing.T) {
 			)
 		}
 
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "resources/list",
@@ -248,7 +248,7 @@ func TestMCPServer_PaginationEdgeCases(t *testing.T) {
 		// Create cursor that points beyond the list
 		beyondCursor := base64.StdEncoding.EncodeToString([]byte("tool-99"))
 
-		response := server.HandleMessage(context.Background(), fmt.Appendf(nil, `{
+		response := server.HandleMessage(t.Context(), fmt.Appendf(nil, `{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/list",
@@ -283,7 +283,7 @@ func TestMCPServer_PaginationEdgeCases(t *testing.T) {
 			)
 		}
 
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "prompts/list"
@@ -300,7 +300,7 @@ func TestMCPServer_PaginationEdgeCases(t *testing.T) {
 		assert.NotEmpty(t, result.NextCursor, "Cursor should be set when exactly at limit")
 
 		// Request next page - should be empty
-		response = server.HandleMessage(context.Background(), fmt.Appendf(nil, `{
+		response = server.HandleMessage(t.Context(), fmt.Appendf(nil, `{
 			"jsonrpc": "2.0",
 			"id": 2,
 			"method": "prompts/list",
@@ -325,7 +325,7 @@ func TestMCPServer_PaginationEdgeCases(t *testing.T) {
 			WithPaginationLimit(10),
 		)
 
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "resources/list"
@@ -355,7 +355,7 @@ func TestMCPServer_SessionUnregistrationDuringNotification(t *testing.T) {
 			notificationChannel: make(chan mcp.JSONRPCNotification, 10),
 		}
 		sessions[i].Initialize()
-		err := server.RegisterSession(context.Background(), sessions[i])
+		err := server.RegisterSession(t.Context(), sessions[i])
 		require.NoError(t, err)
 	}
 
@@ -381,7 +381,7 @@ func TestMCPServer_SessionUnregistrationDuringNotification(t *testing.T) {
 	wg.Go(func() {
 		for i := range numSessions {
 			time.Sleep(5 * time.Millisecond)
-			server.UnregisterSession(context.Background(), sessions[i].SessionID())
+			server.UnregisterSession(t.Context(), sessions[i].SessionID())
 		}
 	})
 
@@ -408,11 +408,11 @@ func TestMCPServer_DuplicateSessionRegistration(t *testing.T) {
 	}
 
 	// First registration should succeed
-	err := server.RegisterSession(context.Background(), session1)
+	err := server.RegisterSession(t.Context(), session1)
 	require.NoError(t, err)
 
 	// Second registration with same ID should fail
-	err = server.RegisterSession(context.Background(), session2)
+	err = server.RegisterSession(t.Context(), session2)
 	require.Error(t, err)
 	assert.ErrorIs(t, err, ErrSessionExists)
 }
@@ -427,7 +427,7 @@ func TestMCPServer_SessionToolOperationsAfterUnregister(t *testing.T) {
 		initialized:         true,
 	}
 
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// Add a tool to the session
@@ -435,7 +435,7 @@ func TestMCPServer_SessionToolOperationsAfterUnregister(t *testing.T) {
 	require.NoError(t, err)
 
 	// Unregister the session
-	server.UnregisterSession(context.Background(), session.SessionID())
+	server.UnregisterSession(t.Context(), session.SessionID())
 
 	// Try to add tool to unregistered session
 	err = server.AddSessionTool(session.SessionID(), mcp.NewTool("another-tool"), nil)
@@ -563,7 +563,7 @@ func TestMCPServer_ResourceTemplateURIMatching(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			response := server.HandleMessage(context.Background(), requestBytes)
+			response := server.HandleMessage(t.Context(), requestBytes)
 
 			if tt.shouldMatch {
 				resp, ok := response.(mcp.JSONRPCResponse)
@@ -654,7 +654,7 @@ func TestMCPServer_UnsupportedProtocolVersions(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			response := server.HandleMessage(context.Background(), requestBytes)
+			response := server.HandleMessage(t.Context(), requestBytes)
 
 			resp, ok := response.(mcp.JSONRPCResponse)
 			require.True(t, ok)
@@ -681,7 +681,7 @@ func TestMCPServer_HooksWithNilSession(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithHooks(hooks))
 
 	// Make request without session context
-	response := server.HandleMessage(context.Background(), []byte(`{
+	response := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "ping"
@@ -839,7 +839,7 @@ func TestMCPServer_PaginationCursorStability(t *testing.T) {
 	}
 
 	// Get first page
-	response := server.HandleMessage(context.Background(), []byte(`{
+	response := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "tools/list"
@@ -860,7 +860,7 @@ func TestMCPServer_PaginationCursorStability(t *testing.T) {
 	server.DeleteTools("tool-05")
 
 	// Get second page with original cursor
-	response = server.HandleMessage(context.Background(), fmt.Appendf(nil, `{
+	response = server.HandleMessage(t.Context(), fmt.Appendf(nil, `{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"method": "tools/list",

--- a/server/server_race_test.go
+++ b/server/server_race_test.go
@@ -143,10 +143,7 @@ func runConcurrentOperation(
 	_ string,
 	operation func(),
 ) {
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-
+	wg.Go(func() {
 		done := time.After(duration)
 		for {
 			select {
@@ -156,7 +153,7 @@ func runConcurrentOperation(
 				operation()
 			}
 		}
-	}()
+	})
 }
 
 // TestConcurrentPromptAdd specifically tests for the deadlock scenario where adding a prompt

--- a/server/server_race_test.go
+++ b/server/server_race_test.go
@@ -25,7 +25,7 @@ func TestRaceConditions(t *testing.T) {
 	)
 
 	// Create a context
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a sync.WaitGroup to coordinate test goroutines
 	var wg sync.WaitGroup
@@ -160,7 +160,7 @@ func runConcurrentOperation(
 // from a goroutine can cause a deadlock
 func TestConcurrentPromptAdd(t *testing.T) {
 	srv := NewMCPServer("test-server", "1.0.0", WithPromptCapabilities(true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Add a prompt with a handler that adds another prompt in a goroutine
 	srv.AddPrompt(mcp.Prompt{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2253,7 +2253,7 @@ func listByPaginationForReflect[T any](
 
 func BenchmarkMCPServer_Pagination(b *testing.B) {
 	list := getTools(10000)
-	ctx := context.Background()
+	ctx := b.Context()
 	server := createTestServer()
 	for b.Loop() {
 		_, _, _ = listByPagination(ctx, server, "dG9vbDY1NA==", list)
@@ -2262,7 +2262,7 @@ func BenchmarkMCPServer_Pagination(b *testing.B) {
 
 func BenchmarkMCPServer_PaginationForReflect(b *testing.B) {
 	list := getTools(10000)
-	ctx := context.Background()
+	ctx := b.Context()
 	server := createTestServer()
 	for b.Loop() {
 		_, _, _ = listByPaginationForReflect(ctx, server, "dG9vbDY1NA==", list)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2081,12 +2081,12 @@ func TestMCPServer_GetHooks_Composable(t *testing.T) {
 	assert.Len(t, existing.OnBeforeAny, 2)
 
 	// Trigger hooks via a ping request
-	_ = s.HandleMessage(context.Background(), []byte(`{
+	_ = s.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "initialize"
 	}`))
-	_ = s.HandleMessage(context.Background(), []byte(`{
+	_ = s.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"method": "ping"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1010,7 +1010,7 @@ func TestMCPServer_Prompts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			server := NewMCPServer("test-server", "1.0.0", WithPromptCapabilities(true))
 			_ = server.HandleMessage(ctx, []byte(`{
 				"jsonrpc": "2.0",
@@ -1215,7 +1215,7 @@ func TestMCPServer_Resources(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(true, true))
 			_ = server.HandleMessage(ctx, []byte(`{
 				"jsonrpc": "2.0",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -144,7 +144,7 @@ func TestMCPServer_Capabilities(t *testing.T) {
 			messageBytes, err := json.Marshal(message)
 			assert.NoError(t, err)
 
-			response := server.HandleMessage(context.Background(), messageBytes)
+			response := server.HandleMessage(t.Context(), messageBytes)
 			tt.validate(t, response)
 		})
 	}
@@ -183,7 +183,7 @@ func TestMCPServer_Tools(t *testing.T) {
 		{
 			name: "SetTools sends single notifications/tools/list_changed with one active session",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -214,7 +214,7 @@ func TestMCPServer_Tools(t *testing.T) {
 			name: "SetTools sends single notifications/tools/list_changed per each active session",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
 				for i := range 5 {
-					err := server.RegisterSession(context.TODO(), &fakeSession{
+					err := server.RegisterSession(t.Context(), &fakeSession{
 						sessionID:           fmt.Sprintf("test%d", i),
 						notificationChannel: notificationChannel,
 						initialized:         true,
@@ -223,7 +223,7 @@ func TestMCPServer_Tools(t *testing.T) {
 				}
 				// also let's register inactive sessions
 				for i := range 5 {
-					err := server.RegisterSession(context.TODO(), &fakeSession{
+					err := server.RegisterSession(t.Context(), &fakeSession{
 						sessionID:           fmt.Sprintf("test%d", i+5),
 						notificationChannel: notificationChannel,
 						initialized:         false,
@@ -256,7 +256,7 @@ func TestMCPServer_Tools(t *testing.T) {
 		{
 			name: "AddTool sends multiple notifications/tools/list_changed",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -288,7 +288,7 @@ func TestMCPServer_Tools(t *testing.T) {
 		{
 			name: "DeleteTools sends single notifications/tools/list_changed",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -319,7 +319,7 @@ func TestMCPServer_Tools(t *testing.T) {
 		{
 			name: "DeleteTools with non-existent tools does nothing and not receives notifications from MCPServer",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -347,7 +347,7 @@ func TestMCPServer_Tools(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			server := NewMCPServer("test-server", "1.0.0", WithToolCapabilities(true))
 			_ = server.HandleMessage(ctx, []byte(`{
 				"jsonrpc": "2.0",
@@ -456,7 +456,7 @@ func TestMCPServer_HandleValidMessages(t *testing.T) {
 			messageBytes, err := json.Marshal(tt.message)
 			assert.NoError(t, err)
 
-			response := server.HandleMessage(context.Background(), messageBytes)
+			response := server.HandleMessage(t.Context(), messageBytes)
 			assert.NotNil(t, response)
 			tt.validate(t, response)
 		})
@@ -496,7 +496,7 @@ func TestMCPServer_HandlePagination(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			response := server.HandleMessage(
-				context.Background(),
+				t.Context(),
 				[]byte(tt.message),
 			)
 			tt.validate(t, response)
@@ -520,7 +520,7 @@ func TestMCPServer_HandleNotifications(t *testing.T) {
             "method": "notifications/initialized"
         }`
 
-	response := server.HandleMessage(context.Background(), []byte(message))
+	response := server.HandleMessage(t.Context(), []byte(message))
 	assert.Nil(t, response)
 	assert.True(t, notificationReceived)
 }
@@ -598,7 +598,7 @@ func TestMCPServer_SendNotificationToClient(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := NewMCPServer("test-server", "1.0.0")
-			ctx := tt.contextPrepare(context.Background(), server)
+			ctx := tt.contextPrepare(t.Context(), server)
 			_ = server.HandleMessage(ctx, []byte(`{
 				"jsonrpc": "2.0",
 				"id": 1,
@@ -678,7 +678,7 @@ func TestMCPServer_SendNotificationToAllClients(t *testing.T) {
 
 	t.Run("all sessions", func(t *testing.T) {
 		server := NewMCPServer("test-server", "1.0.0")
-		ctx := contextPrepare(context.Background(), server)
+		ctx := contextPrepare(t.Context(), server)
 		_ = server.HandleMessage(ctx, []byte(`{
 				"jsonrpc": "2.0",
 				"id": 1,
@@ -802,7 +802,7 @@ func TestMCPServer_PromptHandling(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			response := server.HandleMessage(
-				context.Background(),
+				t.Context(),
 				[]byte(tt.message),
 			)
 			tt.validate(t, response)
@@ -820,7 +820,7 @@ func TestMCPServer_Prompts(t *testing.T) {
 		{
 			name: "DeletePrompts sends single notifications/prompts/list_changed",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -861,7 +861,7 @@ func TestMCPServer_Prompts(t *testing.T) {
 		{
 			name: "DeletePrompts removes the first prompt and retains the other",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -914,7 +914,7 @@ func TestMCPServer_Prompts(t *testing.T) {
 		{
 			name: "DeletePrompts with non-existent prompts does nothing and not receives notifications from MCPServer",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -966,7 +966,7 @@ func TestMCPServer_Prompts(t *testing.T) {
 		{
 			name: "SetPrompts sends single notifications/prompts/list_changed with one active session",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -1052,7 +1052,7 @@ func TestMCPServer_Resources(t *testing.T) {
 		{
 			name: "DeleteResources sends single notifications/resources/list_changed",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -1089,7 +1089,7 @@ func TestMCPServer_Resources(t *testing.T) {
 		{
 			name: "DeleteResources removes the first resource and retains the other",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -1133,7 +1133,7 @@ func TestMCPServer_Resources(t *testing.T) {
 		{
 			name: "DeleteResources with non-existent resources does nothing and not receives notifications from MCPServer",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,
@@ -1178,7 +1178,7 @@ func TestMCPServer_Resources(t *testing.T) {
 		{
 			name: "SetResources sends single notifications/resources/list_changed with one active session",
 			action: func(t *testing.T, server *MCPServer, notificationChannel chan mcp.JSONRPCNotification) {
-				err := server.RegisterSession(context.TODO(), &fakeSession{
+				err := server.RegisterSession(t.Context(), &fakeSession{
 					sessionID:           "test",
 					notificationChannel: notificationChannel,
 					initialized:         true,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1304,7 +1304,7 @@ func TestMCPServer_HandleInvalidMessages(t *testing.T) {
 			errs = nil // Reset errors for each test case
 
 			response := server.HandleMessage(
-				context.Background(),
+				t.Context(),
 				[]byte(tt.message),
 			)
 			assert.NotNil(t, response)
@@ -1438,7 +1438,7 @@ func TestMCPServer_HandleUndefinedHandlers(t *testing.T) {
 			errs = nil // Reset errors for each test case
 			beforeResults = nil
 			response := server.HandleMessage(
-				context.Background(),
+				t.Context(),
 				[]byte(tt.message),
 			)
 			assert.NotNil(t, response)
@@ -1529,7 +1529,7 @@ func TestMCPServer_HandleMethodsWithoutCapabilities(t *testing.T) {
 
 			server := NewMCPServer("test-server", "1.0.0", tt.options...)
 			response := server.HandleMessage(
-				context.Background(),
+				t.Context(),
 				[]byte(tt.message),
 			)
 			assert.NotNil(t, response)
@@ -1617,7 +1617,7 @@ func TestMCPServer_Instructions(t *testing.T) {
 			messageBytes, err := json.Marshal(message)
 			assert.NoError(t, err)
 
-			response := server.HandleMessage(context.Background(), messageBytes)
+			response := server.HandleMessage(t.Context(), messageBytes)
 			tt.validate(t, response)
 		})
 	}
@@ -1666,7 +1666,7 @@ func TestMCPServer_ResourceTemplates(t *testing.T) {
 
 	t.Run("Get resource template", func(t *testing.T) {
 		response := server.HandleMessage(
-			context.Background(),
+			t.Context(),
 			[]byte(listMessage),
 		)
 		assert.NotNil(t, response)
@@ -1688,7 +1688,7 @@ func TestMCPServer_ResourceTemplates(t *testing.T) {
 		assert.Equal(t, "test://{a}/test-resource{/b*}", resourceTemplate["uriTemplate"])
 
 		response = server.HandleMessage(
-			context.Background(),
+			t.Context(),
 			[]byte(message),
 		)
 
@@ -1734,7 +1734,7 @@ func TestMCPServer_ResourceTemplates(t *testing.T) {
 
 	t.Run("Get resource template again", func(t *testing.T) {
 		response := server.HandleMessage(
-			context.Background(),
+			t.Context(),
 			[]byte(listMessage),
 		)
 		assert.NotNil(t, response)
@@ -1926,14 +1926,14 @@ func TestMCPServer_WithHooks(t *testing.T) {
 	)
 
 	// Initialize the server
-	_ = server.HandleMessage(context.Background(), []byte(`{
+	_ = server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "initialize"
 	}`))
 
 	// Test 1: Verify ping method hooks
-	pingResponse := server.HandleMessage(context.Background(), []byte(`{
+	pingResponse := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 2,
 		"method": "ping"
@@ -1943,7 +1943,7 @@ func TestMCPServer_WithHooks(t *testing.T) {
 	assert.IsType(t, mcp.JSONRPCResponse{}, pingResponse)
 
 	// Test 2: Verify tools/list method hooks
-	toolsListResponse := server.HandleMessage(context.Background(), []byte(`{
+	toolsListResponse := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 3,
 		"method": "tools/list"
@@ -1953,7 +1953,7 @@ func TestMCPServer_WithHooks(t *testing.T) {
 	assert.IsType(t, mcp.JSONRPCResponse{}, toolsListResponse)
 
 	// Test 3: Verify error hooks with invalid tool
-	errorResponse := server.HandleMessage(context.Background(), []byte(`{
+	errorResponse := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 4,
 		"method": "tools/call",
@@ -2131,7 +2131,7 @@ func TestMCPServer_SessionHooks(t *testing.T) {
 		initialized:         false,
 	}
 
-	ctx := context.WithoutCancel(context.Background())
+	ctx := context.WithoutCancel(t.Context())
 	err := server.RegisterSession(ctx, testSession)
 	require.NoError(t, err)
 
@@ -2158,7 +2158,7 @@ func TestMCPServer_SessionHooks_NilHooks(t *testing.T) {
 		initialized:         false,
 	}
 
-	ctx := context.WithoutCancel(context.Background())
+	ctx := context.WithoutCancel(t.Context())
 	err := server.RegisterSession(ctx, testSession)
 	require.NoError(t, err)
 
@@ -2181,7 +2181,7 @@ func TestMCPServer_WithRecover(t *testing.T) {
 		panicToolHandler,
 	)
 
-	response := server.HandleMessage(context.Background(), []byte(`{
+	response := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 4,
 		"method": "tools/call",
@@ -2377,7 +2377,7 @@ func TestMCPServer_ProtocolNegotiation(t *testing.T) {
 			messageBytes, err := json.Marshal(initRequest)
 			assert.NoError(t, err)
 
-			response := server.HandleMessage(context.Background(), messageBytes)
+			response := server.HandleMessage(t.Context(), messageBytes)
 			assert.NotNil(t, response)
 
 			resp, ok := response.(mcp.JSONRPCResponse)
@@ -2979,7 +2979,7 @@ func TestMCPServer_HandleListTools_IncludesTaskTools(t *testing.T) {
 		request := mcp.ListToolsRequest{}
 
 		// Call handleListTools
-		result, err := server.handleListTools(context.Background(), 1, request)
+		result, err := server.handleListTools(t.Context(), 1, request)
 
 		// Verify both tools are included
 		require.Nil(t, err)
@@ -3042,7 +3042,7 @@ func TestMCPServer_HandleListTools_IncludesTaskTools(t *testing.T) {
 		request := mcp.ListToolsRequest{}
 
 		// Call handleListTools
-		result, err := server.handleListTools(context.Background(), 1, request)
+		result, err := server.handleListTools(t.Context(), 1, request)
 
 		// Verify both task tools are included
 		require.Nil(t, err)
@@ -3061,7 +3061,7 @@ func TestMCPServer_HandleListTools_IncludesTaskTools(t *testing.T) {
 		request := mcp.ListToolsRequest{}
 
 		// Call handleListTools
-		result, err := server.handleListTools(context.Background(), 1, request)
+		result, err := server.handleListTools(t.Context(), 1, request)
 
 		// Verify empty list
 		require.Nil(t, err)
@@ -3109,7 +3109,7 @@ func TestMCPServer_HandleListTools_IncludesTaskTools(t *testing.T) {
 		request := mcp.ListToolsRequest{}
 
 		// Call handleListTools
-		result, err := server.handleListTools(context.Background(), 1, request)
+		result, err := server.handleListTools(t.Context(), 1, request)
 
 		// Verify correct alphabetical ordering
 		require.Nil(t, err)
@@ -3228,7 +3228,7 @@ func TestMCPServer_AddTaskTool(t *testing.T) {
 		)
 
 		// List tools
-		result, err := server.handleListTools(context.Background(), 1, mcp.ListToolsRequest{})
+		result, err := server.handleListTools(t.Context(), 1, mcp.ListToolsRequest{})
 
 		// Verify the task tool appears in the list
 		require.Nil(t, err)
@@ -3491,7 +3491,7 @@ func TestMCPServer_Complete(t *testing.T) {
 		}`
 
 		server := NewMCPServer("test-server", "1.0.0")
-		response := server.HandleMessage(context.Background(), []byte(message))
+		response := server.HandleMessage(t.Context(), []byte(message))
 		assert.Equal(t, mcp.JSONRPCError{
 			JSONRPC: mcp.JSONRPC_VERSION,
 			ID:      mcp.NewRequestId(float64(1)),
@@ -3517,7 +3517,7 @@ func TestMCPServer_Complete(t *testing.T) {
 		}`
 
 		server := NewMCPServer("test-server", "1.0.0", WithCompletions())
-		response := server.HandleMessage(context.Background(), []byte(invalidRefTypeMessage))
+		response := server.HandleMessage(t.Context(), []byte(invalidRefTypeMessage))
 		assert.Equal(t, mcp.JSONRPCError{
 			JSONRPC: mcp.JSONRPC_VERSION,
 			ID:      mcp.NewRequestId(float64(1)),
@@ -3546,7 +3546,7 @@ func TestMCPServer_Complete(t *testing.T) {
 					}
 				}
 			}`
-			response := server.HandleMessage(context.Background(), []byte(promptMessage))
+			response := server.HandleMessage(t.Context(), []byte(promptMessage))
 			assert.Equal(t, mcp.JSONRPCResponse{
 				JSONRPC: mcp.JSONRPC_VERSION,
 				ID:      mcp.NewRequestId(float64(1)),
@@ -3574,7 +3574,7 @@ func TestMCPServer_Complete(t *testing.T) {
 					}
 				}
 			}`
-			response := server.HandleMessage(context.Background(), []byte(resourceMessage))
+			response := server.HandleMessage(t.Context(), []byte(resourceMessage))
 			assert.Equal(t, mcp.JSONRPCResponse{
 				JSONRPC: mcp.JSONRPC_VERSION,
 				ID:      mcp.NewRequestId(float64(1)),
@@ -3621,7 +3621,7 @@ func TestMCPServer_Complete(t *testing.T) {
 					}),
 				),
 			)
-			response := server.HandleMessage(context.Background(), []byte(message))
+			response := server.HandleMessage(t.Context(), []byte(message))
 			assert.Equal(t, mcp.JSONRPCResponse{
 				JSONRPC: mcp.JSONRPC_VERSION,
 				ID:      mcp.NewRequestId(float64(1)),
@@ -3676,7 +3676,7 @@ func TestMCPServer_Complete(t *testing.T) {
 					}),
 				),
 			)
-			response := server.HandleMessage(context.Background(), []byte(message))
+			response := server.HandleMessage(t.Context(), []byte(message))
 			assert.Equal(t, mcp.JSONRPCResponse{
 				JSONRPC: mcp.JSONRPC_VERSION,
 				ID:      mcp.NewRequestId(float64(1)),
@@ -3706,7 +3706,7 @@ func TestMCPServer_TaskSupportValidation(t *testing.T) {
 		})
 
 		// Try to call the tool without task param
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3735,7 +3735,7 @@ func TestMCPServer_TaskSupportValidation(t *testing.T) {
 		})
 
 		// Create request with task param
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3772,7 +3772,7 @@ func TestMCPServer_TaskSupportValidation(t *testing.T) {
 		})
 
 		// Call without task param
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3802,7 +3802,7 @@ func TestMCPServer_TaskSupportValidation(t *testing.T) {
 		})
 
 		// Call with task param
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3838,7 +3838,7 @@ func TestMCPServer_TaskSupportValidation(t *testing.T) {
 		})
 
 		// Call without task param
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3867,7 +3867,7 @@ func TestMCPServer_TaskSupportValidation(t *testing.T) {
 		})
 
 		// Call with task param (should still work, just ignores the task param for now)
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3896,7 +3896,7 @@ func TestMCPServer_TaskSupportValidation(t *testing.T) {
 		})
 
 		// Call without task param
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3928,7 +3928,7 @@ func TestMCPServer_HybridModeDetection(t *testing.T) {
 		})
 
 		// Call without task param - should execute synchronously
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -3961,7 +3961,7 @@ func TestMCPServer_HybridModeDetection(t *testing.T) {
 		})
 
 		// Call with task param - should execute as task
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -4003,7 +4003,7 @@ func TestMCPServer_HybridModeDetection(t *testing.T) {
 		})
 
 		// Call with task param - should execute as task
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -4045,7 +4045,7 @@ func TestMCPServer_HybridModeDetection(t *testing.T) {
 		})
 
 		// Call with task param - should still execute synchronously (task param ignored)
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",
@@ -4077,7 +4077,7 @@ func TestMCPServer_HybridModeDetection(t *testing.T) {
 		})
 
 		// Call with task param - should still execute synchronously (no task support)
-		response := server.HandleMessage(context.Background(), []byte(`{
+		response := server.HandleMessage(t.Context(), []byte(`{
 			"jsonrpc": "2.0",
 			"id": 1,
 			"method": "tools/call",

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2255,7 +2255,7 @@ func BenchmarkMCPServer_Pagination(b *testing.B) {
 	list := getTools(10000)
 	ctx := context.Background()
 	server := createTestServer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, _ = listByPagination(ctx, server, "dG9vbDY1NA==", list)
 	}
 }
@@ -2264,7 +2264,7 @@ func BenchmarkMCPServer_PaginationForReflect(b *testing.B) {
 	list := getTools(10000)
 	ctx := context.Background()
 	server := createTestServer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _, _ = listByPaginationForReflect(ctx, server, "dG9vbDY1NA==", list)
 	}
 }

--- a/server/session_resource_helpers_test.go
+++ b/server/session_resource_helpers_test.go
@@ -14,7 +14,7 @@ import (
 // TestAddSessionResource tests adding a single resource to a session
 func TestAddSessionResource(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session with resources support
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -68,7 +68,7 @@ func TestAddSessionResource(t *testing.T) {
 // TestAddSessionResources tests adding multiple resources to a session
 func TestAddSessionResources(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session with resources support
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -151,7 +151,7 @@ func TestAddSessionResources(t *testing.T) {
 // TestDeleteSessionResources tests removing resources from a session
 func TestDeleteSessionResources(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session with pre-existing resources
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -205,7 +205,7 @@ func TestDeleteSessionResources(t *testing.T) {
 // TestSessionResourcesWithGlobalResources tests merging of global and session resources
 func TestSessionResourcesWithGlobalResources(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Add global resources
 	server.AddResource(
@@ -321,7 +321,7 @@ func TestSessionResourcesWithGlobalResources(t *testing.T) {
 // TestAddSessionResourcesUninitialized tests adding resources to uninitialized session
 func TestAddSessionResourcesUninitialized(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create an uninitialized session
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -391,7 +391,7 @@ func TestAddSessionResourcesUninitialized(t *testing.T) {
 // TestDeleteSessionResourcesUninitialized tests deleting resources from uninitialized session
 func TestDeleteSessionResourcesUninitialized(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create an uninitialized session with resources
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -461,7 +461,7 @@ func TestSessionResourceCapabilitiesBehavior(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := tt.setupServer()
-			ctx := context.Background()
+			ctx := t.Context()
 
 			sessionChan := make(chan mcp.JSONRPCNotification, 10)
 			session := &sessionTestClientWithResources{
@@ -529,7 +529,7 @@ func TestSessionResourceCapabilitiesBehavior(t *testing.T) {
 // TestSessionResourceOperationsAfterUnregister tests operations on unregistered sessions
 func TestSessionResourceOperationsAfterUnregister(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create and register a session
 	session := &sessionTestClientWithResources{
@@ -563,7 +563,7 @@ func TestSessionResourceOperationsAfterUnregister(t *testing.T) {
 // TestSessionResourcesConcurrency tests thread-safe resource operations
 func TestSessionResourcesConcurrency(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session
 	session := &sessionTestClientWithResources{
@@ -660,7 +660,7 @@ func TestSessionResourcesConcurrency(t *testing.T) {
 // TestSessionDoesNotSupportResources tests error handling for incompatible sessions
 func TestSessionDoesNotSupportResources(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0")
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session that doesn't implement SessionWithResources
 	session := &sessionTestClientWithTools{
@@ -719,7 +719,7 @@ func TestNotificationErrorHandling(t *testing.T) {
 		},
 	}
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session with a blocking notification channel
 	blockingChan := make(chan mcp.JSONRPCNotification) // No buffer, will block

--- a/server/session_resource_templates_test.go
+++ b/server/session_resource_templates_test.go
@@ -205,7 +205,7 @@ func TestMCPServer_ResourceTemplatesWithSessionResourceTemplates(t *testing.T) {
 
 func TestMCPServer_AddSessionResourceTemplates(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
 	session := &sessionTestClientWithResourceTemplates{
@@ -235,7 +235,7 @@ func TestMCPServer_AddSessionResourceTemplates(t *testing.T) {
 
 func TestMCPServer_AddSessionResourceTemplate(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
 	session := &sessionTestClientWithResourceTemplates{
@@ -283,7 +283,7 @@ func TestMCPServer_AddSessionResourceTemplatesUninitialized(t *testing.T) {
 		WithResourceCapabilities(false, true),
 		WithHooks(hooks),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sessionChan := make(chan mcp.JSONRPCNotification, 1)
 	session := &sessionTestClientWithResourceTemplates{
@@ -352,7 +352,7 @@ func TestMCPServer_DeleteSessionResourceTemplatesUninitialized(t *testing.T) {
 		WithResourceCapabilities(false, true),
 		WithHooks(hooks),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sessionChan := make(chan mcp.JSONRPCNotification, 1)
 	session := &sessionTestClientWithResourceTemplates{
@@ -469,7 +469,7 @@ func TestMCPServer_CallSessionResourceTemplate(t *testing.T) {
 
 func TestMCPServer_DeleteSessionResourceTemplates(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
 	session := &sessionTestClientWithResourceTemplates{
@@ -506,7 +506,7 @@ func TestMCPServer_DeleteSessionResourceTemplates(t *testing.T) {
 
 func TestMCPServer_SessionResourceTemplateError(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0")
-	ctx := context.Background()
+	ctx := t.Context()
 
 	session := &sessionTestClient{
 		sessionID:           "session-1",
@@ -525,7 +525,7 @@ func TestMCPServer_SessionResourceTemplateError(t *testing.T) {
 
 func TestMCPServer_ResourceTemplatesNotificationsDisabled(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithResourceCapabilities(false, false))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	sessionChan := make(chan mcp.JSONRPCNotification, 1)
 	session := &sessionTestClientWithResourceTemplates{

--- a/server/session_resource_templates_test.go
+++ b/server/session_resource_templates_test.go
@@ -75,13 +75,13 @@ func TestSessionWithResourceTemplates_Integration(t *testing.T) {
 	}
 	session.initialized.Store(true)
 
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	testReq := mcp.ReadResourceRequest{}
 	testReq.Params.URI = "test://session/123"
 
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 
 	s := ClientSessionFromContext(sessionCtx)
 	require.NotNil(t, s, "Session should be available from context")
@@ -151,10 +151,10 @@ func TestMCPServer_ResourceTemplatesWithSessionResourceTemplates(t *testing.T) {
 	}
 	session.initialized.Store(true)
 
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	resp := server.HandleMessage(sessionCtx, []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
@@ -426,7 +426,7 @@ func TestMCPServer_CallSessionResourceTemplate(t *testing.T) {
 		notificationChannel: sessionChan,
 	}
 
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	err = server.AddSessionResourceTemplate(
@@ -441,7 +441,7 @@ func TestMCPServer_CallSessionResourceTemplate(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	resourceRequest := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -539,7 +539,7 @@ func TestMCPServer_ResourcesWithSessionResources(t *testing.T) {
 
 func TestMCPServer_AddSessionTools(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithToolCapabilities(true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -574,7 +574,7 @@ func TestMCPServer_AddSessionTools(t *testing.T) {
 
 func TestMCPServer_AddSessionTool(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithToolCapabilities(true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -634,7 +634,7 @@ func TestMCPServer_AddSessionToolsUninitialized(t *testing.T) {
 		WithToolCapabilities(true),
 		WithHooks(hooks),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create an uninitialized session
 	sessionChan := make(chan mcp.JSONRPCNotification, 1)
@@ -727,7 +727,7 @@ func TestMCPServer_DeleteSessionToolsUninitialized(t *testing.T) {
 		WithToolCapabilities(true),
 		WithHooks(hooks),
 	)
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create an uninitialized session with some tools
 	sessionChan := make(chan mcp.JSONRPCNotification, 1)
@@ -856,7 +856,7 @@ func TestMCPServer_CallSessionTool(t *testing.T) {
 
 func TestMCPServer_DeleteSessionTools(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithToolCapabilities(true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session with tools
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -1188,7 +1188,7 @@ func TestMCPServer_ToolNotificationsDisabled(t *testing.T) {
 
 	// Create a server WITHOUT tool capabilities
 	server := NewMCPServer("test-server", "1.0.0", WithToolCapabilities(false))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create an initialized session
 	sessionChan := make(chan mcp.JSONRPCNotification, 1)
@@ -1378,7 +1378,7 @@ func TestSessionWithClientInfo_Integration(t *testing.T) {
 // New test function to cover log notification functionality
 func TestMCPServer_SendLogMessageToClient(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithLogging())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session that supports logging
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)
@@ -1471,7 +1471,7 @@ func TestMCPServer_SendLogMessageToClient(t *testing.T) {
 
 func TestMCPServer_SendLogMessageToSpecificClient(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithLogging())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create two sessions
 	session1Chan := make(chan mcp.JSONRPCNotification, 10)
@@ -1593,7 +1593,7 @@ func TestMCPServer_SendLogMessageToSpecificClient(t *testing.T) {
 
 func TestMCPServer_LoggingWithUnsupportedSessions(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithLogging())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create three types of sessions:
 	// 1. Logging-supported session
@@ -1680,7 +1680,7 @@ func TestMCPServer_LoggingWithUnsupportedSessions(t *testing.T) {
 
 func TestMCPServer_LoggingNotificationFormat(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithLogging())
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a session
 	sessionChan := make(chan mcp.JSONRPCNotification, 10)

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -268,7 +268,7 @@ func TestSessionWithTools_Integration(t *testing.T) {
 	}
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// Test that we can access the session-specific tool
@@ -277,7 +277,7 @@ func TestSessionWithTools_Integration(t *testing.T) {
 	testReq.Params.Arguments = map[string]any{}
 
 	// Call using session context
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 
 	// Check if the session was stored in the context correctly
 	s := ClientSessionFromContext(sessionCtx)
@@ -337,7 +337,7 @@ func TestSessionWithResources_Integration(t *testing.T) {
 	}
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// Test that we can access the session-specific resource
@@ -346,7 +346,7 @@ func TestSessionWithResources_Integration(t *testing.T) {
 	testReq.Params.Arguments = map[string]any{}
 
 	// Call using session context
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 
 	// Check if the session was stored in the context correctly
 	s := ClientSessionFromContext(sessionCtx)
@@ -403,11 +403,11 @@ func TestMCPServer_ToolsWithSessionTools(t *testing.T) {
 	}
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// List tools with session context
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	resp := server.HandleMessage(sessionCtx, []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
@@ -479,11 +479,11 @@ func TestMCPServer_ResourcesWithSessionResources(t *testing.T) {
 	}
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// List resources with session context via HandleMessage
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	resp := server.HandleMessage(sessionCtx, []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
@@ -810,7 +810,7 @@ func TestMCPServer_CallSessionTool(t *testing.T) {
 	}
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// Add session-specific tool with the same name to override the global tool
@@ -824,7 +824,7 @@ func TestMCPServer_CallSessionTool(t *testing.T) {
 	require.NoError(t, err)
 
 	// Call the tool using session context
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	toolRequest := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -940,11 +940,11 @@ func TestMCPServer_ToolFiltering(t *testing.T) {
 	}
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// List tools with session context
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	response := server.HandleMessage(sessionCtx, []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
@@ -990,11 +990,11 @@ func TestMCPServer_SendNotificationToSpecificClient(t *testing.T) {
 	}
 
 	// Register sessions
-	err := server.RegisterSession(context.Background(), session1)
+	err := server.RegisterSession(t.Context(), session1)
 	require.NoError(t, err)
-	err = server.RegisterSession(context.Background(), session2)
+	err = server.RegisterSession(t.Context(), session2)
 	require.NoError(t, err)
-	err = server.RegisterSession(context.Background(), session3)
+	err = server.RegisterSession(t.Context(), session3)
 	require.NoError(t, err)
 
 	// Send notification to session 1
@@ -1069,7 +1069,7 @@ func TestMCPServer_NotificationChannelBlocked(t *testing.T) {
 	session.Initialize()
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// Fill the buffer first to ensure it gets blocked
@@ -1165,7 +1165,7 @@ func TestMCPServer_SessionToolCapabilitiesBehavior(t *testing.T) {
 				notificationChannel: make(chan mcp.JSONRPCNotification, 10),
 				initialized:         true,
 			}
-			err := server.RegisterSession(context.Background(), session)
+			err := server.RegisterSession(t.Context(), session)
 			require.NoError(t, err)
 
 			// Add a session tool and verify listChanged remains false
@@ -1249,11 +1249,11 @@ func TestMCPServer_SetLevelNotEnabled(t *testing.T) {
 	session.Initialize()
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// Try to set logging level when capability is disabled
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	setRequest := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -1291,11 +1291,11 @@ func TestMCPServer_SetLevel(t *testing.T) {
 	}
 
 	// Register the session
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	// Set Logging level to critical
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 	setRequest := map[string]any{
 		"jsonrpc": "2.0",
 		"id":      1,
@@ -1331,7 +1331,7 @@ func TestSessionWithClientInfo_Integration(t *testing.T) {
 		initialized:         false,
 	}
 
-	err := server.RegisterSession(context.Background(), session)
+	err := server.RegisterSession(t.Context(), session)
 	require.NoError(t, err)
 
 	clientInfo := mcp.Implementation{
@@ -1348,7 +1348,7 @@ func TestSessionWithClientInfo_Integration(t *testing.T) {
 	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	initRequest.Params.Capabilities = clientCapability
 
-	sessionCtx := server.WithContext(context.Background(), session)
+	sessionCtx := server.WithContext(t.Context(), session)
 
 	// Retrieve the session from context
 	retrievedSession := ClientSessionFromContext(sessionCtx)

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -1427,7 +1427,7 @@ func TestSSEServer(t *testing.T) {
 		time.Sleep(50 * time.Millisecond)
 
 		shutdownDone := make(chan error, 1)
-		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 300*time.Millisecond)
 		defer cancel()
 		go func() {
 			err := sseServer.Shutdown(ctx)

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -259,7 +259,7 @@ func TestSSEServer(t *testing.T) {
 		}
 
 		// Test SSE endpoint with proper cleanup
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/sse", ts.URL), nil)
@@ -308,7 +308,7 @@ func TestSSEServer(t *testing.T) {
 		ts := httptest.NewServer(middleware(sseServer))
 		defer ts.Close()
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/sse", ts.URL), nil)
@@ -355,7 +355,7 @@ func TestSSEServer(t *testing.T) {
 
 		sseServer.baseURL = ts.URL + "/mcp"
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/mcp/sse", ts.URL), nil)
@@ -427,7 +427,7 @@ func TestSSEServer(t *testing.T) {
 
 		sseServer.baseURL = ts.URL + "/mcp"
 		sseServer.useFullURLForMessageEndpoint = false
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, "GET", fmt.Sprintf("%s/sse", sseServer.baseURL), nil)
@@ -516,7 +516,7 @@ func TestSSEServer(t *testing.T) {
 		}
 
 		// Test SSE endpoint with proper cleanup
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		sseURL := fmt.Sprintf("%s/sse", ts.URL+sseServer.basePath)
@@ -1383,7 +1383,7 @@ func TestSSEServer(t *testing.T) {
 		requestBody, err := json.Marshal(messageRequest)
 		require.NoError(t, err, "Failed to marshal request")
 
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		req, err := http.NewRequestWithContext(ctx, "POST", messageURL, bytes.NewBuffer(requestBody))
 		require.NoError(t, err, "Failed to create request")
 		req.Header.Set("Content-Type", "application/json")

--- a/server/stdio_test.go
+++ b/server/stdio_test.go
@@ -41,7 +41,7 @@ func TestStdioServer(t *testing.T) {
 		stdioServer.SetErrorLogger(log.New(io.Discard, "", 0))
 
 		// Create context with cancel
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		// Create error channel to catch server errors
@@ -153,7 +153,7 @@ func TestStdioServer(t *testing.T) {
 		stdioServer.SetContextFunc(setTestValFromEnv)
 
 		// Create context with cancel
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		// Create error channel to catch server errors
@@ -306,7 +306,7 @@ func TestStdioServer(t *testing.T) {
 		stdioServer.SetErrorLogger(log.New(io.Discard, "", 0))
 
 		// Create context with cancel
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 
 		// Start server

--- a/server/streamable_http_sampling_test.go
+++ b/server/streamable_http_sampling_test.go
@@ -190,7 +190,7 @@ func TestStreamableHTTPServer_SamplingQueueFull(t *testing.T) {
 	}
 
 	// Try to add another request (should fail)
-	ctx := context.Background()
+	ctx := t.Context()
 	request := mcp.CreateMessageRequest{
 		CreateMessageParams: mcp.CreateMessageParams{
 			Messages: []mcp.SamplingMessage{

--- a/server/streamable_http_sampling_test.go
+++ b/server/streamable_http_sampling_test.go
@@ -148,7 +148,7 @@ func TestStreamableHTTPServer_SamplingInterface(t *testing.T) {
 	}
 
 	// Test RequestSampling with timeout
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer cancel()
 
 	request := mcp.CreateMessageRequest{

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2197,8 +2197,7 @@ func TestStreamableHTTP_SendNotificationToSpecificClient(t *testing.T) {
 		var toolResponse jsonRPCResponse
 		if strings.HasPrefix(bodyStr, "event: message") {
 			// Parse SSE format
-			lines := strings.Split(bodyStr, "\n")
-			for _, line := range lines {
+			for line := range strings.SplitSeq(bodyStr, "\n") {
 				if jsonData, ok := strings.CutPrefix(line, "data: "); ok {
 					if err := json.Unmarshal([]byte(jsonData), &toolResponse); err == nil {
 						break

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -505,7 +505,7 @@ func TestStreamableHTTP_GET(t *testing.T) {
 	addSSETool(mcpServer)
 	server := NewTestStreamableHTTPServer(mcpServer)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 1*time.Second)
 	defer cancel()
 	req, err := http.NewRequestWithContext(ctx, "GET", server.URL, nil)
 	if err != nil {
@@ -747,7 +747,7 @@ func TestStreamableHTTP_SessionWithTools(t *testing.T) {
 
 		// Watch the notification to ensure the session is registered
 		// (Normal http request (post) will not trigger the session registration)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 		go func() {
 			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, testServer.URL, nil)
@@ -876,7 +876,7 @@ func TestStreamableHTTP_SessionWithResources(t *testing.T) {
 
 		// Watch the notification to ensure the session is registered
 		// (Normal http request (post) will not trigger the session registration)
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 		defer cancel()
 		go func() {
 			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, testServer.URL, nil)
@@ -1333,7 +1333,7 @@ func TestStreamableHTTPServer_WithDisableStreaming(t *testing.T) {
 		server := NewTestStreamableHTTPServer(mcpServer, WithDisableStreaming(false))
 		defer server.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		defer cancel()
 
 		// GET request should work when streaming is enabled
@@ -2385,7 +2385,7 @@ func TestStreamableHTTP_GET_NonFlusherReturns405(t *testing.T) {
 		server := NewTestStreamableHTTPServer(mcpServer)
 		defer server.Close()
 
-		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
 		defer cancel()
 
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, server.URL, nil)
@@ -2619,7 +2619,7 @@ func TestStreamableHTTP_SessionIdleTTLSweeper(t *testing.T) {
 			WithStateful(true),
 			WithSessionIdleTTL(100*time.Millisecond),
 		)
-		defer func() { _ = httpServer.Shutdown(context.Background()) }()
+		defer func() { _ = httpServer.Shutdown(t.Context()) }()
 		ts := httptest.NewServer(httpServer)
 		defer ts.Close()
 
@@ -2657,7 +2657,7 @@ func TestStreamableHTTP_SessionIdleTTLSweeper(t *testing.T) {
 			WithStateful(true),
 			WithSessionIdleTTL(200*time.Millisecond),
 		)
-		defer func() { _ = httpServer.Shutdown(context.Background()) }()
+		defer func() { _ = httpServer.Shutdown(t.Context()) }()
 		ts := httptest.NewServer(httpServer)
 		defer ts.Close()
 
@@ -2696,7 +2696,7 @@ func TestStreamableHTTP_SessionIdleTTLSweeper(t *testing.T) {
 			WithStateful(true),
 			// No WithSessionIdleTTL — sweeper disabled
 		)
-		defer func() { _ = httpServer.Shutdown(context.Background()) }()
+		defer func() { _ = httpServer.Shutdown(t.Context()) }()
 		ts := httptest.NewServer(httpServer)
 		defer ts.Close()
 
@@ -2724,7 +2724,7 @@ func TestStreamableHTTP_SessionIdleTTLSweeper(t *testing.T) {
 			WithStateful(true),
 			WithSessionIdleTTL(10*time.Second), // long TTL so sweeper won't fire
 		)
-		defer func() { _ = httpServer.Shutdown(context.Background()) }()
+		defer func() { _ = httpServer.Shutdown(t.Context()) }()
 		ts := httptest.NewServer(httpServer)
 		defer ts.Close()
 

--- a/server/task_hooks_test.go
+++ b/server/task_hooks_test.go
@@ -28,7 +28,7 @@ func TestTaskHooks_TaskCreated(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithTaskHooks(hooks))
 
 	// Create a task
-	ctx := context.Background()
+	ctx := t.Context()
 	_, err := server.createTask(ctx, "test-task-1", "test-tool", nil, nil)
 	require.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestTaskHooks_TaskCompleted(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithTaskHooks(hooks))
 
 	// Create and complete a task
-	ctx := context.Background()
+	ctx := t.Context()
 	entry, err := server.createTask(ctx, "test-task-2", "test-tool", nil, nil)
 	require.NoError(t, err)
 
@@ -107,7 +107,7 @@ func TestTaskHooks_TaskFailed(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithTaskHooks(hooks))
 
 	// Create and fail a task
-	ctx := context.Background()
+	ctx := t.Context()
 	entry, err := server.createTask(ctx, "test-task-3", "test-tool", nil, nil)
 	require.NoError(t, err)
 
@@ -151,7 +151,7 @@ func TestTaskHooks_TaskCancelled(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithTaskHooks(hooks))
 
 	// Create a task
-	ctx := context.Background()
+	ctx := t.Context()
 	entry, err := server.createTask(ctx, "test-task-4", "test-tool", nil, nil)
 	require.NoError(t, err)
 
@@ -201,7 +201,7 @@ func TestTaskHooks_TaskStatusChanged(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithTaskHooks(hooks))
 
 	// Create a task (status change 1: working)
-	ctx := context.Background()
+	ctx := t.Context()
 	entry, err := server.createTask(ctx, "test-task-5", "test-tool", nil, nil)
 	require.NoError(t, err)
 
@@ -255,7 +255,7 @@ func TestTaskHooks_MultipleHooks(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0", WithTaskHooks(hooks))
 
 	// Create and complete a task
-	ctx := context.Background()
+	ctx := t.Context()
 	entry, err := server.createTask(ctx, "test-task-6", "test-tool", nil, nil)
 	require.NoError(t, err)
 	server.completeTask(entry, "result", nil)
@@ -285,7 +285,7 @@ func TestTaskHooks_NilHooks(t *testing.T) {
 	// Test that nil hooks don't cause panics
 	server := NewMCPServer("test-server", "1.0.0")
 
-	ctx := context.Background()
+	ctx := t.Context()
 	entry, err := server.createTask(ctx, "test-task-7", "test-tool", nil, nil)
 	require.NoError(t, err)
 
@@ -333,7 +333,7 @@ func TestTaskHooks_IntegrationWithTaskTool(t *testing.T) {
 	server.AddTaskTool(tool, handler)
 
 	// Call the tool
-	ctx := context.Background()
+	ctx := t.Context()
 	request := mcp.CallToolRequest{
 		Params: mcp.CallToolParams{
 			Name: "async-tool",

--- a/server/task_limit_test.go
+++ b/server/task_limit_test.go
@@ -18,7 +18,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 			WithMaxConcurrentTasks(3),
 		)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create 3 tasks (at the limit)
 		_, err := server.createTask(ctx, "task-1", "test-tool", nil, nil)
@@ -42,7 +42,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 			WithMaxConcurrentTasks(2),
 		)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create 2 tasks (at the limit)
 		_, err := server.createTask(ctx, "task-1", "test-tool", nil, nil)
@@ -69,7 +69,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 			WithMaxConcurrentTasks(2),
 		)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create 2 tasks (at the limit)
 		entry1, err := server.createTask(ctx, "task-1", "test-tool", nil, nil)
@@ -112,7 +112,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 			WithMaxConcurrentTasks(2),
 		)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create 2 tasks (at the limit)
 		entry1, err := server.createTask(ctx, "task-1", "test-tool", nil, nil)
@@ -144,7 +144,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 		server := NewMCPServer("test-server", "1.0.0",
 			WithTaskCapabilities(true, true, true),
 		)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create many tasks without limit
 		for i := range 100 {
@@ -163,7 +163,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 			WithMaxConcurrentTasks(0),
 		)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create many tasks without limit
 		for i := range 50 {
@@ -182,7 +182,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 			WithMaxConcurrentTasks(10),
 		)
-		ctx := context.Background()
+		ctx := t.Context()
 
 		var wg sync.WaitGroup
 		successCount := 0
@@ -240,7 +240,7 @@ func TestMaxConcurrentTasks(t *testing.T) {
 		}
 		server.AddTaskTool(tool, handler)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create first task (should succeed)
 		request1 := mcp.CallToolRequest{

--- a/server/task_response_format_test.go
+++ b/server/task_response_format_test.go
@@ -27,7 +27,7 @@ func TestTaskAugmentedToolCall_ResponseFormat(t *testing.T) {
 	})
 
 	// Call with task param
-	response := server.HandleMessage(context.Background(), []byte(`{
+	response := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "tools/call",
@@ -68,7 +68,7 @@ func TestTaskAugmentedToolCall_SpecCompliance(t *testing.T) {
 	})
 
 	// Call with task param
-	response := server.HandleMessage(context.Background(), []byte(`{
+	response := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "tools/call",

--- a/server/task_test.go
+++ b/server/task_test.go
@@ -52,7 +52,7 @@ func TestMCPServer_TaskCapabilities(t *testing.T) {
 			server := NewMCPServer("test-server", "1.0.0", tt.serverOptions...)
 
 			// Initialize to get capabilities
-			response := server.HandleMessage(context.Background(), []byte(`{
+			response := server.HandleMessage(t.Context(), []byte(`{
 				"jsonrpc": "2.0",
 				"id": 1,
 				"method": "initialize",
@@ -181,7 +181,7 @@ func TestMCPServer_HandleGetTaskNotFound(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	response := server.HandleMessage(context.Background(), []byte(`{
+	response := server.HandleMessage(t.Context(), []byte(`{
 		"jsonrpc": "2.0",
 		"id": 1,
 		"method": "tasks/get",

--- a/server/task_test.go
+++ b/server/task_test.go
@@ -341,7 +341,7 @@ func TestMCPServer_TaskWithoutCapabilities(t *testing.T) {
 				"method": "` + tt.method + `"` + paramsStr + `
 			}`
 
-			response := server.HandleMessage(context.Background(), []byte(requestJSON))
+			response := server.HandleMessage(t.Context(), []byte(requestJSON))
 
 			errResp, ok := response.(mcp.JSONRPCError)
 			require.True(t, ok, "Expected JSONRPCError, got %T", response)

--- a/server/task_test.go
+++ b/server/task_test.go
@@ -103,7 +103,7 @@ func TestMCPServer_TaskLifecycle(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a task
 	ttl := int64(60000)
@@ -146,7 +146,7 @@ func TestMCPServer_HandleGetTask(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a task
 	ttl := int64(60000)
@@ -202,7 +202,7 @@ func TestMCPServer_HandleListTasks(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create multiple tasks
 	ttl := int64(60000)
@@ -241,7 +241,7 @@ func TestMCPServer_HandleCancelTask(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a task
 	ttl := int64(60000)
@@ -279,7 +279,7 @@ func TestMCPServer_HandleCancelTerminalTask(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create and complete a task
 	ttl := int64(60000)
@@ -357,7 +357,7 @@ func TestMCPServer_TaskTTLCleanup(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a task with very short TTL
 	ttl := int64(100) // 100ms
@@ -390,7 +390,7 @@ func TestMCPServer_TaskExpiredVsNotFoundErrors(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("expired task returns 'task has expired' error", func(t *testing.T) {
 		ttl := int64(50) // 50ms
@@ -459,7 +459,7 @@ func TestMCPServer_TaskResultWaitForCompletion(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a task
 	ttl := int64(60000)
@@ -516,7 +516,7 @@ func TestMCPServer_CompleteTaskWithError(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create a task
 	ttl := int64(60000)
@@ -625,7 +625,7 @@ func TestMCPServer_TaskListPagination(t *testing.T) {
 		WithPaginationLimit(2), // Limit to 2 tasks per page
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Create multiple tasks with predictable IDs
 	ttl := int64(60000)
@@ -785,7 +785,7 @@ func TestMCPServer_TaskLastUpdatedAt(t *testing.T) {
 		WithTaskCapabilities(true, true, true),
 	)
 
-	ctx := context.Background()
+	ctx := t.Context()
 
 	t.Run("task creation sets initial lastUpdatedAt", func(t *testing.T) {
 		ttl := int64(60000)
@@ -921,7 +921,7 @@ func TestMCPServer_TaskStatusNotifications(t *testing.T) {
 	)
 
 	// Create a session to receive notifications
-	ctx := context.Background()
+	ctx := t.Context()
 	notifyChan := make(chan mcp.JSONRPCNotification, 10)
 	session := fakeSess{
 		sessionID:  "test-session",
@@ -1178,7 +1178,7 @@ func TestMCPServer_TaskStatusNotifications(t *testing.T) {
 func TestMCPServer_ExecuteTaskTool(t *testing.T) {
 	t.Run("successful task execution stores result", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create a task tool that returns a successful result
 		taskTool := ServerTaskTool{
@@ -1225,7 +1225,7 @@ func TestMCPServer_ExecuteTaskTool(t *testing.T) {
 
 	t.Run("failed task execution stores error", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		expectedErr := fmt.Errorf("task execution failed")
 
@@ -1273,7 +1273,7 @@ func TestMCPServer_ExecuteTaskTool(t *testing.T) {
 
 	t.Run("task can be cancelled via context", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Channel to synchronize the test
 		started := make(chan struct{})
@@ -1344,7 +1344,7 @@ func TestMCPServer_ExecuteTaskTool(t *testing.T) {
 
 	t.Run("cancel function is stored before handler execution", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Channel to check when handler starts
 		handlerStarted := make(chan struct{})
@@ -1392,7 +1392,7 @@ func TestMCPServer_ExecuteTaskTool(t *testing.T) {
 
 	t.Run("sends task status notification on completion", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Register a test session to receive notifications
 		notifyChan := make(chan mcp.JSONRPCNotification, 10)
@@ -1452,7 +1452,7 @@ func TestMCPServer_ExecuteTaskTool(t *testing.T) {
 
 	t.Run("multiple tasks can execute concurrently", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create multiple task tools
 		numTasks := 5
@@ -1514,7 +1514,7 @@ func TestMCPServer_ExecuteTaskTool(t *testing.T) {
 func TestMCPServer_HandleTaskResult(t *testing.T) {
 	t.Run("returns tool result with related task metadata", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create a task and complete it with a CallToolResult
 		taskID := "test-task-result"
@@ -1568,7 +1568,7 @@ func TestMCPServer_HandleTaskResult(t *testing.T) {
 
 	t.Run("returns error when task failed", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create a task and complete it with an error
 		taskID := "test-task-error"
@@ -1594,7 +1594,7 @@ func TestMCPServer_HandleTaskResult(t *testing.T) {
 
 	t.Run("waits for task completion before returning result", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create a task but don't complete it yet
 		taskID := "test-task-wait"
@@ -1631,7 +1631,7 @@ func TestMCPServer_HandleTaskResult(t *testing.T) {
 
 	t.Run("merges original result meta with related task meta", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Create a task and complete it with a result that has meta
 		taskID := "test-task-meta-merge"
@@ -1681,7 +1681,7 @@ func TestMCPServer_HandleTaskResult(t *testing.T) {
 
 	t.Run("returns error for non-existent task", func(t *testing.T) {
 		server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Call handleTaskResult with non-existent task ID
 		request := mcp.TaskResultRequest{
@@ -1700,7 +1700,7 @@ func TestMCPServer_HandleTaskResult(t *testing.T) {
 // TestTaskResultEndToEnd tests the complete flow of task-augmented tool call and result retrieval
 func TestTaskResultEndToEnd(t *testing.T) {
 	server := NewMCPServer("test", "1.0.0", WithTaskCapabilities(true, true, true))
-	ctx := context.Background()
+	ctx := t.Context()
 
 	// Register a tool with TaskSupportRequired
 	tool := mcp.NewTool("long_operation",

--- a/server/task_tool_test.go
+++ b/server/task_tool_test.go
@@ -36,7 +36,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 		)
 
 		// Register a test session to receive notifications
-		ctx := context.Background()
+		ctx := t.Context()
 		notifyChan := make(chan mcp.JSONRPCNotification, 10)
 		session := fakeSess{
 			sessionID:  "test-session-tracer",
@@ -234,7 +234,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Step 2: Register a task-optional tool
 		optionalTool := mcp.NewTool("flexible_operation",
@@ -292,7 +292,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Step 2: Register a task-optional tool
 		optionalTool := mcp.NewTool("flexible_operation",
@@ -371,7 +371,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Step 2: Register a long-running task tool
 		started := make(chan struct{})
@@ -432,7 +432,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Step 2: Register a tool that returns an error
 		expectedErr := fmt.Errorf("processing failed: invalid input")
@@ -568,7 +568,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 			WithTaskCapabilities(true, true, true),
 		)
 
-		ctx := context.Background()
+		ctx := t.Context()
 
 		// Step 2: Register a task tool
 		concurrentTool := mcp.NewTool("concurrent_operation",

--- a/server/task_tool_test.go
+++ b/server/task_tool_test.go
@@ -504,7 +504,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 		)
 
 		// Step 2: Create a parent context that we'll cancel
-		parentCtx, cancelParent := context.WithCancel(context.Background())
+		parentCtx, cancelParent := context.WithCancel(t.Context())
 		defer cancelParent()
 
 		// Step 3: Register a task tool that respects context cancellation
@@ -546,7 +546,7 @@ func TestTaskToolTracerBullet(t *testing.T) {
 		// Step 6: Wait for task to complete
 		var finalTask mcp.Task
 		for range 20 {
-			task, _, err := server.getTask(context.Background(), taskID)
+			task, _, err := server.getTask(t.Context(), taskID)
 			require.NoError(t, err)
 			finalTask = task
 			if task.Status.IsTerminal() {

--- a/server/version_test.go
+++ b/server/version_test.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -76,7 +75,7 @@ func TestMCPServer_VersionNegotiation_Explicit(t *testing.T) {
 			messageBytes, err := json.Marshal(initReq)
 			assert.NoError(t, err)
 
-			response := server.HandleMessage(context.Background(), messageBytes)
+			response := server.HandleMessage(t.Context(), messageBytes)
 			assert.NotNil(t, response)
 
 			resp, ok := response.(mcp.JSONRPCResponse)


### PR DESCRIPTION
## Description

Upgrades the Go version from 1.23.0 to 1.25.5 and addresses all usetesting linter errors by replacing context.Background() with t.Context() in test functions.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [x] Other (please describe): version upgrade

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped Go language version requirement.
* **Tests**
  * Updated tests to use test-scoped contexts and improved goroutine wait patterns for more reliable lifecycle, cancellation and timeout behavior.
* **Bug Fixes**
  * Adjusted JSON serialization tags so select fields are omitted when zero-valued, improving consistency of produced payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->