### PR TITLE
server: return 202 for empty ping responses

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -344,10 +344,16 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	}
 
 	// detect empty ping response, skip session ID validation
-	isPingResponse := jsonMessage.Method == "" && jsonMessage.ID != nil &&
+	isEmptyResponse := jsonMessage.Method == "" && jsonMessage.ID != nil &&
 		(isJSONEmpty(jsonMessage.Result) && isJSONEmpty(jsonMessage.Error))
+	isPingResponse := jsonMessage.Method == "" && jsonMessage.ID != nil &&
+		isExplicitEmptyObject(jsonMessage.Result) && len(bytes.TrimSpace(jsonMessage.Error)) == 0
 
 	if isPingResponse {
+		w.WriteHeader(http.StatusAccepted)
+		return
+	}
+	if isEmptyResponse {
 		return
 	}
 
@@ -1579,4 +1585,23 @@ func isJSONEmpty(data json.RawMessage) bool {
 			trimmed[3] == 'l'
 	}
 	return false
+}
+
+// isExplicitEmptyObject reports whether data is a JSON object literal with no fields.
+func isExplicitEmptyObject(data json.RawMessage) bool {
+	if len(data) == 0 {
+		return false
+	}
+
+	trimmed := bytes.TrimSpace(data)
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return false
+	}
+
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(trimmed, &obj); err != nil {
+		return false
+	}
+
+	return len(obj) == 0
 }

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -1157,7 +1157,7 @@ func TestStreamableHTTP_PongResponseHandling(t *testing.T) {
 	server := NewTestStreamableHTTPServer(mcpServer)
 	defer server.Close()
 
-	t.Run("Pong response with empty result should not be treated as sampling response", func(t *testing.T) {
+	t.Run("Pong response with empty result should return 202 and not be treated as sampling response", func(t *testing.T) {
 		// According to MCP spec, pong responses have empty result: {"jsonrpc": "2.0", "id": "123", "result": {}}
 		pongResponse := map[string]any{
 			"jsonrpc": "2.0",
@@ -1184,8 +1184,8 @@ func TestStreamableHTTP_PongResponseHandling(t *testing.T) {
 			t.Errorf("Pong response was incorrectly detected as sampling response. Response: %s", bodyStr)
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Expected status 200 for pong response, got %d. Body: %s", resp.StatusCode, bodyStr)
+		if resp.StatusCode != http.StatusAccepted {
+			t.Errorf("Expected status 202 for pong response, got %d. Body: %s", resp.StatusCode, bodyStr)
 		}
 	})
 


### PR DESCRIPTION
## Description

Fixes #740

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x ] My code follows the code style of this project

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

- [n/a] I have updated the documentation accordingly

## MCP Spec Compliance

<!-- If this PR implements a feature from the MCP specification, please answer the following -->

<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http)
- [x] Implementation follows the specification exactly

## Additional Information

- The PR fixes the Streamable HTTP rule for POST bodies that contain only JSON-RPC responses.
- The spec says in that case the server `MUST return HTTP status code 202 Accepted with no body`.
- That is what the patch now does for the empty ping-response path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ping-style requests with an explicit empty JSON result now return HTTP 202 Accepted with an empty body, clarifying ping handling and avoiding being treated as regular sampling responses.
* **Tests**
  * Updated tests to expect HTTP 202 for ping responses with empty results, ensuring behavior is validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->