### PR TITLE
fix: account for upgradedHeader in handlePost response path

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -510,7 +510,10 @@ drainLoop:
 		return
 	}
 	// If client-server communication already upgraded to SSE stream
-	if session.upgradeToSSE.Load() {
+	// Also check upgradedHeader: a notification during HandleMessage processing
+	// may have already written SSE headers on this response, so we must continue
+	// in SSE mode to avoid writing JSON on top of SSE data.
+	if session.upgradeToSSE.Load() || upgradedHeader {
 		if !upgradedHeader {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Connection", "keep-alive")

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2613,6 +2613,93 @@ func TestStreamableHTTP_DrainNotifications(t *testing.T) {
 	})
 }
 
+// TestStreamableHTTP_NotificationUpgradeDoesNotCorruptResponse verifies that when
+// a notification is sent during HandleMessage (triggering an SSE upgrade on the
+// response), the final response is written as SSE — not as JSON on top of SSE
+// headers, which would corrupt the response.
+//
+// This is a regression test for https://github.com/mark3labs/mcp-go/issues/742
+func TestStreamableHTTP_NotificationUpgradeDoesNotCorruptResponse(t *testing.T) {
+	// Run multiple iterations to increase the chance of hitting the race window.
+	// The bug is timing-dependent: a notification must be processed by the
+	// goroutine before the main handler writes the response.
+	for i := range 20 {
+		t.Run(fmt.Sprintf("iteration_%d", i), func(t *testing.T) {
+			t.Parallel()
+
+			mcpServer := NewMCPServer("test-mcp-server", "1.0",
+				WithToolCapabilities(true),
+			)
+
+			// Add a tool that sends a notification during execution.
+			// This notification goes through session.notificationChannel,
+			// where the goroutine in handlePost picks it up and writes SSE
+			// headers before the main handler gets to write the response.
+			mcpServer.AddTool(mcp.NewTool("notifying_tool"), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				server := ServerFromContext(ctx)
+				_ = server.SendNotificationToClient(ctx, "test/raceNotification", map[string]any{
+					"info": "this triggers the SSE upgrade",
+				})
+				return mcp.NewToolResultText("tool result ok"), nil
+			})
+
+			server := NewTestStreamableHTTPServer(mcpServer)
+			defer server.Close()
+
+			// Initialize session
+			resp, err := postJSON(server.URL, initRequest)
+			require.NoError(t, err)
+			resp.Body.Close()
+			sessionID := resp.Header.Get(HeaderKeySessionID)
+			require.NotEmpty(t, sessionID)
+
+			// Call the tool — this is where the race can happen
+			callReq := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/call",
+				"params":  map[string]any{"name": "notifying_tool"},
+			}
+			resp, err = postSessionJSON(server.URL, sessionID, callReq)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, err)
+			bodyStr := string(body)
+
+			assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+			contentType := resp.Header.Get("Content-Type")
+
+			// The tool sends a notification synchronously before returning,
+			// so by the time HandleMessage completes the notification is on the
+			// channel. Either the goroutine or the drain loop will process it,
+			// setting upgradedHeader = true. The response MUST be SSE.
+			require.True(t, strings.HasPrefix(contentType, "text/event-stream"),
+				"notification path must upgrade this response to SSE, got %q", contentType)
+			require.Contains(t, bodyStr, "event: message")
+			require.Contains(t, bodyStr, "tool result ok")
+
+			// Every non-empty line must be valid SSE syntax — no raw JSON
+			// objects appended (which would indicate the corruption this test guards against).
+			for _, line := range strings.Split(strings.TrimSpace(bodyStr), "\n") {
+				if line == "" {
+					continue
+				}
+				require.True(t,
+					strings.HasPrefix(line, "event:") ||
+						strings.HasPrefix(line, "data:") ||
+						strings.HasPrefix(line, "id:") ||
+						strings.HasPrefix(line, "retry:") ||
+						strings.HasPrefix(line, ":"),
+					"unexpected non-SSE line %q", line,
+				)
+			}
+		})
+	}
+}
+
 func TestStreamableHTTP_SessionIdleTTLSweeper(t *testing.T) {
 	t.Run("expired sessions are swept", func(t *testing.T) {
 		mcpServer := NewMCPServer("test", "1.0")


### PR DESCRIPTION
## Description

There's a race condition in `handlePost` where the notification goroutine (or the drain loop from #670) can upgrade the HTTP response to SSE by writing `text/event-stream` headers and setting the local `upgradedHeader = true`. However, when the main handler gets to the response-writing logic, it only checks `session.upgradeToSSE.Load()` to decide between SSE and JSON format — completely ignoring `upgradedHeader`.

So, basically, when `session.upgradeToSSE` is `false` (the common case for standard request-response flows), the main handler falls through to the JSON branch and tries to write `Content-Type: application/json` + `WriteHeader(200)` + JSON body on top of the already-written SSE response. This corrupts the HTTP response.

The two flags represent different things:

- `session.upgradeToSSE`: "the client wants SSE" (set externally)
- `upgradedHeader`: "this response has already been written as SSE" (set locally by notification handling)

The JSON branch should only execute when neither is true.

**The fix:** add `|| upgradedHeader` to the condition at the response-writing logic. The existing `if !upgradedHeader` guard inside the SSE branch already handles writing headers only when needed, so this is a one-line change.

In practice, this triggers with servers that inject per-session capabilities (tools, resources) during initialization, which sends `tools/list_changed` or similar notifications through `session.notificationChannel` while `HandleMessage` is still running.

Note that the drain loop added in #670 actually makes the race more likely since it's another code path that can set `upgradedHeader = true` without the JSON branch knowing — but the fundamental bug predates that change.

Fixes #742

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional Information

Added `TestStreamableHTTP_NotificationUpgradeDoesNotCorruptResponse` — 20 parallel iterations of a tool that sends a notification during `HandleMessage`, verifying the response is either valid SSE or valid JSON (never a corrupted mix). Tests pass with `-race` detector.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure responses remain correctly formatted when upgrading to Server-Sent Events (SSE) during concurrent notification handling, preventing mixed SSE/JSON output.
* **Tests**
  * Added regression tests covering SSE upgrade scenarios with concurrent notifications to guard against response corruption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->