### PR TITLE
docs(clients): replace stale NewSSEClient examples

### DIFF
--- a/www/docs/pages/clients/transports.mdx
+++ b/www/docs/pages/clients/transports.mdx
@@ -463,11 +463,15 @@ SSE (Server-Sent Events) clients provide real-time communication with servers.
 ```go
 func createSSEClient() {
     // Create SSE client
-    c := client.NewSSEClient("http://localhost:8080/mcp/sse")
+    c, err := client.NewSSEMCPClient("http://localhost:8080/mcp/sse",
+        transport.WithHeaders(map[string]string{
+            "Authorization": "Bearer your-token",
+        }),
+    )
+    if err != nil {
+        log.Fatal(err)
+    }
     defer c.Close()
-
-    // Set authentication
-    c.SetHeader("Authorization", "Bearer your-token")
 
     ctx := context.Background()
 
@@ -539,7 +543,7 @@ func createCustomSSEClient() {
 type ResilientSSEClient struct {
     baseURL     string
     headers     map[string]string
-    client      *client.SSEClient
+    client      *client.Client
     ctx         context.Context
     cancel      context.CancelFunc
     reconnectCh chan struct{}
@@ -575,11 +579,11 @@ func (rsc *ResilientSSEClient) connect() error {
         rsc.client.Close()
     }
 
-    client := client.NewSSEClient(rsc.baseURL)
-
-    // Set headers
-    for key, value := range rsc.headers {
-        client.SetHeader(key, value)
+    client, err := client.NewSSEMCPClient(rsc.baseURL,
+        transport.WithHeaders(rsc.headers),
+    )
+    if err != nil {
+        return err
     }
 
     if err := client.Initialize(rsc.ctx); err != nil {


### PR DESCRIPTION
## Summary

- replace outdated `NewSSEClient` docs examples with `NewSSEMCPClient`
- update examples to correctly handle returned errors
- align resilient SSE example client type with current API

Closes #704

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated guidance on Server-Sent Events client construction with improved authentication handling during initialization.
* **Bug Fixes**
  * Enhanced error handling during client creation with better error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->