### PR TITLE
add support for extensions in ClientCapabilities and ServerCapabilities

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -511,6 +511,8 @@ type InitializedNotification struct {
 // capabilities are defined here, in this schema, but this is not a closed set: any
 // client can define its own, additional capabilities.
 type ClientCapabilities struct {
+	// Optional, present if the client is advertising extension support.
+	Extensions map[string]any `json:"extensions,omitempty"`
 	// Experimental, non-standard capabilities that the client supports.
 	Experimental map[string]any `json:"experimental,omitempty"`
 	// Present if the client supports listing roots.
@@ -530,6 +532,8 @@ type ClientCapabilities struct {
 // capabilities are defined here, in this schema, but this is not a closed set: any
 // server can define its own, additional capabilities.
 type ServerCapabilities struct {
+	// Optional, present if the server is advertising extension support.
+	Extensions map[string]any `json:"extensions,omitempty"`
 	// Experimental, non-standard capabilities that the server supports.
 	Experimental map[string]any `json:"experimental,omitempty"`
 	// Present if the server supports sending log messages to the client.


### PR DESCRIPTION
## Description

Adding the `extensions` field to both `ClientCapabilities` and `ServerCapabilities` as per [SEP-2133](https://modelcontextprotocol.io/seps/2133-extensions) (merged [here](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2133))

## Type of Change

- [x] MCP spec compatibility implementation

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works: N/A
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section) -> This one I'll defer to authors on. It's not in the authoritative 2025-11-25 `schema.ts` ([ref](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/2025-11-25/schema/2025-11-25/schema.ts#L308)), though I do see that the offical modelcontextprotocol's Go sdk [added extensions](https://github.com/modelcontextprotocol/go-sdk/commit/3dd262606ec4139948b03dd5135a9735f0e2f955#diff-43ef5dbdf51ec3f0cf3fcf614e10ae6a089cc81b9fc9752b0b406aa67a7ec1d2).
- [x] Implementation follows the specification exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Protocol capabilities now include extension support. Clients and servers can advertise their supported extensions during the initial capability exchange phase, enhancing interoperability between different implementations. This enables flexible protocol customization while maintaining full backward compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->