### PR TITLE
feature: Add prompt filter and handler middleware support (parity with tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,14 @@ Add middleware to tool call handlers using the `server.WithToolHandlerMiddleware
 
 A recovery middleware option is available to recover from panics in a tool call and can be added to the server with the `server.WithRecovery` option.
 
+### Prompt Handler Middleware
+
+Add middleware to prompt handlers using the `server.WithPromptHandlerMiddleware` option. Middlewares can be registered on server creation and are applied on every `prompts/get` call.
+
+### Prompt Filtering
+
+Filter prompts based on context using the `server.WithPromptFilter` option. This works the same way as tool filtering but applies to `prompts/list` results.
+
 ### Regenerating Server Code
 
 Server hooks and request handlers are generated. Regenerate them by running:

--- a/server/server.go
+++ b/server/server.go
@@ -72,6 +72,12 @@ type ResourceHandlerMiddleware func(ResourceHandlerFunc) ResourceHandlerFunc
 // ToolFilterFunc is a function that filters tools based on context, typically using session information.
 type ToolFilterFunc func(ctx context.Context, tools []mcp.Tool) []mcp.Tool
 
+// PromptHandlerMiddleware is a middleware function that wraps a PromptHandlerFunc.
+type PromptHandlerMiddleware func(PromptHandlerFunc) PromptHandlerFunc
+
+// PromptFilterFunc is a function that filters prompts based on context, typically using session information.
+type PromptFilterFunc func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt
+
 // ServerTool combines a Tool with its ToolHandlerFunc.
 type ServerTool struct {
 	Tool    mcp.Tool
@@ -173,9 +179,11 @@ type MCPServer struct {
 	promptsMu              sync.RWMutex
 	toolsMu                sync.RWMutex
 	toolMiddlewareMu       sync.RWMutex
+	promptMiddlewareMu     sync.RWMutex
 	notificationHandlersMu sync.RWMutex
 	capabilitiesMu         sync.RWMutex
 	toolFiltersMu          sync.RWMutex
+	promptFiltersMu        sync.RWMutex
 	tasksMu                sync.RWMutex
 
 	name                       string
@@ -189,7 +197,9 @@ type MCPServer struct {
 	taskTools                  map[string]ServerTaskTool
 	toolHandlerMiddlewares     []ToolHandlerMiddleware
 	resourceHandlerMiddlewares []ResourceHandlerMiddleware
+	promptHandlerMiddlewares   []PromptHandlerMiddleware
 	toolFilters                []ToolFilterFunc
+	promptFilters              []PromptFilterFunc
 	notificationHandlers       map[string]NotificationHandlerFunc
 	promptCompletionProvider   PromptCompletionProvider
 	resourceCompletionProvider ResourceCompletionProvider
@@ -324,6 +334,29 @@ func WithToolFilter(
 		s.toolFiltersMu.Lock()
 		s.toolFilters = append(s.toolFilters, toolFilter)
 		s.toolFiltersMu.Unlock()
+	}
+}
+
+// WithPromptHandlerMiddleware allows adding a middleware for the
+// prompt handler call chain.
+func WithPromptHandlerMiddleware(
+	promptHandlerMiddleware PromptHandlerMiddleware,
+) ServerOption {
+	return func(s *MCPServer) {
+		s.promptMiddlewareMu.Lock()
+		s.promptHandlerMiddlewares = append(s.promptHandlerMiddlewares, promptHandlerMiddleware)
+		s.promptMiddlewareMu.Unlock()
+	}
+}
+
+// WithPromptFilter adds a filter function that will be applied to prompts before they are returned in list_prompts
+func WithPromptFilter(
+	promptFilter PromptFilterFunc,
+) ServerOption {
+	return func(s *MCPServer) {
+		s.promptFiltersMu.Lock()
+		s.promptFilters = append(s.promptFilters, promptFilter)
+		s.promptFiltersMu.Unlock()
 	}
 }
 
@@ -467,6 +500,7 @@ func NewMCPServer(
 		taskTools:                  make(map[string]ServerTaskTool),
 		toolHandlerMiddlewares:     make([]ToolHandlerMiddleware, 0),
 		resourceHandlerMiddlewares: make([]ResourceHandlerMiddleware, 0),
+		promptHandlerMiddlewares:   make([]PromptHandlerMiddleware, 0),
 		name:                       name,
 		version:                    version,
 		notificationHandlers:       make(map[string]NotificationHandlerFunc),
@@ -1299,6 +1333,16 @@ func (s *MCPServer) handleListPrompts(
 	sort.Slice(prompts, func(i, j int) bool {
 		return prompts[i].Name < prompts[j].Name
 	})
+
+	// Apply prompt filters if any are defined
+	s.promptFiltersMu.RLock()
+	if len(s.promptFilters) > 0 {
+		for _, filter := range s.promptFilters {
+			prompts = filter(ctx, prompts)
+		}
+	}
+	s.promptFiltersMu.RUnlock()
+
 	promptsToReturn, nextCursor, err := listByPagination(
 		ctx,
 		s,
@@ -1338,7 +1382,18 @@ func (s *MCPServer) handleGetPrompt(
 		}
 	}
 
-	result, err := handler(ctx, request)
+	finalHandler := handler
+
+	s.promptMiddlewareMu.RLock()
+	mw := s.promptHandlerMiddlewares
+
+	// Apply middlewares in reverse order
+	for i := len(mw) - 1; i >= 0; i-- {
+		finalHandler = mw[i](finalHandler)
+	}
+	s.promptMiddlewareMu.RUnlock()
+
+	result, err := finalHandler(ctx, request)
 	if err != nil {
 		return nil, &requestError{
 			id:   id,

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -966,6 +966,207 @@ func TestMCPServer_ToolFiltering(t *testing.T) {
 	}
 }
 
+func TestMCPServer_PromptFiltering(t *testing.T) {
+	// Create a filter that filters prompts by prefix
+	filterByPrefix := func(prefix string) PromptFilterFunc {
+		return func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt {
+			var filtered []mcp.Prompt
+			for _, prompt := range prompts {
+				if len(prompt.Name) >= len(prefix) && prompt.Name[:len(prefix)] == prefix {
+					filtered = append(filtered, prompt)
+				}
+			}
+			return filtered
+		}
+	}
+
+	// Create a server with a prompt filter
+	server := NewMCPServer("test-server", "1.0.0",
+		WithPromptCapabilities(true),
+		WithPromptFilter(filterByPrefix("allow-")),
+	)
+
+	// Add prompts with different prefixes
+	noopHandler := func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return &mcp.GetPromptResult{}, nil
+	}
+	server.AddPrompt(mcp.Prompt{Name: "allow-prompt-1"}, noopHandler)
+	server.AddPrompt(mcp.Prompt{Name: "allow-prompt-2"}, noopHandler)
+	server.AddPrompt(mcp.Prompt{Name: "deny-prompt-1"}, noopHandler)
+	server.AddPrompt(mcp.Prompt{Name: "deny-prompt-2"}, noopHandler)
+
+	// List prompts
+	ctx := context.Background()
+	response := server.HandleMessage(ctx, []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "prompts/list"
+	}`))
+	resp, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+
+	result, ok := resp.Result.(mcp.ListPromptsResult)
+	require.True(t, ok)
+
+	// Should only include prompts with the "allow-" prefix
+	assert.Len(t, result.Prompts, 2)
+	for _, prompt := range result.Prompts {
+		assert.True(t, len(prompt.Name) >= 6 && prompt.Name[:6] == "allow-",
+			"Prompt should start with 'allow-', got: %s", prompt.Name)
+	}
+}
+
+func TestMCPServer_MultiplePromptFilters(t *testing.T) {
+	// First filter: keep only prompts starting with "a"
+	filterA := func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt {
+		var filtered []mcp.Prompt
+		for _, p := range prompts {
+			if len(p.Name) > 0 && p.Name[0] == 'a' {
+				filtered = append(filtered, p)
+			}
+		}
+		return filtered
+	}
+	// Second filter: keep only prompts containing "keep"
+	filterKeep := func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt {
+		var filtered []mcp.Prompt
+		for _, p := range prompts {
+			for i := 0; i+4 <= len(p.Name); i++ {
+				if p.Name[i:i+4] == "keep" {
+					filtered = append(filtered, p)
+					break
+				}
+			}
+		}
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithPromptCapabilities(true),
+		WithPromptFilter(PromptFilterFunc(filterA)),
+		WithPromptFilter(PromptFilterFunc(filterKeep)),
+	)
+
+	noopHandler := func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return &mcp.GetPromptResult{}, nil
+	}
+	server.AddPrompt(mcp.Prompt{Name: "a-keep-this"}, noopHandler)
+	server.AddPrompt(mcp.Prompt{Name: "a-remove-this"}, noopHandler)
+	server.AddPrompt(mcp.Prompt{Name: "b-keep-this"}, noopHandler)
+
+	ctx := context.Background()
+	response := server.HandleMessage(ctx, []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "prompts/list"
+	}`))
+	resp, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+
+	result, ok := resp.Result.(mcp.ListPromptsResult)
+	require.True(t, ok)
+
+	// Only "a-keep-this" should survive both filters
+	assert.Len(t, result.Prompts, 1)
+	assert.Equal(t, "a-keep-this", result.Prompts[0].Name)
+}
+
+func TestMCPServer_PromptHandlerMiddleware(t *testing.T) {
+	server := NewMCPServer("test-server", "1.0.0",
+		WithPromptCapabilities(true),
+		WithPromptHandlerMiddleware(func(next PromptHandlerFunc) PromptHandlerFunc {
+			return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+				result, err := next(ctx, req)
+				if err != nil {
+					return nil, err
+				}
+				// Middleware appends a message
+				result.Messages = append(result.Messages, mcp.PromptMessage{
+					Role: mcp.RoleAssistant,
+					Content: mcp.TextContent{
+						Type: "text",
+						Text: "added-by-middleware",
+					},
+				})
+				return result, nil
+			}
+		}),
+	)
+
+	server.AddPrompt(mcp.Prompt{Name: "test-prompt"}, func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return &mcp.GetPromptResult{
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: "original"},
+				},
+			},
+		}, nil
+	})
+
+	ctx := context.Background()
+	response := server.HandleMessage(ctx, []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "prompts/get",
+		"params": {"name": "test-prompt"}
+	}`))
+	resp, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+
+	result, ok := resp.Result.(mcp.GetPromptResult)
+	require.True(t, ok)
+
+	assert.Len(t, result.Messages, 2)
+	// Verify original message is first
+	tc, ok := result.Messages[0].Content.(mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t, "original", tc.Text)
+	// Verify middleware-added message is second
+	tc, ok = result.Messages[1].Content.(mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t, "added-by-middleware", tc.Text)
+}
+
+func TestMCPServer_MultiplePromptHandlerMiddlewares(t *testing.T) {
+	var order []string
+
+	makeMiddleware := func(name string) PromptHandlerMiddleware {
+		return func(next PromptHandlerFunc) PromptHandlerFunc {
+			return func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+				order = append(order, name+"-before")
+				result, err := next(ctx, req)
+				order = append(order, name+"-after")
+				return result, err
+			}
+		}
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithPromptCapabilities(true),
+		WithPromptHandlerMiddleware(makeMiddleware("first")),
+		WithPromptHandlerMiddleware(makeMiddleware("second")),
+	)
+
+	server.AddPrompt(mcp.Prompt{Name: "test-prompt"}, func(ctx context.Context, req mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		order = append(order, "handler")
+		return &mcp.GetPromptResult{}, nil
+	})
+
+	ctx := context.Background()
+	response := server.HandleMessage(ctx, []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "prompts/get",
+		"params": {"name": "test-prompt"}
+	}`))
+	_, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+
+	// Middlewares applied in reverse order means first-registered wraps outermost
+	assert.Equal(t, []string{"first-before", "second-before", "handler", "second-after", "first-after"}, order)
+}
+
 func TestMCPServer_SendNotificationToSpecificClient(t *testing.T) {
 	server := NewMCPServer("test-server", "1.0.0")
 


### PR DESCRIPTION
## Description

Add `PromptFilterFunc` and `PromptHandlerMiddleware` support, mirroring the existing tool filter/middleware pattern.

Addresses #750

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

New types: `PromptHandlerMiddleware`, `PromptFilterFunc`
New options: `WithPromptHandlerMiddleware()`, `WithPromptFilter()`
Modified handlers: `handleListPrompts` (applies filters), `handleGetPrompt` (applies middleware chain)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prompt handler middleware to modify prompt retrieval/composition with a predictable wrapping order.
  * Prompt filters to control which prompts appear in prompt listings before pagination.
* **Documentation**
  * Added usage examples and configuration notes for prompt middleware and filters.
* **Tests**
  * Added coverage validating filter composition, middleware wrapping/order, and list/get behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->