### PR TITLE
Add AgentRank score badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/mark3labs/mcp-go?cache)](https://goreportcard.com/report/github.com/mark3labs/mcp-go)
 [![GoDoc](https://pkg.go.dev/badge/github.com/mark3labs/mcp-go.svg)](https://pkg.go.dev/github.com/mark3labs/mcp-go)
 
+[![AgentRank](https://agentrank-ai.com/api/badge/tool/mark3labs--mcp-go)](https://agentrank-ai.com/tool/mark3labs--mcp-go/)
 <strong>A Go implementation of the Model Context Protocol (MCP), enabling seamless integration between LLM applications and external data sources and tools.</strong>
 
 <br>


### PR DESCRIPTION
Hi! I'm adding an [AgentRank](https://agentrank-ai.com) score badge to your README.

AgentRank is an open index of 25,000+ MCP servers and agent tools, scored daily by real signals (stars, freshness, issue health, contributors, dependents). Your repo is currently ranked **#6** in the index.

The badge links back to your [tool page on AgentRank](https://agentrank-ai.com/tool/mark3labs--mcp-go) where maintainers can see their full score breakdown. It also updates automatically as your score changes.

Feel free to close if you'd prefer not to have it — no pressure!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Inserted an AgentRank badge beneath the README's top badge area.
  * Added surrounding blank lines to improve spacing and visual layout; this is a content/markup-only change that does not affect functionality.
  * No exported or public entities were modified; estimated review effort: low.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->