### PR TITLE
fix(server): clean up sessionRequestIDs on GET connection close

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -607,6 +607,7 @@ func (s *StreamableHTTPServer) handleGet(w http.ResponseWriter, r *http.Request)
 		}
 		defer s.server.UnregisterSession(r.Context(), sessionID)
 		defer s.activeSessions.Delete(sessionID)
+		defer s.sessionRequestIDs.Delete(sessionID)
 	}
 
 	s.touchSession(sessionID)

--- a/server/streamable_http_memleak_bench_test.go
+++ b/server/streamable_http_memleak_bench_test.go
@@ -1,0 +1,105 @@
+package server
+
+// BenchmarkSessionRequestIDs_RetainedAfterClose measures memory retained in
+// sessionRequestIDs after GET connections close without a DELETE request.
+//
+// This benchmark exists to detect regressions of the memory leak where
+// sessionRequestIDs grew unboundedly because entries were only removed in
+// handleDelete, which stateless clients rarely call.
+//
+// Run with:
+//
+//	go test ./server/ -run=^$ -bench=BenchmarkSessionRequestIDs -benchmem -v
+//
+// Expected output with the fix:
+//
+//	map_entries_retained    0        retained_heap_bytes/op   0
+//
+// Expected output without the fix (entries and bytes grow with b.N):
+//
+//	map_entries_retained   <b.N>    retained_heap_bytes/op  >0
+//
+// To reproduce the leak, comment out the fix in handleGet
+// (streamable_http.go) and re-run this benchmark:
+//
+//	// defer s.sessionRequestIDs.Delete(sessionID)
+//
+// You should see map_entries_retained equal to b.N.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+	"time"
+)
+
+func BenchmarkSessionRequestIDs_RetainedAfterClose(b *testing.B) {
+	mcpServer := NewMCPServer("bench", "1.0.0")
+	httpServer := NewStreamableHTTPServer(mcpServer,
+		// Short heartbeat so sessionRequestIDs is populated quickly.
+		WithHeartbeatInterval(20*time.Millisecond),
+	)
+	ts := httptest.NewServer(httpServer)
+	b.Cleanup(ts.Close)
+
+	// Establish a heap baseline after warm-up GC.
+	runtime.GC()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		// Open a GET (SSE) connection and close it without sending DELETE.
+		ctx, cancel := context.WithCancel(context.Background())
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+		if err != nil {
+			b.Fatalf("failed to create request: %v", err)
+		}
+		req.Header.Set("Content-Type", "text/event-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			b.Fatalf("GET failed: %v", err)
+		}
+
+		// Let the heartbeat goroutine tick at least once so that
+		// nextRequestID populates sessionRequestIDs.
+		time.Sleep(60 * time.Millisecond)
+
+		cancel()
+		_ = resp.Body.Close()
+
+		// Give the server goroutine time to run the deferred cleanup.
+		time.Sleep(30 * time.Millisecond)
+	}
+
+	b.StopTimer()
+
+	// Force several GC cycles to reclaim anything that can be reclaimed.
+	for i := 0; i < 5; i++ {
+		runtime.GC()
+	}
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	// Count entries still live in the map.
+	var retained int
+	httpServer.sessionRequestIDs.Range(func(_, _ any) bool {
+		retained++
+		return true
+	})
+
+	// HeapInuse can decrease between GC cycles; clamp negative delta to 0.
+	retainedBytes := int64(after.HeapInuse) - int64(before.HeapInuse)
+	if retainedBytes < 0 {
+		retainedBytes = 0
+	}
+
+	b.ReportMetric(float64(retained), "map_entries_retained")
+	b.ReportMetric(float64(retainedBytes)/float64(b.N), "retained_heap_bytes/op")
+}

--- a/server/streamable_http_memleak_bench_test.go
+++ b/server/streamable_http_memleak_bench_test.go
@@ -57,7 +57,7 @@ func BenchmarkSessionRequestIDs_RetainedAfterClose(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Open a GET (SSE) connection and close it without sending DELETE.
-		ctx, cancel := context.WithCancel(b.Context())
+		ctx, cancel := context.WithCancel(context.Background())
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 		if err != nil {
 			b.Fatalf("failed to create request: %v", err)

--- a/server/streamable_http_memleak_bench_test.go
+++ b/server/streamable_http_memleak_bench_test.go
@@ -35,6 +35,9 @@ import (
 	"time"
 )
 
+// BenchmarkSessionRequestIDs_RetainedAfterClose measures heap objects retained
+// in sessionRequestIDs after GET/SSE connections close without a DELETE request.
+// map_entries_retained should be 0 with the fix and equal to b.N without it.
 func BenchmarkSessionRequestIDs_RetainedAfterClose(b *testing.B) {
 	mcpServer := NewMCPServer("bench", "1.0.0")
 	httpServer := NewStreamableHTTPServer(mcpServer,

--- a/server/streamable_http_memleak_bench_test.go
+++ b/server/streamable_http_memleak_bench_test.go
@@ -57,33 +57,36 @@ func BenchmarkSessionRequestIDs_RetainedAfterClose(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		// Open a GET (SSE) connection and close it without sending DELETE.
-		ctx, cancel := context.WithCancel(context.Background())
+		ctx, cancel := context.WithCancel(b.Context())
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 		if err != nil {
 			b.Fatalf("failed to create request: %v", err)
 		}
-		req.Header.Set("Content-Type", "text/event-stream")
+		req.Header.Set("Accept", "text/event-stream")
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
 			b.Fatalf("GET failed: %v", err)
 		}
 
-		// Let the heartbeat goroutine tick at least once so that
-		// nextRequestID populates sessionRequestIDs.
+		// Sleep ~3× the heartbeat interval (20 ms) to ensure the heartbeat
+		// goroutine has called nextRequestID and written to sessionRequestIDs.
+		// Fixed sleep is intentional here: require.Eventually would add
+		// synchronization overhead that skews the benchmark measurements.
 		time.Sleep(60 * time.Millisecond)
 
 		cancel()
 		_ = resp.Body.Close()
 
-		// Give the server goroutine time to run the deferred cleanup.
+		// Give the server goroutine a generous window to execute the deferred
+		// sessionRequestIDs.Delete before the next iteration measures the map.
 		time.Sleep(30 * time.Millisecond)
 	}
 
 	b.StopTimer()
 
 	// Force several GC cycles to reclaim anything that can be reclaimed.
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		runtime.GC()
 	}
 
@@ -98,10 +101,7 @@ func BenchmarkSessionRequestIDs_RetainedAfterClose(b *testing.B) {
 	})
 
 	// HeapInuse can decrease between GC cycles; clamp negative delta to 0.
-	retainedBytes := int64(after.HeapInuse) - int64(before.HeapInuse)
-	if retainedBytes < 0 {
-		retainedBytes = 0
-	}
+	retainedBytes := max(int64(after.HeapInuse)-int64(before.HeapInuse), 0)
 
 	b.ReportMetric(float64(retained), "map_entries_retained")
 	b.ReportMetric(float64(retainedBytes)/float64(b.N), "retained_heap_bytes/op")

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2886,7 +2886,7 @@ func TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose(t *testing.T) {
 	defer ts.Close()
 
 	// Open a GET (SSE) connection with a short-lived context.
-	ctx, cancel := context.WithCancel(t.Context())
+	ctx, cancel := context.WithCancel(context.Background())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "text/event-stream")

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2886,7 +2886,7 @@ func TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose(t *testing.T) {
 	defer ts.Close()
 
 	// Open a GET (SSE) connection with a short-lived context.
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(t.Context())
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
 	require.NoError(t, err)
 	req.Header.Set("Content-Type", "text/event-stream")

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2873,3 +2873,41 @@ func TestStreamableHTTPNotificationRace(t *testing.T) {
 		}
 	}
 }
+
+func TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose(t *testing.T) {
+	// Verify that sessionRequestIDs entry is removed when a GET connection closes,
+	// preventing unbounded growth in stateless/heartbeat scenarios.
+	mcpServer := NewMCPServer("test", "1.0.0")
+	httpServer := NewStreamableHTTPServer(mcpServer,
+		WithHeartbeatInterval(50*time.Millisecond),
+	)
+	ts := httptest.NewServer(httpServer)
+	defer ts.Close()
+
+	// Open a GET (SSE) connection with a short-lived context.
+	ctx, cancel := context.WithCancel(context.Background())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	// Let the heartbeat tick at least once so that sessionRequestIDs is populated.
+	time.Sleep(150 * time.Millisecond)
+
+	countEntries := func() int {
+		n := 0
+		httpServer.sessionRequestIDs.Range(func(_, _ any) bool { n++; return true })
+		return n
+	}
+
+	require.Greater(t, countEntries(), 0, "sessionRequestIDs should have an entry while GET is open")
+
+	// Close the connection and wait for cleanup.
+	cancel()
+	resp.Body.Close()
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, 0, countEntries(), "sessionRequestIDs should be empty after GET connection closes")
+}

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2878,37 +2878,47 @@ func TestStreamableHTTPNotificationRace(t *testing.T) {
 // sessionRequestIDs entry is removed when a GET connection closes, preventing
 // unbounded growth in stateless/heartbeat scenarios.
 func TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose(t *testing.T) {
-	mcpServer := NewMCPServer("test", "1.0.0")
-	httpServer := NewStreamableHTTPServer(mcpServer,
-		WithHeartbeatInterval(50*time.Millisecond),
-	)
-	ts := httptest.NewServer(httpServer)
-	defer ts.Close()
-
-	// Open a GET (SSE) connection with a short-lived context.
-	ctx, cancel := context.WithCancel(context.Background())
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
-	require.NoError(t, err)
-	req.Header.Set("Content-Type", "text/event-stream")
-
-	resp, err := http.DefaultClient.Do(req)
-	require.NoError(t, err)
-
-	countEntries := func() int {
-		n := 0
-		httpServer.sessionRequestIDs.Range(func(_, _ any) bool { n++; return true })
-		return n
+	tests := []struct {
+		name string
+	}{
+		{name: "cleanup on GET close"},
 	}
 
-	// Poll until the heartbeat fires and populates sessionRequestIDs.
-	require.Eventually(t, func() bool { return countEntries() > 0 },
-		time.Second, 10*time.Millisecond,
-		"sessionRequestIDs should have an entry while GET is open")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer := NewMCPServer("test", "1.0.0")
+			httpServer := NewStreamableHTTPServer(mcpServer,
+				WithHeartbeatInterval(50*time.Millisecond),
+			)
+			ts := httptest.NewServer(httpServer)
+			defer ts.Close()
 
-	// Close the connection and poll until the deferred cleanup runs.
-	cancel()
-	resp.Body.Close()
-	assert.Eventually(t, func() bool { return countEntries() == 0 },
-		time.Second, 10*time.Millisecond,
-		"sessionRequestIDs should be empty after GET connection closes")
+			// Open a GET (SSE) connection with a short-lived context.
+			ctx, cancel := context.WithCancel(context.Background())
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+			require.NoError(t, err)
+			req.Header.Set("Content-Type", "text/event-stream")
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+
+			countEntries := func() int {
+				n := 0
+				httpServer.sessionRequestIDs.Range(func(_, _ any) bool { n++; return true })
+				return n
+			}
+
+			// Poll until the heartbeat fires and populates sessionRequestIDs.
+			require.Eventually(t, func() bool { return countEntries() > 0 },
+				time.Second, 10*time.Millisecond,
+				"sessionRequestIDs should have an entry while GET is open")
+
+			// Close the connection and poll until the deferred cleanup runs.
+			cancel()
+			resp.Body.Close()
+			assert.Eventually(t, func() bool { return countEntries() == 0 },
+				time.Second, 10*time.Millisecond,
+				"sessionRequestIDs should be empty after GET connection closes")
+		})
+	}
 }

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2874,9 +2874,10 @@ func TestStreamableHTTPNotificationRace(t *testing.T) {
 	}
 }
 
+// TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose verifies that the
+// sessionRequestIDs entry is removed when a GET connection closes, preventing
+// unbounded growth in stateless/heartbeat scenarios.
 func TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose(t *testing.T) {
-	// Verify that sessionRequestIDs entry is removed when a GET connection closes,
-	// preventing unbounded growth in stateless/heartbeat scenarios.
 	mcpServer := NewMCPServer("test", "1.0.0")
 	httpServer := NewStreamableHTTPServer(mcpServer,
 		WithHeartbeatInterval(50*time.Millisecond),
@@ -2893,21 +2894,21 @@ func TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose(t *testing.T) {
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
 
-	// Let the heartbeat tick at least once so that sessionRequestIDs is populated.
-	time.Sleep(150 * time.Millisecond)
-
 	countEntries := func() int {
 		n := 0
 		httpServer.sessionRequestIDs.Range(func(_, _ any) bool { n++; return true })
 		return n
 	}
 
-	require.Greater(t, countEntries(), 0, "sessionRequestIDs should have an entry while GET is open")
+	// Poll until the heartbeat fires and populates sessionRequestIDs.
+	require.Eventually(t, func() bool { return countEntries() > 0 },
+		time.Second, 10*time.Millisecond,
+		"sessionRequestIDs should have an entry while GET is open")
 
-	// Close the connection and wait for cleanup.
+	// Close the connection and poll until the deferred cleanup runs.
 	cancel()
 	resp.Body.Close()
-	time.Sleep(100 * time.Millisecond)
-
-	assert.Equal(t, 0, countEntries(), "sessionRequestIDs should be empty after GET connection closes")
+	assert.Eventually(t, func() bool { return countEntries() == 0 },
+		time.Second, 10*time.Millisecond,
+		"sessionRequestIDs should be empty after GET connection closes")
 }


### PR DESCRIPTION
## Description

When heartbeat is enabled, nextRequestID stores a sessionID→*atomic.Int64 entry in sessionRequestIDs. Previously this entry was only deleted in handleDelete or via the idle sweeper (cleanupSessionState), but any client that closes the GET connection without sending DELETE leaves the entry behind.    
                                                                                                                                                                                                                                                                                                                 
In the default StatelessGeneratingSessionIdManager mode every GET connection receives a unique UUID session ID, so the map grows proportionally to the total number of connections over the lifetime of the process.                                                                                           
                                                                                                                                                                                                                                                                                                                 
Add defer s.sessionRequestIDs.Delete(sessionID) in handleGet alongside the existing activeSessions and UnregisterSession defers so the entry is always removed when the SSE connection closes, regardless of whether the client sends DELETE.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (not applicable)

## Additional Information

The leak is confirmed by BenchmarkSessionRequestIDs_RetainedAfterClose in server/streamable_http_memleak_bench_test.go. Without the fix the benchmark reports map_entries_retained = b.N and retained_heap_bytes/op > 0; with the fix both metrics are 0.
                                                                                                                                                                              
To reproduce:   
comment out the fix in handleGet (streamable_http.go):                                                                                                                    
// defer s.sessionRequestIDs.Delete(sessionID)                                                                                                                          
                                                                                                                                                                              
go test ./server/ -run=^$ -bench=BenchmarkSessionRequestIDs -benchmem -v -benchtime=10x


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cleanup for long-lived GET/SSE sessions now runs reliably on connection close, reducing retained memory and improving server stability.

* **Tests**
  * Added a unit test verifying session tracking is cleared after GET/SSE connection closure.
  * Added a benchmark measuring retained map entries and retained heap bytes across repeated GET/SSE connection cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->