### PR TITLE
fix(server): reject sync calls to task-only tools

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1442,6 +1442,7 @@ func (s *MCPServer) handleToolCall(
 	// First check session-specific tools
 	var tool ServerTool
 	var ok bool
+	var taskToolOnly bool
 
 	session := ClientSessionFromContext(ctx)
 	if session != nil {
@@ -1470,6 +1471,7 @@ func (s *MCPServer) handleToolCall(
 					Handler: nil, // Handler will be used from taskTool in handleTaskAugmentedToolCall
 				}
 				ok = true
+				taskToolOnly = true
 			}
 		}
 		s.toolsMu.RUnlock()
@@ -1504,6 +1506,14 @@ func (s *MCPServer) handleToolCall(
 	if shouldExecuteAsTask {
 		// Route to task-augmented execution handler
 		return s.handleTaskAugmentedToolCall(ctx, id, request)
+	}
+
+	if taskToolOnly {
+		return nil, &requestError{
+			id:   id,
+			code: mcp.METHOD_NOT_FOUND,
+			err:  fmt.Errorf("tool '%s' does not support synchronous execution", request.Params.Name),
+		}
 	}
 
 	finalHandler := tool.Handler

--- a/server/task_tool_test.go
+++ b/server/task_tool_test.go
@@ -284,6 +284,46 @@ func TestTaskToolTracerBullet(t *testing.T) {
 		}
 	})
 
+	t.Run("AddTaskTool with TaskSupportOptional rejects sync calls without task param", func(t *testing.T) {
+		server := NewMCPServer(
+			"test-optional-task-only-sync",
+			"1.0.0",
+			WithTaskCapabilities(true, true, true),
+		)
+
+		ctx := context.Background()
+		handlerCalled := false
+
+		optionalTool := mcp.NewTool("task_only_optional",
+			mcp.WithDescription("Task-only registration with optional task support"),
+			mcp.WithTaskSupport(mcp.TaskSupportOptional),
+		)
+
+		server.AddTaskTool(optionalTool, func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CreateTaskResult, error) {
+			handlerCalled = true
+			return &mcp.CreateTaskResult{
+				Task: mcp.Task{TaskId: "task-1", Status: mcp.TaskStatusWorking},
+			}, nil
+		})
+
+		syncRequest := mcp.CallToolRequest{
+			Params: mcp.CallToolParams{
+				Name: "task_only_optional",
+			},
+		}
+
+		var syncResult any
+		var syncErr *requestError
+		assert.NotPanics(t, func() {
+			syncResult, syncErr = server.handleToolCall(ctx, 1, syncRequest)
+		})
+		require.Nil(t, syncResult, "Sync call should not produce a tool result")
+		require.NotNil(t, syncErr, "Sync call should return a request error")
+		assert.Equal(t, mcp.METHOD_NOT_FOUND, syncErr.code)
+		assert.Contains(t, syncErr.err.Error(), "does not support synchronous execution")
+		assert.False(t, handlerCalled, "Task handler should not be called without task augmentation")
+	})
+
 	t.Run("task tool with TaskSupportOptional - asynchronous execution", func(t *testing.T) {
 		// Step 1: Create server
 		server := NewMCPServer(


### PR DESCRIPTION
## Summary

- return a clear request error when a tool registered only through `AddTaskTool` is called without task augmentation
- avoid falling through to the synchronous handler path when no sync handler exists
- add a focused regression test covering `AddTaskTool` + `TaskSupportOptional` without a `task` payload

## Validation

- `go test ./server -run 'TestTaskToolTracerBullet|TestMCPServer_TaskSupportValidation' -count=1 -v`
- `go test ./server`
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tools registered with task-only support now properly reject synchronous calls with a descriptive error message.
* **Tests**
  * Added test coverage for task-only tool synchronous call rejection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->