### PR TITLE
feat(server): add WithExperimental server option

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -220,8 +220,9 @@ type serverCapabilities struct {
 	sampling    *bool
 	elicitation *bool
 	roots       *bool
-	tasks       *taskCapabilities
-	completions *bool
+	tasks        *taskCapabilities
+	completions  *bool
+	experimental map[string]any
 }
 
 // resourceCapabilities defines the supported resource-related features
@@ -441,6 +442,13 @@ func WithInstructions(instructions string) ServerOption {
 func WithCompletions() ServerOption {
 	return func(s *MCPServer) {
 		s.capabilities.completions = mcp.ToBoolPtr(true)
+	}
+}
+
+// WithExperimental sets experimental, non-standard capabilities on the server.
+func WithExperimental(experimental map[string]any) ServerOption {
+	return func(s *MCPServer) {
+		s.capabilities.experimental = experimental
 	}
 }
 
@@ -882,6 +890,10 @@ func (s *MCPServer) handleInitialize(
 
 	if s.capabilities.completions != nil && *s.capabilities.completions {
 		capabilities.Completions = &struct{}{}
+	}
+
+	if s.capabilities.experimental != nil {
+		capabilities.Experimental = s.capabilities.experimental
 	}
 
 	result := mcp.InitializeResult{

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -129,6 +129,25 @@ func TestMCPServer_Capabilities(t *testing.T) {
 				assert.NotNil(t, initResult.Capabilities.Logging)
 			},
 		},
+		{
+			name: "Experimental capabilities",
+			options: []ServerOption{
+				WithExperimental(map[string]any{
+					"claude/channel": map[string]any{},
+				}),
+			},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				assert.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				assert.True(t, ok)
+
+				assert.NotNil(t, initResult.Capabilities.Experimental)
+				_, hasChannel := initResult.Capabilities.Experimental["claude/channel"]
+				assert.True(t, hasChannel, "expected claude/channel in experimental capabilities")
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `experimental map[string]any` field to internal `serverCapabilities` struct
- Add `WithExperimental()` server option matching the pattern of other capability options
- Wire it through `handleInitialize` to populate `ServerCapabilities.Experimental`
- Add test case for experimental capabilities

## Motivation

The `ServerCapabilities` type already has an `Experimental map[string]any` field, but there's no way to set it via the server builder API. This is needed for servers that declare experimental capabilities like `claude/channel`.

## Test plan

- Added subtest "Experimental capabilities" to `TestMCPServer_Capabilities`
- All existing tests pass unchanged
- Verified wire JSON output matches expected shape:

```json
{
  "capabilities": {
    "experimental": {
      "claude/channel": {}
    },
    "tools": {}
  }
}
```