### PR TITLE
fix(server): improve response codes for sampling errors

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -830,9 +830,8 @@ func (s *StreamableHTTPServer) handleSamplingResponse(w http.ResponseWriter, r *
 	// Find the corresponding session and deliver the response
 	// The response is delivered to the specific session identified by sessionID
 	if err := s.deliverSamplingResponse(w, sessionID, response); err != nil {
-		s.logger.Errorf("Failed to deliver sampling response: %v", err)
 		// HTTP Status code is already set in deliverSamplingResponse, just return here
-		return err
+		return fmt.Errorf("failed to deliver sampling response: %w", err)
 	}
 
 	// Acknowledge receipt
@@ -852,7 +851,7 @@ func (s *StreamableHTTPServer) deliverSamplingResponse(w http.ResponseWriter, se
 
 	session, ok := sessionInterface.(*streamableHttpSession)
 	if !ok {
-		http.Error(w, "Invalid session type for the given session ID", http.StatusBadRequest)
+		http.Error(w, "Invalid session type for the given session ID", http.StatusInternalServerError)
 		return fmt.Errorf("invalid session type for session %s", sessionID)
 	}
 

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -845,7 +845,7 @@ func (s *StreamableHTTPServer) deliverSamplingResponse(w http.ResponseWriter, se
 	// Look up the active session
 	sessionInterface, ok := s.activeSessions.Load(sessionID)
 	if !ok {
-		http.Error(w, "No active session found for the given session ID", http.StatusBadRequest)
+		http.Error(w, "No active session found for the given session ID", http.StatusNotFound)
 		return fmt.Errorf("no active session found for session %s", sessionID)
 	}
 

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -18,6 +18,7 @@ import (
 	"unicode"
 
 	"github.com/google/uuid"
+
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/util"
 )
@@ -372,7 +373,7 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	if isSamplingResponse {
 		if err := s.handleSamplingResponse(w, r, jsonMessage); err != nil {
 			s.logger.Errorf("Failed to handle sampling response: %v", err)
-			http.Error(w, "Failed to handle sampling response", http.StatusInternalServerError)
+			// HTTP Status code is already set in handleSamplingResponse, just return here
 		}
 		return
 	}
@@ -828,9 +829,9 @@ func (s *StreamableHTTPServer) handleSamplingResponse(w http.ResponseWriter, r *
 
 	// Find the corresponding session and deliver the response
 	// The response is delivered to the specific session identified by sessionID
-	if err := s.deliverSamplingResponse(sessionID, response); err != nil {
+	if err := s.deliverSamplingResponse(w, sessionID, response); err != nil {
 		s.logger.Errorf("Failed to deliver sampling response: %v", err)
-		http.Error(w, "Failed to deliver response", http.StatusInternalServerError)
+		// HTTP Status code is already set in deliverSamplingResponse, just return here
 		return err
 	}
 
@@ -839,27 +840,32 @@ func (s *StreamableHTTPServer) handleSamplingResponse(w http.ResponseWriter, r *
 	return nil
 }
 
-// deliverSamplingResponse delivers a sampling response to the appropriate session
-func (s *StreamableHTTPServer) deliverSamplingResponse(sessionID string, response samplingResponseItem) error {
+// deliverSamplingResponse delivers a sampling response to the appropriate session.
+// On failure it writes the HTTP error status directly to w.
+func (s *StreamableHTTPServer) deliverSamplingResponse(w http.ResponseWriter, sessionID string, response samplingResponseItem) error {
 	// Look up the active session
 	sessionInterface, ok := s.activeSessions.Load(sessionID)
 	if !ok {
+		http.Error(w, "No active session found for the given session ID", http.StatusBadRequest)
 		return fmt.Errorf("no active session found for session %s", sessionID)
 	}
 
 	session, ok := sessionInterface.(*streamableHttpSession)
 	if !ok {
+		http.Error(w, "Invalid session type for the given session ID", http.StatusBadRequest)
 		return fmt.Errorf("invalid session type for session %s", sessionID)
 	}
 
 	// Look up the dedicated response channel for this specific request
 	responseChannelInterface, exists := session.samplingRequests.Load(response.requestID)
 	if !exists {
+		http.Error(w, "No pending sampling request found for the given request ID", http.StatusBadRequest)
 		return fmt.Errorf("no pending request found for session %s, request %d", sessionID, response.requestID)
 	}
 
 	responseChan, ok := responseChannelInterface.(chan samplingResponseItem)
 	if !ok {
+		http.Error(w, "Failed to deliver response", http.StatusInternalServerError)
 		return fmt.Errorf("invalid response channel type for session %s, request %d", sessionID, response.requestID)
 	}
 
@@ -869,6 +875,7 @@ func (s *StreamableHTTPServer) deliverSamplingResponse(sessionID string, respons
 		s.logger.Infof("Delivered sampling response for session %s, request %d", sessionID, response.requestID)
 		return nil
 	default:
+		http.Error(w, "Failed to deliver response", http.StatusInternalServerError)
 		return fmt.Errorf("failed to deliver sampling response for session %s, request %d: channel full or blocked", sessionID, response.requestID)
 	}
 }

--- a/server/streamable_http_sampling_test.go
+++ b/server/streamable_http_sampling_test.go
@@ -98,7 +98,7 @@ func TestStreamableHTTPServer_SamplingErrorHandling(t *testing.T) {
 				"id":      1,
 				"result":  "invalid-result",
 			},
-			expectedStatus: http.StatusInternalServerError,
+			expectedStatus: http.StatusBadRequest,
 		},
 	}
 

--- a/server/streamable_http_sampling_test.go
+++ b/server/streamable_http_sampling_test.go
@@ -98,7 +98,7 @@ func TestStreamableHTTPServer_SamplingErrorHandling(t *testing.T) {
 				"id":      1,
 				"result":  "invalid-result",
 			},
-			expectedStatus: http.StatusBadRequest,
+			expectedStatus: http.StatusNotFound,
 		},
 	}
 

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2926,3 +2926,61 @@ func TestStreamableHTTP_SessionRequestIDs_CleanedOnGetClose(t *testing.T) {
 		})
 	}
 }
+
+func TestStreamableHTTP_SamplingResponseErrors(t *testing.T) {
+	mcpServer := NewMCPServer("test", "1.0")
+	ts := NewTestStreamableHTTPServer(mcpServer, WithStateful(true))
+	defer ts.Close()
+
+	// Initialize a session to get a valid session ID
+	resp, err := postJSON(ts.URL, initRequest)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	sessionID := resp.Header.Get(HeaderKeySessionID)
+	require.NotEmpty(t, sessionID)
+
+	// A sampling response: has id + result, no method
+	samplingResponse := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      42,
+		"result": map[string]any{
+			"model": "test-model",
+			"role":  "assistant",
+			"content": map[string]any{
+				"type": "text",
+				"text": "hello",
+			},
+		},
+	}
+
+	t.Run("missing session ID returns 400", func(t *testing.T) {
+		// POST without session header
+		resp, err := postJSON(ts.URL, samplingResponse)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		assert.Contains(t, string(body), "Missing session ID")
+	})
+
+	t.Run("invalid session ID returns 404", func(t *testing.T) {
+		resp, err := postSessionJSON(ts.URL, "bogus-session-id", samplingResponse)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("valid session but no pending sampling request returns 400", func(t *testing.T) {
+		// Session exists but there is no pending sampling request with id=42
+		resp, err := postSessionJSON(ts.URL, sessionID, samplingResponse)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		body, _ := io.ReadAll(resp.Body)
+		assert.Contains(t, string(body), "No pending sampling request")
+	})
+}


### PR DESCRIPTION
## Description
The server treated any sampling error as a server error and returned the 500 code.  This PR handles errors more precisely and returns either a client error (400 - Bad Request) or a server error.

Fixes #<issue_number> (if applicable)

## Type of Change

- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [X] My code follows the code style of this project
- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have updated the documentation accordingly



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sampling delivery now returns more precise HTTP status codes and messages for missing/invalid sessions, missing pending requests, malformed results (404), and delivery failures.

* **Tests**
  * Added/updated tests covering sampling response error cases: missing session header, invalid session ID, no pending request, and malformed result handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->