### PR TITLE
Fix AddTaskTool task result payload handling

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1439,6 +1439,9 @@ type TaskParams struct {
 type CreateTaskResult struct {
 	Result
 	Task Task `json:"task"`
+	Content []Content `json:"-"`
+	StructuredContent any `json:"-"`
+	IsError bool `json:"-"`
 }
 
 // GetTaskRequest retrieves the current status of a task.

--- a/server/server.go
+++ b/server/server.go
@@ -1968,28 +1968,36 @@ func (s *MCPServer) handleTaskResult(
 		},
 	}
 
-	// If the stored result is a CallToolResult, extract its fields
-	if callToolResult, ok := storedResult.(*mcp.CallToolResult); ok {
-		result.Content = callToolResult.Content
-		result.StructuredContent = callToolResult.StructuredContent
-		result.IsError = callToolResult.IsError
-
-		// Merge any meta from the original result with the related task meta
-		if callToolResult.Meta != nil {
-			if result.Meta.AdditionalFields == nil {
-				result.Meta.AdditionalFields = make(map[string]any)
-			}
-			// Copy over any additional fields from the original result
-			for k, v := range callToolResult.Meta.AdditionalFields {
-				// Don't overwrite the related task meta
-				if k != mcp.RelatedTaskMetaKey {
-					result.Meta.AdditionalFields[k] = v
-				}
-			}
-		}
+	switch taskResult := storedResult.(type) {
+	case *mcp.CallToolResult:
+		result.Content = taskResult.Content
+		result.StructuredContent = taskResult.StructuredContent
+		result.IsError = taskResult.IsError
+		mergeTaskResultMeta(result, taskResult.Meta)
+	case *mcp.CreateTaskResult:
+		result.Content = taskResult.Content
+		result.StructuredContent = taskResult.StructuredContent
+		result.IsError = taskResult.IsError
+		mergeTaskResultMeta(result, taskResult.Meta)
 	}
 
 	return result, nil
+}
+
+func mergeTaskResultMeta(result *mcp.TaskResultResult, meta *mcp.Meta) {
+	if meta == nil {
+		return
+	}
+
+	if result.Meta.AdditionalFields == nil {
+		result.Meta.AdditionalFields = make(map[string]any)
+	}
+
+	for k, v := range meta.AdditionalFields {
+		if k != mcp.RelatedTaskMetaKey {
+			result.Meta.AdditionalFields[k] = v
+		}
+	}
 }
 
 // handleCancelTask handles tasks/cancel requests to cancel a task.


### PR DESCRIPTION
## Summary

- preserve deferred tool payload fields on CreateTaskResult for task tools
- return deferred payload from tasks/result for AddTaskTool paths as well as CallToolResult paths
- keep related-task metadata merge behavior shared across both result types

## Verification

- go test ./server ./mcp

Closes #748

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Task result handling now carries richer in-memory content and an explicit error flag while preserving existing JSON payload behavior.
  * Metadata from stored task results is merged consistently into responses, improving accuracy of result context.
* **Bug Fixes**
  * Fixed inconsistent metadata merging across different task result types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->