### PR TITLE
fix: close done channel on nil response to prevent goroutine leak

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -479,8 +479,14 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	// Process message through MCPServer
 	response := s.server.HandleMessage(ctx, rawData)
 	if response == nil {
-		// For notifications, just send 202 Accepted with no body
-		w.WriteHeader(http.StatusAccepted)
+		mu.Lock()
+		close(done)
+		if !upgradedHeader {
+			mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+		} else {
+			mu.Unlock()
+		}
 		return
 	}
 

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2840,3 +2840,36 @@ func TestStreamableHTTP_SessionIdleTTLSweeper(t *testing.T) {
 		assert.False(t, hasActiveSession, "activeSessions should be cleaned after DELETE")
 	})
 }
+
+func TestStreamableHTTPNotificationRace(t *testing.T) {
+	s := NewMCPServer("test-server", "1.0")
+	s.AddNotificationHandler("notifications/initialized", func(ctx context.Context, _ mcp.JSONRPCNotification) {
+		session := ClientSessionFromContext(ctx)
+		session.NotificationChannel() <- mcp.JSONRPCNotification{
+			JSONRPC:      mcp.JSONRPC_VERSION,
+			Notification: mcp.Notification{Method: "server/ping"},
+		}
+	})
+
+	hs := NewStreamableHTTPServer(s,
+		WithSessionIdManager(&StatelessSessionIdManager{}),
+	)
+
+	ts := httptest.NewServer(hs)
+	defer ts.Close()
+
+	client := &http.Client{Transport: &http.Transport{DisableKeepAlives: true}}
+	body := `{"jsonrpc":"2.0","method":"notifications/initialized"}`
+
+	for i := range 200 {
+		resp, err := client.Post(ts.URL+"/mcp", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("iteration %d: %v", i, err)
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusAccepted && resp.StatusCode != http.StatusOK {
+			t.Fatalf("iteration %d: expected 200 or 202, got %d", i, resp.StatusCode)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes a race condition panic in `handlePost` when processing notifications (nil responses).

When `HandleMessage` returns `nil` (e.g. for `notifications/initialized`), the handler sent 202 and returned without closing the `done` channel. The background notification pump goroutine kept running and could write to a dead `ResponseWriter`, causing panics like:

- `http: superfluous response.WriteHeader call`
- `panic: nil pointer dereference` in `bufio.(*Writer).Flush`

The fix closes the `done` channel under the mutex before returning, matching the pattern already used in the non-nil response path. Also checks `upgradedHeader` to avoid a superfluous `WriteHeader` if the goroutine already wrote SSE headers.

Includes a race-detector test (`TestStreamableHTTPNotificationRace`) that reproduces the issue.

Fixes #763

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a race condition in notification handling that could cause response conflicts, ensuring reliable notification delivery without conflicting writes to the HTTP response.
* **Tests**
  * Added a regression test to verify notification handling under concurrent conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->