### PR TITLE
docs: add optional hardening example for downstream servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - uses: aak204/MCP-Trust-Kit@v0.4.0
+      - uses: aak204/MCP-Trust-Kit@5d37f99e3cdfd703e4fe75aa88969475d1970e28
         with:
           cmd: go run ./cmd/your-server
           sarif-out: mcp-trust.sarif

--- a/README.md
+++ b/README.md
@@ -647,6 +647,32 @@ Key examples include:
 - [`examples/task_tool/`](examples/task_tool/) - Demonstrates task-augmented tools with TaskSupportRequired and TaskSupportOptional modes
 - Additional examples covering resources, prompts, and more in the examples directory
 
+### Optional CI hardening for downstream servers
+
+If you maintain an MCP server built with `mcp-go`, the following workflow is a small optional starting point for running a manual surface-risk check in your own repository:
+
+```yaml
+name: Optional MCP hardening
+
+on:
+  workflow_dispatch:
+
+jobs:
+  hardening:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - uses: aak204/MCP-Trust-Kit@v0.4.0
+        with:
+          cmd: go run ./cmd/your-server
+          sarif-out: mcp-trust.sarif
+```
+
+The action also produces SARIF output, so downstream repositories can upload it in a separate step if they already use code scanning.
+
 ## Extras
 
 ### Transports


### PR DESCRIPTION
## Description

This docs-only PR adds a small optional CI hardening example for downstream MCP servers built with `mcp-go`.

Fixes #<issue_number> (if applicable)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

- optional example for downstream repos only
- does not modify this repository's workflows or code
- the action reference is pinned to an immutable commit SHA
- tests are not applicable because this change only updates the README
- example tool: https://github.com/aak204/MCP-Trust-Kit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added optional CI hardening guidance for downstream servers using a manually-triggered GitHub Actions workflow.
  * Included a sample workflow snippet showing how to run security checks and generate SARIF output that downstream repositories can upload via existing code scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->