### PR TITLE
fix(transport): preserve OAuth discovery paths

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -375,8 +375,11 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 			return
 		}
 
-		// Try to fetch the OAuth Protected Resource metadata
-		protectedResourceURL := baseURL + "/.well-known/oauth-protected-resource"
+		protectedResourceURL, err := buildWellKnownURL(baseURL, "oauth-protected-resource")
+		if err != nil {
+			h.metadataFetchErr = fmt.Errorf("failed to build protected resource URL: %w", err)
+			return
+		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, protectedResourceURL, nil)
 		if err != nil {
 			h.metadataFetchErr = fmt.Errorf("failed to create protected resource request: %w", err)
@@ -395,7 +398,12 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 
 		// If we can't get the protected resource metadata, try OAuth Authorization Server discovery
 		if resp.StatusCode != http.StatusOK {
-			h.fetchMetadataFromURL(ctx, baseURL+"/.well-known/oauth-authorization-server")
+			authMetadataURL, err := buildWellKnownURL(baseURL, "oauth-authorization-server")
+			if err != nil {
+				h.metadataFetchErr = fmt.Errorf("failed to build authorization server metadata URL: %w", err)
+				return
+			}
+			h.fetchMetadataFromURL(ctx, authMetadataURL)
 			if h.serverMetadata != nil {
 				return
 			}
@@ -431,13 +439,23 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		authServerURL := protectedResource.AuthorizationServers[0]
 
 		// Try OAuth Authorization Server Metadata first
-		h.fetchMetadataFromURL(ctx, authServerURL+"/.well-known/oauth-authorization-server")
+		authMetadataURL, err := buildWellKnownURL(authServerURL, "oauth-authorization-server")
+		if err != nil {
+			h.metadataFetchErr = fmt.Errorf("failed to build authorization server metadata URL: %w", err)
+			return
+		}
+		h.fetchMetadataFromURL(ctx, authMetadataURL)
 		if h.serverMetadata != nil {
 			return
 		}
 
 		// If OAuth Authorization Server Metadata discovery fails, try OpenID Connect discovery
-		h.fetchMetadataFromURL(ctx, authServerURL+"/.well-known/openid-configuration")
+		openidMetadataURL, err := buildWellKnownURL(authServerURL, "openid-configuration")
+		if err != nil {
+			h.metadataFetchErr = fmt.Errorf("failed to build openid metadata URL: %w", err)
+			return
+		}
+		h.fetchMetadataFromURL(ctx, openidMetadataURL)
 		if h.serverMetadata != nil {
 			return
 		}
@@ -456,6 +474,25 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 	}
 
 	return h.serverMetadata, nil
+}
+
+func buildWellKnownURL(baseURL string, suffix string) (string, error) {
+	parsedURL, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse base URL: %w", err)
+	}
+
+	if parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return "", fmt.Errorf("invalid base URL: missing scheme or host in %q", baseURL)
+	}
+
+	path := strings.TrimSuffix(parsedURL.EscapedPath(), "/")
+	root := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+	if path == "" || path == "/" {
+		return root + "/.well-known/" + suffix, nil
+	}
+
+	return root + "/.well-known/" + suffix + path, nil
 }
 
 // fetchMetadataFromURL fetches and parses OAuth server metadata from a URL

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -945,6 +945,50 @@ func TestOAuthHandler_GetServerMetadata_FallbackToDefaultEndpoints(t *testing.T)
 	}
 }
 
+func TestOAuthHandler_GetServerMetadata_PathAwareDiscovery(t *testing.T) {
+	protectedResourceRequested := false
+	authServerRequested := false
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource/googledrive":
+			protectedResourceRequested = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OAuthProtectedResource{
+				AuthorizationServers: []string{server.URL + "/oauth/googledrive"},
+			})
+		case "/.well-known/oauth-authorization-server/oauth/googledrive":
+			authServerRequested = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+				Issuer:                server.URL + "/oauth/googledrive",
+				AuthorizationEndpoint: server.URL + "/oauth/googledrive/authorize",
+				TokenEndpoint:         server.URL + "/oauth/googledrive/token",
+				RegistrationEndpoint:  server.URL + "/oauth/googledrive/register",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  NewMemoryTokenStore(),
+	})
+	handler.SetBaseURL(server.URL + "/googledrive")
+
+	metadata, err := handler.GetServerMetadata(context.Background())
+	require.NoError(t, err)
+	assert.True(t, protectedResourceRequested)
+	assert.True(t, authServerRequested)
+	assert.Equal(t, server.URL+"/oauth/googledrive", metadata.Issuer)
+	assert.Equal(t, server.URL+"/oauth/googledrive/authorize", metadata.AuthorizationEndpoint)
+	assert.Equal(t, server.URL+"/oauth/googledrive/token", metadata.TokenEndpoint)
+}
+
 // TestOAuthHandler_RefreshToken_GitHubErrorIn200Response tests that we properly detect
 // GitHub's non-spec-compliant behavior of returning HTTP 200 with error details in the JSON body
 func TestOAuthHandler_RefreshToken_GitHubErrorIn200Response(t *testing.T) {

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -206,7 +206,7 @@ func TestOAuthHandler_GetServerMetadata_EmptyURL(t *testing.T) {
 	// Create an OAuth handler with an empty AuthServerMetadataURL
 	config := OAuthConfig{
 		ClientID:              "test-client",
-		RedirectURI:           "http://localhost:8085/callback",
+		RedirectURI:           "",
 		Scopes:                []string{"mcp.read"},
 		TokenStore:            NewMemoryTokenStore(),
 		AuthServerMetadataURL: "", // Empty URL
@@ -221,11 +221,9 @@ func TestOAuthHandler_GetServerMetadata_EmptyURL(t *testing.T) {
 		t.Fatalf("Expected error when getting server metadata with empty URL")
 	}
 
-	// Verify the error message contains something about a connection error
-	// since we're now trying to connect to the well-known endpoint
-	if !strings.Contains(err.Error(), "connection refused") &&
-		!strings.Contains(err.Error(), "failed to send protected resource request") {
-		t.Errorf("Expected error message to contain connection error, got %s", err.Error())
+	if !strings.Contains(err.Error(), "failed to extract base URL") &&
+		!strings.Contains(err.Error(), "no base URL available") {
+		t.Errorf("Expected error message to mention missing base URL, got %s", err.Error())
 	}
 }
 

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -113,9 +113,10 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 
 	// If OAuth is configured, set the base URL for metadata discovery
 	if smc.oauthHandler != nil {
-		parsedURL.RawQuery = ""
-		parsedURL.Fragment = ""
-		baseURL := parsedURL.String()
+		discoveryURL := *parsedURL
+		discoveryURL.RawQuery = ""
+		discoveryURL.Fragment = ""
+		baseURL := discoveryURL.String()
 		smc.oauthHandler.SetBaseURL(baseURL)
 	}
 

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -113,8 +113,9 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 
 	// If OAuth is configured, set the base URL for metadata discovery
 	if smc.oauthHandler != nil {
-		// Extract base URL from server URL for metadata discovery
-		baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+		parsedURL.RawQuery = ""
+		parsedURL.Fragment = ""
+		baseURL := parsedURL.String()
 		smc.oauthHandler.SetBaseURL(baseURL)
 	}
 

--- a/client/transport/sse_oauth_test.go
+++ b/client/transport/sse_oauth_test.go
@@ -239,3 +239,20 @@ func TestSSE_IsOAuthEnabled(t *testing.T) {
 		t.Errorf("Expected IsOAuthEnabled() to return true")
 	}
 }
+
+func TestSSE_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
+	transport, err := NewSSE("https://example.com/googledrive", WithOAuth(OAuthConfig{
+		ClientID: "test-client",
+	}))
+	if err != nil {
+		t.Fatalf("Failed to create SSE: %v", err)
+	}
+
+	if transport.GetOAuthHandler() == nil {
+		t.Fatalf("Expected GetOAuthHandler() to return a handler")
+	}
+
+	if transport.GetOAuthHandler().baseURL != "https://example.com/googledrive" {
+		t.Errorf("Expected OAuth base URL to preserve path, got %q", transport.GetOAuthHandler().baseURL)
+	}
+}

--- a/client/transport/sse_oauth_test.go
+++ b/client/transport/sse_oauth_test.go
@@ -241,7 +241,7 @@ func TestSSE_IsOAuthEnabled(t *testing.T) {
 }
 
 func TestSSE_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
-	transport, err := NewSSE("https://example.com/googledrive", WithOAuth(OAuthConfig{
+	transport, err := NewSSE("https://example.com/googledrive?foo=bar#frag", WithOAuth(OAuthConfig{
 		ClientID: "test-client",
 	}))
 	if err != nil {
@@ -254,5 +254,9 @@ func TestSSE_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
 
 	if transport.GetOAuthHandler().baseURL != "https://example.com/googledrive" {
 		t.Errorf("Expected OAuth base URL to preserve path, got %q", transport.GetOAuthHandler().baseURL)
+	}
+
+	if transport.baseURL.String() != "https://example.com/googledrive?foo=bar#frag" {
+		t.Errorf("Expected transport base URL to retain query and fragment, got %q", transport.baseURL.String())
 	}
 }

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -162,9 +162,10 @@ func NewStreamableHTTP(serverURL string, options ...StreamableHTTPCOption) (*Str
 
 	// If OAuth is configured, set the base URL for metadata discovery
 	if smc.oauthHandler != nil {
-		parsedURL.RawQuery = ""
-		parsedURL.Fragment = ""
-		baseURL := parsedURL.String()
+		discoveryURL := *parsedURL
+		discoveryURL.RawQuery = ""
+		discoveryURL.Fragment = ""
+		baseURL := discoveryURL.String()
 		smc.oauthHandler.SetBaseURL(baseURL)
 	}
 

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -162,8 +162,9 @@ func NewStreamableHTTP(serverURL string, options ...StreamableHTTPCOption) (*Str
 
 	// If OAuth is configured, set the base URL for metadata discovery
 	if smc.oauthHandler != nil {
-		// Extract base URL from server URL for metadata discovery
-		baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
+		parsedURL.RawQuery = ""
+		parsedURL.Fragment = ""
+		baseURL := parsedURL.String()
 		smc.oauthHandler.SetBaseURL(baseURL)
 	}
 

--- a/client/transport/streamable_http_oauth_test.go
+++ b/client/transport/streamable_http_oauth_test.go
@@ -220,7 +220,7 @@ func TestStreamableHTTP_IsOAuthEnabled(t *testing.T) {
 }
 
 func TestStreamableHTTP_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
-	transport, err := NewStreamableHTTP("https://example.com/googledrive", WithHTTPOAuth(OAuthConfig{
+	transport, err := NewStreamableHTTP("https://example.com/googledrive?foo=bar#frag", WithHTTPOAuth(OAuthConfig{
 		ClientID: "test-client",
 	}))
 	if err != nil {
@@ -233,5 +233,9 @@ func TestStreamableHTTP_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
 
 	if transport.GetOAuthHandler().baseURL != "https://example.com/googledrive" {
 		t.Errorf("Expected OAuth base URL to preserve path, got %q", transport.GetOAuthHandler().baseURL)
+	}
+
+	if transport.serverURL.String() != "https://example.com/googledrive?foo=bar#frag" {
+		t.Errorf("Expected transport server URL to retain query and fragment, got %q", transport.serverURL.String())
 	}
 }

--- a/client/transport/streamable_http_oauth_test.go
+++ b/client/transport/streamable_http_oauth_test.go
@@ -218,3 +218,20 @@ func TestStreamableHTTP_IsOAuthEnabled(t *testing.T) {
 		t.Errorf("Expected IsOAuthEnabled() to return true")
 	}
 }
+
+func TestStreamableHTTP_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
+	transport, err := NewStreamableHTTP("https://example.com/googledrive", WithHTTPOAuth(OAuthConfig{
+		ClientID: "test-client",
+	}))
+	if err != nil {
+		t.Fatalf("Failed to create StreamableHTTP: %v", err)
+	}
+
+	if transport.GetOAuthHandler() == nil {
+		t.Fatalf("Expected GetOAuthHandler() to return a handler")
+	}
+
+	if transport.GetOAuthHandler().baseURL != "https://example.com/googledrive" {
+		t.Errorf("Expected OAuth base URL to preserve path, got %q", transport.GetOAuthHandler().baseURL)
+	}
+}


### PR DESCRIPTION
## Summary

- keep OAuth discovery path segments intact for both SSE and streamable HTTP transports instead of collapsing to the origin root
- avoid mutating the client transport URLs while still deriving the correct well-known discovery endpoints
- stabilize the empty-metadata regression test so it no longer depends on ambient localhost services

## End-user benefit

Servers that expose OAuth discovery under a path prefix (for example `/oauth/googledrive`) currently fail because the client strips the path before probing `/.well-known/...`. This fix preserves the path, so OAuth discovery works for path-scoped providers without breaking the transport's original URL.

## Testing

- `go test ./client/... ./examples/oauth_client/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved OAuth server metadata discovery to properly handle URLs with path components and query parameters.
  * Enhanced URL validation and error handling during OAuth discovery initialization.
* **Tests**
  * Added tests validating path-aware OAuth discovery and URL component handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->