### PR TITLE
fix: extract and set _meta field in ParseContent

### DIFF
--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -581,6 +581,9 @@ func ExtractMap(data map[string]any, key string) map[string]any {
 	return nil
 }
 
+// ParseContent parses a generic map into a strongly-typed Content value.
+// It extracts annotations and _meta fields from the map and sets them on
+// the returned content type.
 func ParseContent(contentMap map[string]any) (Content, error) {
 	contentType := ExtractString(contentMap, "type")
 
@@ -589,11 +592,17 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 		annotations = ParseAnnotations(annotationsMap)
 	}
 
+	var meta *Meta
+	if metaMap := ExtractMap(contentMap, "_meta"); metaMap != nil {
+		meta = NewMetaFromMap(metaMap)
+	}
+
 	switch contentType {
 	case ContentTypeText:
 		text := ExtractString(contentMap, "text")
 		c := NewTextContent(text)
 		c.Annotations = annotations
+		c.Meta = meta
 		return c, nil
 
 	case ContentTypeImage:
@@ -604,6 +613,7 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 		}
 		c := NewImageContent(data, mimeType)
 		c.Annotations = annotations
+		c.Meta = meta
 		return c, nil
 
 	case ContentTypeAudio:
@@ -614,6 +624,7 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 		}
 		c := NewAudioContent(data, mimeType)
 		c.Annotations = annotations
+		c.Meta = meta
 		return c, nil
 
 	case ContentTypeLink:
@@ -641,6 +652,7 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 
 		c := NewEmbeddedResource(resourceContents)
 		c.Annotations = annotations
+		c.Meta = meta
 		return c, nil
 	}
 

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -301,6 +301,120 @@ func TestParseContent(t *testing.T) {
 			expected:    nil,
 			expectError: true,
 		},
+		{
+			name: "text content with _meta",
+			contentMap: map[string]any{
+				"type": "text",
+				"text": "Hello, world!",
+				"_meta": map[string]any{
+					"source_url": "https://example.com",
+				},
+			},
+			expected: TextContent{
+				Type: ContentTypeText,
+				Text: "Hello, world!",
+				Meta: &Meta{
+					AdditionalFields: map[string]any{
+						"source_url": "https://example.com",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "image content with _meta",
+			contentMap: map[string]any{
+				"type":     "image",
+				"data":     "base64data",
+				"mimeType": "image/png",
+				"_meta": map[string]any{
+					"source": "camera",
+				},
+			},
+			expected: ImageContent{
+				Type:     ContentTypeImage,
+				Data:     "base64data",
+				MIMEType: "image/png",
+				Meta: &Meta{
+					AdditionalFields: map[string]any{
+						"source": "camera",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "audio content with _meta",
+			contentMap: map[string]any{
+				"type":     "audio",
+				"data":     "base64data",
+				"mimeType": "audio/mp3",
+				"_meta": map[string]any{
+					"duration": 120.5,
+				},
+			},
+			expected: AudioContent{
+				Type:     ContentTypeAudio,
+				Data:     "base64data",
+				MIMEType: "audio/mp3",
+				Meta: &Meta{
+					AdditionalFields: map[string]any{
+						"duration": 120.5,
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "embedded resource with _meta",
+			contentMap: map[string]any{
+				"type": "resource",
+				"resource": map[string]any{
+					"uri":      "file:///test.txt",
+					"mimeType": "text/plain",
+					"text":     "Hello, world!",
+				},
+				"_meta": map[string]any{
+					"version": "1.0",
+				},
+			},
+			expected: EmbeddedResource{
+				Type: ContentTypeResource,
+				Resource: TextResourceContents{
+					URI:      "file:///test.txt",
+					MIMEType: "text/plain",
+					Text:     "Hello, world!",
+				},
+				Meta: &Meta{
+					AdditionalFields: map[string]any{
+						"version": "1.0",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "text content with _meta containing progressToken",
+			contentMap: map[string]any{
+				"type": "text",
+				"text": "data",
+				"_meta": map[string]any{
+					"progressToken": "tok-123",
+					"custom_field":  "value",
+				},
+			},
+			expected: TextContent{
+				Type: ContentTypeText,
+				Text: "data",
+				Meta: &Meta{
+					ProgressToken: "tok-123",
+					AdditionalFields: map[string]any{
+						"custom_field": "value",
+					},
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -321,6 +435,7 @@ func TestParseContent(t *testing.T) {
 					assert.Equal(t, exp.Type, act.Type)
 					assert.Equal(t, exp.Text, act.Text)
 					assert.Equal(t, exp.Annotations, act.Annotations)
+					assert.Equal(t, exp.Meta, act.Meta)
 				case ImageContent:
 					act, ok := result.(ImageContent)
 					assert.True(t, ok)
@@ -328,6 +443,7 @@ func TestParseContent(t *testing.T) {
 					assert.Equal(t, exp.Data, act.Data)
 					assert.Equal(t, exp.MIMEType, act.MIMEType)
 					assert.Equal(t, exp.Annotations, act.Annotations)
+					assert.Equal(t, exp.Meta, act.Meta)
 				case AudioContent:
 					act, ok := result.(AudioContent)
 					assert.True(t, ok)
@@ -335,6 +451,7 @@ func TestParseContent(t *testing.T) {
 					assert.Equal(t, exp.Data, act.Data)
 					assert.Equal(t, exp.MIMEType, act.MIMEType)
 					assert.Equal(t, exp.Annotations, act.Annotations)
+					assert.Equal(t, exp.Meta, act.Meta)
 				case ResourceLink:
 					act, ok := result.(ResourceLink)
 					assert.True(t, ok)
@@ -350,6 +467,7 @@ func TestParseContent(t *testing.T) {
 					assert.Equal(t, exp.Type, act.Type)
 					assert.Equal(t, exp.Resource, act.Resource)
 					assert.Equal(t, exp.Annotations, act.Annotations)
+					assert.Equal(t, exp.Meta, act.Meta)
 				default:
 					assert.Equal(t, tt.expected, result)
 				}


### PR DESCRIPTION
## Description

`ParseContent` extracts `annotations` from content maps but skips `_meta`, silently dropping metadata on `TextContent`, `ImageContent`, `AudioContent`, and `EmbeddedResource` when clients parse tool call results via `ParseCallToolResult` → `ParseContent`.

The fix extracts `_meta` alongside `annotations` using `ExtractMap` + `NewMetaFromMap` and sets `c.Meta` on all content types that define a `Meta` field. `ResourceLink` is skipped since it does not have one. This follows the same pattern already used correctly in `ParseResourceContents`.

Fixes #776

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

The `UnmarshalContent` path (which uses `json.Unmarshal`) was already preserving `_meta` correctly — only the `ParseContent` manual-construction path was affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Content objects now support metadata. Text, Image, Audio, and Resource content types can parse and attach metadata information, including progress tokens and custom fields for enhanced tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->