### PR TITLE
Bound stdio child shutdown in Close()

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -18,9 +18,14 @@ import (
 	"github.com/mark3labs/mcp-go/util"
 )
 
-// ErrTransportClosed is returned when attempting to send a request or notification
-// to a transport that has already been closed.
-var ErrTransportClosed = errors.New("transport closed")
+var (
+	// ErrTransportClosed is returned when attempting to send a request or notification
+	// to a transport that has already been closed.
+	ErrTransportClosed = errors.New("transport closed")
+	// ErrChildShutdownTimeout is returned when a stdio subprocess still has not exited
+	// after the forced shutdown path has been attempted.
+	ErrChildShutdownTimeout = errors.New("stdio child did not exit after forced shutdown")
+)
 
 // Stdio implements the transport layer of the MCP protocol using stdio communication.
 // It launches a subprocess and communicates with it via standard input/output streams
@@ -56,6 +61,15 @@ const (
 	gracefulShutdownTimeout = 2 * time.Second
 	forceKillTimeout        = 3 * time.Second
 )
+
+func waitForProcessExit(waitErrCh <-chan error, timeout time.Duration) (error, bool) {
+	select {
+	case err := <-waitErrCh:
+		return err, true
+	case <-time.After(timeout):
+		return nil, false
+	}
+}
 
 // StdioOption defines a function that configures a Stdio transport instance.
 // Options can be used to customize the behavior of the transport before it starts,
@@ -250,34 +264,36 @@ func (c *Stdio) Close() error {
 				waitErrCh <- c.cmd.Wait()
 			}()
 
-			select {
-			case err := <-waitErrCh:
+			if err, done := waitForProcessExit(waitErrCh, gracefulShutdownTimeout); done {
 				if err != nil && closeErr == nil {
 					closeErr = err
 				}
 				return
-			case <-time.After(gracefulShutdownTimeout):
 			}
 
 			if c.cmd.Process != nil {
 				_ = c.cmd.Process.Signal(syscall.SIGTERM)
 			}
 
-			select {
-			case err := <-waitErrCh:
+			if err, done := waitForProcessExit(waitErrCh, forceKillTimeout); done {
 				if err != nil && closeErr == nil {
 					closeErr = err
 				}
 				return
-			case <-time.After(forceKillTimeout):
 			}
 
 			if c.cmd.Process != nil {
-				_ = c.cmd.Process.Kill()
+				if err := c.cmd.Process.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) && closeErr == nil {
+					closeErr = fmt.Errorf("failed to kill process: %w", err)
+				}
 			}
 
-			if err := <-waitErrCh; err != nil && closeErr == nil {
-				closeErr = err
+			if err, done := waitForProcessExit(waitErrCh, forceKillTimeout); done {
+				if err != nil && closeErr == nil {
+					closeErr = err
+				}
+			} else if closeErr == nil {
+				closeErr = ErrChildShutdownTimeout
 			}
 		}
 	})

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -740,31 +740,80 @@ func TestStdio_SpawnCommand_UsesCommandFunc_Error(t *testing.T) {
 	require.EqualError(t, err, "test error")
 }
 
-func TestStdio_Close_TerminatesChildThatIgnoresStdinClose(t *testing.T) {
+func TestStdio_Close_ShutsDownHungChild(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("signal-based shutdown test is not supported on Windows")
 	}
 
-	stdio := NewStdio("sh", nil, "-c", "trap 'exit 0' TERM; while :; do sleep 1; done")
-	require.NotNil(t, stdio)
+	deadline := gracefulShutdownTimeout + forceKillTimeout + 2*time.Second
+	tests := []struct {
+		name          string
+		script        string
+		wantErr       bool
+		wantForceKill bool
+	}{
+		{
+			name:          "exits_on_sigterm",
+			script:        "trap 'exit 0' TERM; while :; do sleep 1; done",
+			wantErr:       false,
+			wantForceKill: false,
+		},
+		{
+			name:          "requires_sigkill",
+			script:        "trap '' TERM; while :; do sleep 1; done",
+			wantErr:       true,
+			wantForceKill: true,
+		},
+	}
 
-	err := stdio.spawnCommand(context.Background())
-	require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdio := NewStdio("sh", nil, "-c", tt.script)
+			require.NotNil(t, stdio)
 
-	t.Cleanup(func() {
-		if stdio.cmd != nil && stdio.cmd.Process != nil {
-			_ = stdio.cmd.Process.Kill()
-		}
-	})
+			err := stdio.spawnCommand(context.Background())
+			require.NoError(t, err)
 
-	start := time.Now()
-	err = stdio.Close()
-	elapsed := time.Since(start)
+			t.Cleanup(func() {
+				if stdio.cmd != nil && stdio.cmd.Process != nil {
+					_ = stdio.cmd.Process.Kill()
+				}
+			})
 
-	require.NoError(t, err)
-	require.Less(t, elapsed, gracefulShutdownTimeout+forceKillTimeout+time.Second)
-	require.NotNil(t, stdio.cmd.ProcessState)
-	require.True(t, stdio.cmd.ProcessState.Exited())
+			closeErrCh := make(chan error, 1)
+			start := time.Now()
+			go func() {
+				closeErrCh <- stdio.Close()
+			}()
+
+			var closeErr error
+			select {
+			case closeErr = <-closeErrCh:
+			case <-time.After(deadline):
+				t.Fatalf("Close() did not return within %s", deadline)
+			}
+
+			elapsed := time.Since(start)
+			if tt.wantErr {
+				require.Error(t, closeErr)
+			} else {
+				require.NoError(t, closeErr)
+			}
+			if tt.wantForceKill {
+				require.NotErrorIs(t, closeErr, ErrChildShutdownTimeout)
+			}
+			if tt.wantForceKill {
+				require.GreaterOrEqual(t, elapsed, gracefulShutdownTimeout+forceKillTimeout)
+			} else {
+				require.Less(t, elapsed, gracefulShutdownTimeout+forceKillTimeout)
+			}
+			require.Less(t, elapsed, deadline)
+			require.NotNil(t, stdio.cmd.ProcessState)
+			if !tt.wantForceKill {
+				require.True(t, stdio.cmd.ProcessState.Exited())
+			}
+		})
+	}
 }
 
 func TestStdio_NewStdioWithOptions_AppliesOptions(t *testing.T) {


### PR DESCRIPTION
## Summary

- bound stdio child shutdown in `Close()` instead of waiting forever after stdin closes
- fall back to `SIGTERM` and then `SIGKILL` when the child stays alive
- add regression coverage for a child process that ignores stdin close

## Why

In a stateless stdio flow, `CallTool` can succeed and the child can still remain alive after the client closes stdin. In that case the current `Close()` blocks indefinitely in `Wait()`, which means callers never receive the successful result.

I reproduced this against `n8n-mcp` through `mcpjungle`, and also with a smaller local repro using a child process that keeps running until signaled.

## Testing

- `go test ./client/transport`

Fixes #783

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess shutdown: attempts graceful stop (2s), then escalates to forced termination (3s) and reports a clear timeout error if the child still doesn't exit.
* **Tests**
  * Added tests covering hung-subprocess shutdown scenarios to verify timing, error reporting, and resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->