### PR TITLE
fix(client/http_streamable): exit ContinuousListening goroutine on context cancellation

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -191,6 +191,8 @@ func (c *StreamableHTTP) Start(ctx context.Context) error {
 				c.listenForever(ctx)
 			case <-c.closed:
 				return
+			case <-ctx.Done():
+				return
 			}
 		}()
 	}

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1322,6 +1323,54 @@ func TestSendRequestSSEStreamStaysOpen(t *testing.T) {
 	resp2, err := trans.SendRequest(ctx, echoReq)
 	require.NoError(t, err, "Second request should not hang even though SSE streams stay open")
 	require.NotNil(t, resp2)
+}
+
+// TestContinuousListeningGoroutineExitsOnContextCancel verifies that the goroutine
+// spawned by WithContinuousListening exits when the context passed to Start() is
+// cancelled, even if Initialize never succeeds.
+func TestContinuousListeningGoroutineExitsOnContextCancel(t *testing.T) {
+	origRetryInterval := retryInterval
+	retryInterval = 10 * time.Millisecond
+	t.Cleanup(func() { retryInterval = origRetryInterval })
+
+	// Server that always rejects requests, so Initialize never succeeds.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"jsonrpc":"2.0","id":"1","error":{"code":-32600,"message":"Bad Request"}}`, http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	const cycles = 5
+	before := runtime.NumGoroutine()
+
+	for range cycles {
+		trans, err := NewStreamableHTTP(srv.URL, WithContinuousListening())
+		require.NoError(t, err)
+
+		startCtx, cancel := context.WithCancel(context.Background())
+
+		err = trans.Start(startCtx)
+		require.NoError(t, err)
+
+		// Attempt Initialize — it will fail because the server returns 400.
+		initReq := JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      mcp.NewRequestId(int64(1)),
+			Method:  "initialize",
+		}
+		_, err = trans.SendRequest(startCtx, initReq)
+		require.Error(t, err)
+
+		// Cancel the context. This should be sufficient to release the goroutine
+		// spawned in Start(), without requiring an explicit Close() call.
+		cancel()
+	}
+
+	// Poll until goroutines settle, to avoid a flaky single-snapshot check.
+	allowed := 1
+	require.Eventually(t, func() bool {
+		runtime.Gosched()
+		return runtime.NumGoroutine()-before <= allowed
+	}, 5*time.Second, 50*time.Millisecond, "goroutines leaked beyond allowed=%d (ran %d cycles)", allowed, cycles)
 }
 
 // TestSendRequestSSEStreamStaysOpenWithContinuousListening is the same as above but


### PR DESCRIPTION
## Description

The goroutine spawned by WithContinuousListening() in Start() only selected on c.initialized and c.closed, ignoring ctx.Done(). If initialization never succeeded and   Close() was not called, the goroutine leaked indefinitely.

Add ctx.Done() as a third select case so that cancelling the context passed to Start() is sufficient to release the goroutine, consistent with how the SSE transport handles cancellation.

Fixes goroutine leak when Initialize fails and Close() is not called.

Fixes #789, please let me know if you'd like any changes!

## Type of Change

<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (N/A)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Background HTTP streaming listener now stops immediately when an operation's context is cancelled, preventing lingering background work and improving cleanup and stability.
* **Tests**
  * Added a test that verifies the background listener exits on context cancellation to prevent goroutine/resource leaks across repeated start/cancel cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->