### PR TITLE
fix: add RFC 8707 resource parameter to OAuth requests

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -144,6 +144,7 @@ type OAuthHandler struct {
 	metadataFetchErr error
 	metadataOnce     sync.Once
 	baseURL          string
+	resourceURL      string // RFC 8707 resource indicator; set from protected resource metadata
 
 	mu            sync.RWMutex // Protects expectedState
 	expectedState string       // Expected state value for CSRF protection
@@ -216,6 +217,10 @@ func (h *OAuthHandler) refreshToken(ctx context.Context, refreshToken string) (*
 	data.Set("client_id", h.config.ClientID)
 	if h.config.ClientSecret != "" {
 		data.Set("client_secret", h.config.ClientSecret)
+	}
+	// RFC 8707: Include resource parameter on refresh requests
+	if h.resourceURL != "" {
+		data.Set("resource", h.resourceURL)
 	}
 
 	req, err := http.NewRequestWithContext(
@@ -411,6 +416,16 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		if err := json.NewDecoder(resp.Body).Decode(&protectedResource); err != nil {
 			h.metadataFetchErr = fmt.Errorf("failed to decode protected resource response: %w", err)
 			return
+		}
+
+		// RFC 8707: Capture the resource identifier for use in authorization requests.
+		// If not provided in metadata, fall back to base URL per RFC 8707 Section 2:
+		// "The client SHOULD use the base URI of the API as the resource parameter value
+		// unless specific knowledge of the resource dictates otherwise."
+		if protectedResource.Resource != "" {
+			h.resourceURL = protectedResource.Resource
+		} else {
+			h.resourceURL = baseURL
 		}
 
 		// If no authorization servers are specified, fall back to default endpoints
@@ -732,6 +747,11 @@ func (h *OAuthHandler) GetAuthorizationURL(ctx context.Context, state, codeChall
 	if h.config.PKCEEnabled && codeChallenge != "" {
 		params.Set("code_challenge", codeChallenge)
 		params.Set("code_challenge_method", "S256")
+	}
+
+	// RFC 8707: Include resource parameter in authorization URL
+	if h.resourceURL != "" {
+		params.Set("resource", h.resourceURL)
 	}
 
 	return metadata.AuthorizationEndpoint + "?" + params.Encode(), nil

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -581,6 +581,11 @@ func (h *OAuthHandler) RegisterClient(ctx context.Context, clientName string) er
 		regRequest["token_endpoint_auth_method"] = "client_secret_basic"
 	}
 
+	// RFC 8707: Include resource parameter in client registration
+	if h.resourceURL != "" {
+		regRequest["resource"] = h.resourceURL
+	}
+
 	reqBody, err := json.Marshal(regRequest)
 	if err != nil {
 		return fmt.Errorf("failed to marshal registration request: %w", err)
@@ -667,6 +672,11 @@ func (h *OAuthHandler) ProcessAuthorizationResponse(ctx context.Context, code, s
 
 	if h.config.PKCEEnabled && codeVerifier != "" {
 		data.Set("code_verifier", codeVerifier)
+	}
+
+	// RFC 8707: Include resource parameter in token exchange
+	if h.resourceURL != "" {
+		data.Set("resource", h.resourceURL)
 	}
 
 	req, err := http.NewRequestWithContext(

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -1381,3 +1381,284 @@ func TestOAuthHandler_RefreshToken_ProperHTTP400Error(t *testing.T) {
 	_, getErr := tokenStore.GetToken(ctx)
 	assert.ErrorIs(t, getErr, ErrNoToken, "No token should be saved after HTTP 400 error")
 }
+
+// TestOAuthHandler_RFC8707_ResourceParameter tests that the resource parameter
+// from protected resource metadata is included in OAuth requests per RFC 8707
+func TestOAuthHandler_RFC8707_ResourceParameter(t *testing.T) {
+	t.Run("resource parameter captured from protected resource metadata", func(t *testing.T) {
+		var server *httptest.Server
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				// Return protected resource metadata with resource field (RFC 9728)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"resource":              "https://api.example.com/mcp",
+					"authorization_servers": []string{server.URL},
+				})
+			case "/.well-known/oauth-authorization-server":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 server.URL,
+					"authorization_endpoint": server.URL + "/authorize",
+					"token_endpoint":         server.URL + "/token",
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		config := OAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: server.URL + "/callback",
+			TokenStore:  NewMemoryTokenStore(),
+			PKCEEnabled: true,
+		}
+
+		handler := NewOAuthHandler(config)
+		handler.SetBaseURL(server.URL)
+
+		// Trigger metadata discovery
+		_, err := handler.GetServerMetadata(context.Background())
+		require.NoError(t, err)
+
+		// Verify resourceURL was captured
+		assert.Equal(t, "https://api.example.com/mcp", handler.resourceURL)
+	})
+
+	t.Run("resource parameter falls back to baseURL when not in metadata", func(t *testing.T) {
+		var server *httptest.Server
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				// Return metadata WITHOUT resource field - should fall back to baseURL
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"authorization_servers": []string{server.URL},
+				})
+			case "/.well-known/oauth-authorization-server":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 server.URL,
+					"authorization_endpoint": server.URL + "/authorize",
+					"token_endpoint":         server.URL + "/token",
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		config := OAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: server.URL + "/callback",
+			TokenStore:  NewMemoryTokenStore(),
+		}
+
+		handler := NewOAuthHandler(config)
+		handler.SetBaseURL(server.URL)
+
+		// Trigger metadata discovery
+		_, err := handler.GetServerMetadata(context.Background())
+		require.NoError(t, err)
+
+		// Per RFC 8707 Section 2: "The client SHOULD use the base URI of the API
+		// as the resource parameter value unless specific knowledge of the resource
+		// dictates otherwise."
+		assert.Equal(t, server.URL, handler.resourceURL, "resourceURL should fall back to baseURL")
+	})
+
+	t.Run("resource parameter included in authorization URL", func(t *testing.T) {
+		var server *httptest.Server
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"resource":              "https://api.example.com/mcp",
+					"authorization_servers": []string{server.URL},
+				})
+			case "/.well-known/oauth-authorization-server":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 server.URL,
+					"authorization_endpoint": server.URL + "/authorize",
+					"token_endpoint":         server.URL + "/token",
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		config := OAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: server.URL + "/callback",
+			TokenStore:  NewMemoryTokenStore(),
+			PKCEEnabled: true,
+		}
+
+		handler := NewOAuthHandler(config)
+		handler.SetBaseURL(server.URL)
+
+		authURL, err := handler.GetAuthorizationURL(context.Background(), "test-state", "test-challenge")
+		require.NoError(t, err)
+
+		// Verify resource parameter is in the URL
+		assert.Contains(t, authURL, "resource=https%3A%2F%2Fapi.example.com%2Fmcp")
+	})
+
+	t.Run("resource parameter included in token exchange", func(t *testing.T) {
+		var capturedResource string
+		var server *httptest.Server
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"resource":              "https://api.example.com/mcp",
+					"authorization_servers": []string{server.URL},
+				})
+			case "/.well-known/oauth-authorization-server":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 server.URL,
+					"authorization_endpoint": server.URL + "/authorize",
+					"token_endpoint":         server.URL + "/token",
+				})
+			case "/token":
+				_ = r.ParseForm()
+				capturedResource = r.FormValue("resource")
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":  "test-access-token",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+					"refresh_token": "test-refresh-token",
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		config := OAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: server.URL + "/callback",
+			TokenStore:  NewMemoryTokenStore(),
+			PKCEEnabled: true,
+		}
+
+		handler := NewOAuthHandler(config)
+		handler.SetBaseURL(server.URL)
+		handler.SetExpectedState("test-state")
+
+		err := handler.ProcessAuthorizationResponse(context.Background(), "test-code", "test-state", "test-verifier")
+		require.NoError(t, err)
+
+		// Verify resource parameter was sent in token request
+		assert.Equal(t, "https://api.example.com/mcp", capturedResource)
+	})
+
+	t.Run("resource parameter included in refresh token request", func(t *testing.T) {
+		var capturedResource string
+		var server *httptest.Server
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"resource":              "https://api.example.com/mcp",
+					"authorization_servers": []string{server.URL},
+				})
+			case "/.well-known/oauth-authorization-server":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 server.URL,
+					"authorization_endpoint": server.URL + "/authorize",
+					"token_endpoint":         server.URL + "/token",
+				})
+			case "/token":
+				_ = r.ParseForm()
+				capturedResource = r.FormValue("resource")
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":  "new-access-token",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+					"refresh_token": "new-refresh-token",
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		config := OAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: server.URL + "/callback",
+			TokenStore:  NewMemoryTokenStore(),
+		}
+
+		handler := NewOAuthHandler(config)
+		handler.SetBaseURL(server.URL)
+
+		_, err := handler.RefreshToken(context.Background(), "old-refresh-token")
+		require.NoError(t, err)
+
+		// Verify resource parameter was sent in refresh request
+		assert.Equal(t, "https://api.example.com/mcp", capturedResource)
+	})
+
+	t.Run("baseURL used as resource when not in protected resource metadata", func(t *testing.T) {
+		var capturedResource string
+		var server *httptest.Server
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				// Return metadata WITHOUT resource field - per RFC 8707 Section 2,
+				// client SHOULD use baseURL as resource parameter
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"authorization_servers": []string{server.URL},
+				})
+			case "/.well-known/oauth-authorization-server":
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"issuer":                 server.URL,
+					"authorization_endpoint": server.URL + "/authorize",
+					"token_endpoint":         server.URL + "/token",
+				})
+			case "/token":
+				_ = r.ParseForm()
+				capturedResource = r.FormValue("resource")
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"access_token":  "test-access-token",
+					"token_type":    "Bearer",
+					"expires_in":    3600,
+					"refresh_token": "test-refresh-token",
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+
+		config := OAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: server.URL + "/callback",
+			TokenStore:  NewMemoryTokenStore(),
+		}
+
+		handler := NewOAuthHandler(config)
+		handler.SetBaseURL(server.URL)
+
+		_, err := handler.RefreshToken(context.Background(), "test-refresh-token")
+		require.NoError(t, err)
+
+		// Per RFC 8707 Section 2: resource SHOULD be sent, falling back to baseURL
+		assert.Equal(t, server.URL, capturedResource, "resource should fall back to baseURL")
+	})
+}


### PR DESCRIPTION
## Description

Add RFC 8707 Resource Indicators support to the OAuth implementation. The resource parameter is now included in authorization requests, token exchanges, and token refresh requests.

Previously, the resource field was parsed from the protected resource metadata (RFC 9728) but never used. This caused invalid_target errors when connecting to MCP servers that enforce RFC 8707.

## Type of Change

<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

<!-- If this PR implements a feature from the MCP specification, please answer the following -->

<!-- If not applicable, remove this section -->

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: https://www.rfc-editor.org/rfc/rfc8707.html
- [x] Implementation follows the specification exactly

## Additional Information

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RFC 8707 "resource" parameter support across OAuth flows—included in authorization URLs, token exchanges (authorization-code and refresh), and client registration—improving compatibility with protected-resource configurations.
* **Tests**
  * Added end-to-end tests validating discovery, authorization URL inclusion, token exchange, refresh behavior, and fallback when protected-resource metadata omits resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->