### PR TITLE
fix(client/transport): serialize stdin writes with mutex

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -39,6 +39,7 @@ type Stdio struct {
 	cmd              *exec.Cmd
 	cmdFunc          CommandFunc
 	stdin            io.WriteCloser
+	stdinMu          sync.Mutex
 	stdout           *bufio.Reader
 	stderr           io.ReadCloser
 	responses        map[string]chan *JSONRPCResponse
@@ -451,8 +452,13 @@ func (c *Stdio) SendRequest(
 		c.mu.Unlock()
 	}
 
-	// Send request
-	if _, err := c.stdin.Write(requestBytes); err != nil {
+	// Send request. stdinMu serializes frame writes so concurrent
+	// SendRequest/SendNotification/sendResponse calls cannot interleave
+	// JSON-RPC lines on the subprocess's stdin.
+	c.stdinMu.Lock()
+	_, err = c.stdin.Write(requestBytes)
+	c.stdinMu.Unlock()
+	if err != nil {
 		deleteResponseChan()
 		return nil, fmt.Errorf("failed to write request: %w", err)
 	}
@@ -499,7 +505,10 @@ func (c *Stdio) SendNotification(
 	}
 	notificationBytes = append(notificationBytes, '\n')
 
-	if _, err := c.stdin.Write(notificationBytes); err != nil {
+	c.stdinMu.Lock()
+	_, err = c.stdin.Write(notificationBytes)
+	c.stdinMu.Unlock()
+	if err != nil {
 		return fmt.Errorf("failed to write notification: %w", err)
 	}
 
@@ -562,7 +571,10 @@ func (c *Stdio) sendResponse(response JSONRPCResponse) {
 	}
 	responseBytes = append(responseBytes, '\n')
 
-	if _, err := c.stdin.Write(responseBytes); err != nil {
+	c.stdinMu.Lock()
+	_, err = c.stdin.Write(responseBytes)
+	c.stdinMu.Unlock()
+	if err != nil {
 		c.logger.Errorf("Error writing response: %v", err)
 	}
 }

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -929,6 +929,86 @@ func TestStdio_LargeMessages(t *testing.T) {
 	}
 }
 
+// TestStdio_ConcurrentWritesDoNotInterleave verifies that concurrent calls to
+// SendRequest and SendNotification do not interleave bytes on the subprocess's
+// stdin. Without the stdinMu serialization, large JSON-RPC frames written from
+// different goroutines can be fragmented by the Go runtime or the OS pipe
+// buffer (POSIX guarantees atomicity only up to PIPE_BUF == 4096 bytes), which
+// corrupts messages read line-by-line by the subprocess.
+//
+// Regression coverage for the client-side equivalent of #528 (PR #529 fixed
+// the server-side only).
+func TestStdio_ConcurrentWritesDoNotInterleave(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
+	require.NoError(t, err)
+	tempFile.Close()
+	mockServerPath := tempFile.Name() + ".exe"
+	require.NoError(t, compileTestServer(mockServerPath))
+
+	stdio := NewStdio(mockServerPath, nil)
+	require.NoError(t, stdio.Start(context.Background()))
+	t.Cleanup(func() { _ = stdio.Close() })
+
+	// Payload well above PIPE_BUF so any interleaving would corrupt the frame.
+	const (
+		numGoroutines   = 20
+		requestsPerGo   = 5
+		payloadByteSize = 16 * 1024
+	)
+
+	payload := generateRandomString(payloadByteSize)
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, numGoroutines*requestsPerGo)
+	for g := range numGoroutines {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for r := range requestsPerGo {
+				ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+				id := int64(10_000 + g*requestsPerGo + r)
+				req := JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(id),
+					Method:  "debug/echo",
+					Params: map[string]any{
+						"requestIndex": id,
+						"payload":      payload,
+					},
+				}
+				resp, err := stdio.SendRequest(ctx, req)
+				cancel()
+				if err != nil {
+					errCh <- fmt.Errorf("goroutine %d req %d: %w", g, r, err)
+					continue
+				}
+				if resp == nil {
+					errCh <- fmt.Errorf("goroutine %d req %d: nil response", g, r)
+					continue
+				}
+				gotID, ok := resp.ID.Value().(int64)
+				if !ok || gotID != id {
+					errCh <- fmt.Errorf("goroutine %d req %d: id mismatch got=%v want=%d", g, r, resp.ID.Value(), id)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+	close(errCh)
+
+	var firstErr error
+	errCount := 0
+	for e := range errCh {
+		errCount++
+		if firstErr == nil {
+			firstErr = e
+		}
+	}
+	if errCount > 0 {
+		t.Fatalf("%d concurrent requests failed (first error: %v)", errCount, firstErr)
+	}
+}
+
 func generateRandomString(size int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
 


### PR DESCRIPTION
## Problem

Concurrent calls to `SendRequest`, `SendNotification` and `sendResponse` on the stdio client transport all write to the subprocess's stdin without synchronization:

https://github.com/mark3labs/mcp-go/blob/main/client/transport/stdio.go#L456
https://github.com/mark3labs/mcp-go/blob/main/client/transport/stdio.go#L502
https://github.com/mark3labs/mcp-go/blob/main/client/transport/stdio.go#L566

On large JSON-RPC frames (> `PIPE_BUF` == 4096 bytes on POSIX, and with no such guarantee on Windows), the kernel does not provide atomic writes when multiple goroutines write to the same pipe. As a result, bytes from different frames can interleave and corrupt the newline-delimited JSON stream. The subprocess then fails to parse the corrupted line, silently drops it, and — depending on the MCP server — can end up in a wedged state where subsequent messages never get a response.

This manifests downstream very visibly when a proxy that fans out many concurrent tool calls (for example [TBXark/mcp-proxy](https://github.com/TBXark/mcp-proxy) which embeds this client) holds a slow tool call that the client cancels: a burst of 4-5 concurrent writes (the pending `tools/call` frame + retries + a `notifications/cancelled` + an `initialize` from the next session) lands on stdin within a few microseconds, the frames interleave, the subprocess wedges, and the proxy goes into \"brick\" mode (every next call times out).

[PR #529](https://github.com/mark3labs/mcp-go/pull/529) previously addressed the dual problem on the **server side** (`server/stdio.go`). This PR closes the same gap on the **client side**.

## Fix

Minimal change:

- Add `stdinMu sync.Mutex` to `Stdio` (next to the `stdin io.WriteCloser` field, so the relationship is obvious in the struct).
- Wrap every `c.stdin.Write(...)` with `Lock` / `Unlock` in `SendRequest`, `SendNotification`, and `sendResponse`.

The critical section is tiny (a single `Write` call that is already non-blocking on a healthy pipe), and the mutex is uncontended on single-producer workloads, so there is no measurable overhead in the common case.

## Test

`TestStdio_ConcurrentWritesDoNotInterleave` launches 20 goroutines, each sending 5 `debug/echo` requests with a 16 KiB payload against the existing `mockstdio_server`. Without the fix, the mock server fails to parse corrupted frames and the test surfaces timeouts / mismatched IDs. With the fix, all 100 requests round-trip correctly.

Also compatible with `go test -race`.

## Backward compatibility

Pure internal change. No public API surface affected.

## Related

- Closes the client-side half of #528
- Complementary to #529

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a concurrency issue in the transport layer that could cause data corruption when multiple requests were sent simultaneously.

* **Tests**
  * Added test coverage to verify correct handling of concurrent operations without data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->