### PR TITLE
feat(server): implement WithIcons, WithTitle, WithDescription, WithWebsiteURL

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -188,6 +188,7 @@ type MCPServer struct {
 
 	name                       string
 	version                    string
+	implementation             mcp.Implementation
 	instructions               string
 	resources                  map[string]resourceEntry
 	resourceTemplates          map[string]resourceTemplateEntry
@@ -491,6 +492,44 @@ func WithCompletions() ServerOption {
 func WithExperimental(experimental map[string]any) ServerOption {
 	return func(s *MCPServer) {
 		s.capabilities.experimental = experimental
+	}
+}
+
+// WithIcons sets the server icons for the implementation metadata returned
+// during initialization. The icons slice and nested Sizes fields are defensively
+// copied to prevent external mutation.
+func WithIcons(icons ...mcp.Icon) ServerOption {
+	return func(s *MCPServer) {
+		copied := make([]mcp.Icon, len(icons))
+		for i, icon := range icons {
+			copied[i] = icon
+			if icon.Sizes != nil {
+				copied[i].Sizes = make([]string, len(icon.Sizes))
+				copy(copied[i].Sizes, icon.Sizes)
+			}
+		}
+		s.implementation.Icons = copied
+	}
+}
+
+// WithTitle sets the human-readable display title for the server implementation.
+func WithTitle(title string) ServerOption {
+	return func(s *MCPServer) {
+		s.implementation.Title = title
+	}
+}
+
+// WithDescription sets the description for the server implementation.
+func WithDescription(description string) ServerOption {
+	return func(s *MCPServer) {
+		s.implementation.Description = description
+	}
+}
+
+// WithWebsiteURL sets the website URL for the server implementation.
+func WithWebsiteURL(websiteURL string) ServerOption {
+	return func(s *MCPServer) {
+		s.implementation.WebsiteURL = websiteURL
 	}
 }
 
@@ -942,8 +981,12 @@ func (s *MCPServer) handleInitialize(
 	result := mcp.InitializeResult{
 		ProtocolVersion: s.protocolVersion(request.Params.ProtocolVersion),
 		ServerInfo: mcp.Implementation{
-			Name:    s.name,
-			Version: s.version,
+			Name:        s.name,
+			Version:     s.version,
+			Title:       s.implementation.Title,
+			Description: s.implementation.Description,
+			WebsiteURL:  s.implementation.WebsiteURL,
+			Icons:       s.implementation.Icons,
 		},
 		Capabilities: capabilities,
 		Instructions: s.instructions,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -25,6 +25,217 @@ func TestMCPServer_NewMCPServer(t *testing.T) {
 	assert.Equal(t, "1.0.0", server.version)
 }
 
+func TestMCPServer_ImplementationMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		options  []ServerOption
+		validate func(t *testing.T, response mcp.JSONRPCMessage)
+	}{
+		{
+			name:    "No implementation metadata",
+			options: []ServerOption{},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				require.True(t, ok)
+
+				assert.Equal(t, "test-server", initResult.ServerInfo.Name)
+				assert.Equal(t, "1.0.0", initResult.ServerInfo.Version)
+				assert.Empty(t, initResult.ServerInfo.Title)
+				assert.Empty(t, initResult.ServerInfo.Description)
+				assert.Empty(t, initResult.ServerInfo.WebsiteURL)
+				assert.Nil(t, initResult.ServerInfo.Icons)
+			},
+		},
+		{
+			name: "With title",
+			options: []ServerOption{
+				WithTitle("My Server"),
+			},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				require.True(t, ok)
+
+				assert.Equal(t, "My Server", initResult.ServerInfo.Title)
+			},
+		},
+		{
+			name: "With description",
+			options: []ServerOption{
+				WithDescription("A server that does amazing things"),
+			},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				require.True(t, ok)
+
+				assert.Equal(t, "A server that does amazing things", initResult.ServerInfo.Description)
+			},
+		},
+		{
+			name: "With website URL",
+			options: []ServerOption{
+				WithWebsiteURL("https://example.com"),
+			},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				require.True(t, ok)
+
+				assert.Equal(t, "https://example.com", initResult.ServerInfo.WebsiteURL)
+			},
+		},
+		{
+			name: "With icons",
+			options: []ServerOption{
+				WithIcons(
+					mcp.Icon{
+						Src:      "https://example.com/icon.png",
+						MIMEType: "image/png",
+						Sizes:    []string{"48x48"},
+					},
+				),
+			},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				require.True(t, ok)
+
+				require.Len(t, initResult.ServerInfo.Icons, 1)
+				assert.Equal(t, "https://example.com/icon.png", initResult.ServerInfo.Icons[0].Src)
+				assert.Equal(t, "image/png", initResult.ServerInfo.Icons[0].MIMEType)
+				assert.Equal(t, []string{"48x48"}, initResult.ServerInfo.Icons[0].Sizes)
+			},
+		},
+		{
+			name: "With multiple icons",
+			options: []ServerOption{
+				WithIcons(
+					mcp.Icon{
+						Src:      "https://example.com/icon.png",
+						MIMEType: "image/png",
+						Sizes:    []string{"48x48"},
+					},
+					mcp.Icon{
+						Src:      "https://example.com/icon.svg",
+						MIMEType: "image/svg+xml",
+						Sizes:    []string{"any"},
+					},
+				),
+			},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				require.True(t, ok)
+
+				require.Len(t, initResult.ServerInfo.Icons, 2)
+				assert.Equal(t, "https://example.com/icon.png", initResult.ServerInfo.Icons[0].Src)
+				assert.Equal(t, "https://example.com/icon.svg", initResult.ServerInfo.Icons[1].Src)
+			},
+		},
+		{
+			name: "With all implementation metadata",
+			options: []ServerOption{
+				WithTitle("My Server"),
+				WithDescription("A server that does amazing things"),
+				WithWebsiteURL("https://example.com"),
+				WithIcons(
+					mcp.Icon{
+						Src:      "https://example.com/icon.png",
+						MIMEType: "image/png",
+						Sizes:    []string{"48x48"},
+					},
+				),
+			},
+			validate: func(t *testing.T, response mcp.JSONRPCMessage) {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+
+				initResult, ok := resp.Result.(mcp.InitializeResult)
+				require.True(t, ok)
+
+				assert.Equal(t, "test-server", initResult.ServerInfo.Name)
+				assert.Equal(t, "1.0.0", initResult.ServerInfo.Version)
+				assert.Equal(t, "My Server", initResult.ServerInfo.Title)
+				assert.Equal(t, "A server that does amazing things", initResult.ServerInfo.Description)
+				assert.Equal(t, "https://example.com", initResult.ServerInfo.WebsiteURL)
+				require.Len(t, initResult.ServerInfo.Icons, 1)
+				assert.Equal(t, "https://example.com/icon.png", initResult.ServerInfo.Icons[0].Src)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := NewMCPServer("test-server", "1.0.0", tt.options...)
+			message := mcp.JSONRPCRequest{
+				JSONRPC: "2.0",
+				ID:      mcp.NewRequestId(int64(1)),
+				Request: mcp.Request{
+					Method: "initialize",
+				},
+			}
+			messageBytes, err := json.Marshal(message)
+			require.NoError(t, err)
+
+			response := server.HandleMessage(context.Background(), messageBytes)
+			tt.validate(t, response)
+		})
+	}
+}
+
+func TestMCPServer_WithIcons_DefensiveCopy(t *testing.T) {
+	// Verify that WithIcons makes a defensive copy so external mutation
+	// does not affect the server's stored icons.
+	icons := []mcp.Icon{
+		{
+			Src:      "https://example.com/icon.png",
+			MIMEType: "image/png",
+			Sizes:    []string{"48x48"},
+		},
+	}
+
+	server := NewMCPServer("test-server", "1.0.0", WithIcons(icons...))
+
+	// Mutate the caller's slice and nested Sizes after passing to WithIcons.
+	icons[0].Src = "https://malicious.example.com/icon.png"
+	icons[0].Sizes[0] = "999x999"
+
+	message := mcp.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+		Request: mcp.Request{
+			Method: "initialize",
+		},
+	}
+	messageBytes, err := json.Marshal(message)
+	require.NoError(t, err)
+
+	response := server.HandleMessage(context.Background(), messageBytes)
+	resp, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+
+	initResult, ok := resp.Result.(mcp.InitializeResult)
+	require.True(t, ok)
+
+	require.Len(t, initResult.ServerInfo.Icons, 1)
+	assert.Equal(t, "https://example.com/icon.png", initResult.ServerInfo.Icons[0].Src)
+	assert.Equal(t, []string{"48x48"}, initResult.ServerInfo.Icons[0].Sizes)
+}
+
 func TestMCPServer_Capabilities(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/www/docs/pages/servers/basics.mdx
+++ b/www/docs/pages/servers/basics.mdx
@@ -127,7 +127,24 @@ The server's `Implementation` struct supports additional optional fields for ric
 //   Icons       []Icon — visual identifiers for the implementation
 ```
 
-You can set these via the `WithIcons` option. The `Title`, `Description`, and `WebsiteURL` fields are populated on the `Implementation` struct and sent to clients during initialization.
+You can set these via server options:
+
+```go
+s := server.NewMCPServer(
+    "My Server",
+    "1.0.0",
+    server.WithTitle("My Server"),                                    // Human-readable display title
+    server.WithDescription("A server that does amazing things"),     // Brief description
+    server.WithWebsiteURL("https://example.com"),                    // Website or docs URL
+    server.WithIcons(                                                // Visual identifiers
+        mcp.Icon{
+            Src:      "https://example.com/icon.png",
+            MIMEType: "image/png",
+            Sizes:    []string{"48x48"},
+        },
+    ),
+)
+```
 
 ### Extensions vs Experimental Capabilities
 


### PR DESCRIPTION
## Description

Implements `server.WithIcons` and related server options for setting Implementation metadata, as requested in #797.

The documentation already referenced `server.WithIcons(...)` but the function was not implemented. The `mcp.Implementation` struct had `Title`, `Description`, `WebsiteURL`, and `Icons` fields that were never populated in the server's initialize response.

**New server options:**

- `WithIcons(icons ...mcp.Icon)` — sets server icons for the implementation metadata
- `WithTitle(title string)` — sets the human-readable display title
- `WithDescription(description string)` — sets the server description
- `WithWebsiteURL(websiteURL string)` — sets the website/docs URL

**Implementation:** Added `implementation mcp.Implementation` field to `MCPServer` and updated `handleInitialize` to include all Implementation fields in the `ServerInfo` response. The existing `name` and `version` fields remain as separate strings for backward compatibility and are merged into the `Implementation` response at initialization time.

Fixes #797

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Icons](https://modelcontextprotocol.io/specification/2025-11-25/basic#icons)
- [x] Implementation follows the specification exactly

## Additional Information

The `Implementation` struct already had the `Title`, `Description`, `WebsiteURL`, and `Icons` fields defined in `mcp/types.go`, but they were never populated by the server. This PR wires them up through server options, matching the pattern used by other server options like `WithInstructions`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced new configuration options to customize server metadata during setup, including title, description, website URL, and icon images.
* **Documentation**
  * Updated documentation with practical examples demonstrating how to configure server metadata using the new options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->