### PR TITLE
fix: clear stale metadataFetchErr on successful OAuth discovery fallback

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -463,6 +463,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		}
 		h.fetchMetadataFromURL(ctx, authMetadataURL)
 		if h.serverMetadata != nil {
+			h.metadataFetchErr = nil
 			return
 		}
 
@@ -474,6 +475,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		}
 		h.fetchMetadataFromURL(ctx, openidMetadataURL)
 		if h.serverMetadata != nil {
+			h.metadataFetchErr = nil
 			return
 		}
 

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -410,6 +410,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 			}
 			h.fetchMetadataFromURL(ctx, authMetadataURL)
 			if h.serverMetadata != nil {
+				h.metadataFetchErr = nil
 				return
 			}
 			// If that also fails, fall back to default endpoints

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -419,6 +419,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 				return
 			}
 			h.serverMetadata = metadata
+			h.metadataFetchErr = nil
 			return
 		}
 
@@ -447,6 +448,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 				return
 			}
 			h.serverMetadata = metadata
+			h.metadataFetchErr = nil
 			return
 		}
 
@@ -482,6 +484,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 			return
 		}
 		h.serverMetadata = metadata
+		h.metadataFetchErr = nil
 	})
 
 	if h.metadataFetchErr != nil {

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -1704,3 +1704,54 @@ func TestOAuthHandler_RFC8707_ResourceParameter(t *testing.T) {
 		assert.Equal(t, server.URL, capturedResource, "resource should fall back to baseURL")
 	})
 }
+
+// TestOAuthHandler_GetServerMetadata_AuthServerReturnsHTML tests that when the
+// authorization server's .well-known endpoint returns 200 with HTML (e.g. a login
+// page) instead of JSON, the fallback chain is not poisoned and default endpoints
+// are used successfully.
+func TestOAuthHandler_GetServerMetadata_AuthServerReturnsHTML(t *testing.T) {
+	// Create a separate "auth server" that returns HTML at its .well-known endpoints
+	authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return 200 with HTML for all requests (simulating a login page)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("<html><body>Login Page</body></html>"))
+	}))
+	defer authServer.Close()
+
+	// Create the MCP server that returns valid protected resource metadata
+	// pointing to the auth server above
+	var mcpServerURL string
+	mcpServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/.well-known/oauth-protected-resource" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"resource":              mcpServerURL,
+				"authorization_servers": []string{authServer.URL},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	mcpServerURL = mcpServer.URL
+	defer mcpServer.Close()
+
+	config := OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: mcpServer.URL + "/callback",
+		Scopes:      []string{"mcp.read"},
+		TokenStore:  NewMemoryTokenStore(),
+		PKCEEnabled: true,
+	}
+
+	handler := NewOAuthHandler(config)
+	handler.SetBaseURL(mcpServer.URL)
+
+	metadata, err := handler.GetServerMetadata(context.Background())
+	require.NoError(t, err, "Should fall back to default endpoints when auth server returns HTML")
+
+	// Verify default endpoints were derived from the auth server URL
+	assert.Equal(t, authServer.URL+"/authorize", metadata.AuthorizationEndpoint)
+	assert.Equal(t, authServer.URL+"/token", metadata.TokenEndpoint)
+	assert.Equal(t, authServer.URL+"/register", metadata.RegistrationEndpoint)
+}


### PR DESCRIPTION
## Description

Clear `metadataFetchErr` when [getDefaultEndpoints()](cci:1://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:520:0-543:1) fallback succeeds, so stale decode errors from earlier discovery attempts don't block OAuth.

## Type of Change

<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth metadata discovery error handling to ensure error states are properly cleared when fallback endpoints are successfully resolved, preventing stale error conditions from affecting authentication reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale error state during OAuth/OIDC discovery so fallback authorization endpoints are determined reliably after multiple discovery attempts.
* **Tests**
  * Added test ensuring discovery robustly handles non-JSON (HTML) responses from authorization server endpoints and derives safe default endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->