### PR TITLE
Return 202 Accepted for all accepted JSON-RPC responses and notifications

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -354,6 +354,11 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if isEmptyResponse {
+		// Per MCP spec (Streamable HTTP transport, rule 4): the server MUST return
+		// 202 Accepted for any accepted JSON-RPC response or notification, regardless
+		// of whether result is {} or omitted. HTTP 200 with no body has no defined
+		// meaning in this transport for POST requests carrying responses.
+		w.WriteHeader(http.StatusAccepted)
 		return
 	}
 

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -1189,7 +1189,12 @@ func TestStreamableHTTP_PongResponseHandling(t *testing.T) {
 		}
 	})
 
-	t.Run("Pong response with null result should not be treated as sampling response", func(t *testing.T) {
+	t.Run("Pong response with null result should return 202 and not be treated as sampling response", func(t *testing.T) {
+		// Some MCP clients (e.g. VS Code Copilot Chat) send ping responses without
+		// the result field: {"jsonrpc":"2.0","id":N}. While this is not strictly
+		// compliant with JSON-RPC 2.0 (which requires result or error), the server
+		// should accept it leniently and return 202 Accepted per the MCP spec
+		// (Streamable HTTP transport, rule 4).
 		pongResponse := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      124,
@@ -1211,12 +1216,12 @@ func TestStreamableHTTP_PongResponseHandling(t *testing.T) {
 			t.Errorf("Pong response with omitted result was incorrectly detected as sampling response. Response: %s", bodyStr)
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Expected status 200 for pong response, got %d. Body: %s", resp.StatusCode, bodyStr)
+		if resp.StatusCode != http.StatusAccepted {
+			t.Errorf("Expected status 202 for pong response, got %d. Body: %s", resp.StatusCode, bodyStr)
 		}
 	})
 
-	t.Run("Response with empty error should not be treated as sampling response", func(t *testing.T) {
+	t.Run("Response with empty error should return 202 and not be treated as sampling response", func(t *testing.T) {
 		response := map[string]any{
 			"jsonrpc": "2.0",
 			"id":      125,
@@ -1239,8 +1244,8 @@ func TestStreamableHTTP_PongResponseHandling(t *testing.T) {
 			t.Errorf("Response with empty error was incorrectly detected as sampling response. Response: %s", bodyStr)
 		}
 
-		if resp.StatusCode != http.StatusOK {
-			t.Errorf("Expected status 200 for response with empty error, got %d. Body: %s", resp.StatusCode, bodyStr)
+		if resp.StatusCode != http.StatusAccepted {
+			t.Errorf("Expected status 202 for response with empty error, got %d. Body: %s", resp.StatusCode, bodyStr)
 		}
 	})
 }

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -1189,7 +1189,7 @@ func TestStreamableHTTP_PongResponseHandling(t *testing.T) {
 		}
 	})
 
-	t.Run("Pong response with null result should return 202 and not be treated as sampling response", func(t *testing.T) {
+	t.Run("Pong response with omitted result should return 202 and not be treated as sampling response", func(t *testing.T) {
 		// Some MCP clients (e.g. VS Code Copilot Chat) send ping responses without
 		// the result field: {"jsonrpc":"2.0","id":N}. While this is not strictly
 		// compliant with JSON-RPC 2.0 (which requires result or error), the server


### PR DESCRIPTION
## Summary

Per [MCP Streamable HTTP transport spec (rule 4)](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#sending-messages-to-the-server):

> If the input consists solely of JSON-RPC *responses* or *notifications*:
> - If the server accepts the input, the server **MUST** return HTTP status code **202 Accepted** with no body.

The `isEmptyResponse` path was calling bare `return` without `WriteHeader`, so Go's `net/http` sent an implicit `HTTP 200 OK` with no `Content-Type` and empty body. This violates the spec — HTTP 200 with no body has no defined meaning in this transport for POST requests carrying responses.

## Impact

VS Code Copilot Chat sends ping responses without the `result` field:
```json
{"jsonrpc": "2.0", "id": N}
```
instead of the spec-mandated:
```json
{"jsonrpc": "2.0", "id": N, "result": {}}
```

The `isPingResponse` check requires `isExplicitEmptyObject(result)` so it only matches `result: {}`. VS Code's response (omitted `result`) falls through to `isEmptyResponse`, which returned implicit 200. VS Code's MCP client then logs:

```
Unexpected 200 response for request: 
```

every 30 seconds (matching the server heartbeat interval). This was reported as a bug by users running vmcp on Kubernetes with VS Code Copilot Chat.

## Changes

- `server/streamable_http.go`: add `w.WriteHeader(http.StatusAccepted)` to the `isEmptyResponse` path
- `server/streamable_http_test.go`: update the two test cases that were asserting `StatusOK` (200) for this path to assert `StatusAccepted` (202), and add comments explaining the real-world client behaviour

## Note on VS Code compliance

The omission of `result` is technically non-compliant with JSON-RPC 2.0 (responses MUST include `result` or `error`), and also non-compliant with the MCP ping spec which mandates `result: {}`. However, the lenient approach of accepting and returning 202 is preferable to rejecting it with 400, since VS Code is widely deployed and the semantic intent is unambiguous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty/omitted JSON-RPC responses now return HTTP 202 Accepted instead of leaving status implicit, improving response consistency.
* **Tests**
  * Updated tests to expect 202 Accepted for omitted-result and empty-error cases, and adjusted descriptions/messages to match the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->