### PR TITLE
fix: use client_secret_post to match actual token endpoint auth behavior

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -563,7 +563,7 @@ func (h *OAuthHandler) RegisterClient(ctx context.Context, clientName string) er
 
 	// Add client_secret if this is a confidential client
 	if h.config.ClientSecret != "" {
-		regRequest["token_endpoint_auth_method"] = "client_secret_basic"
+		regRequest["token_endpoint_auth_method"] = "client_secret_post"
 	}
 
 	reqBody, err := json.Marshal(regRequest)


### PR DESCRIPTION
## Description

A spec-compliant authorization server which actually enforces the registered auth method would reject token requests with `invalid_client` since it expects an `Authorization: Basic` header (which is never sent).

This change updates the registration to declare `client_secret_post`, which matches what's actually done in `ProcessAuthorizationResponse` and `refreshToken`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] MCP spec compatibility implementation

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [RFC 6749 §2.3.1 - Client Password](https://datatracker.ietf.org/doc/html/rfc6749#section-2.3.1), [RFC 7591 §2 - Client Metadata](https://datatracker.ietf.org/doc/html/rfc7591#section-2)
- [x] Implementation follows the specification exactly

## Additional Information

The mismatch only affects confidential clients (those with a `ClientSecret`) that use dynamic client registration against a strict authorization server. Lenient servers that accept credentials via either method were unaffected, which is likely why this wasn't caught earlier.