### PR TITLE
feat(oauth): extract Protected Resource Metadata URL from WWW-Authenticate

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -397,9 +397,18 @@ func (h *OAuthHandler) validateAdvertisedPRMURL(candidate string) error {
 	if err != nil {
 		return fmt.Errorf("invalid base URL %q: %w", h.baseURL, err)
 	}
+	// url.Parse accepts relative references (empty Scheme and Host)
+	// without error. Reject those explicitly so two empty values do not
+	// EqualFold-match each other and bypass origin validation.
+	if base.Scheme == "" || base.Host == "" {
+		return fmt.Errorf("base URL %q is not absolute (missing scheme or host)", h.baseURL)
+	}
 	parsed, err := url.Parse(candidate)
 	if err != nil {
 		return fmt.Errorf("invalid advertised PRM URL %q: %w", candidate, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("advertised PRM URL %q is not absolute (missing scheme or host)", candidate)
 	}
 	if !strings.EqualFold(parsed.Scheme, base.Scheme) {
 		return fmt.Errorf("advertised PRM URL scheme %q does not match base %q", parsed.Scheme, base.Scheme)

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -324,10 +324,15 @@ func (h *OAuthHandler) SetBaseURL(baseURL string) {
 // fetches this URL in preference to constructing one from the base URL's
 // /.well-known/oauth-protected-resource path.
 //
-// The transport layer calls this automatically when a 401 response carries
-// a resource_metadata parameter in the WWW-Authenticate header per
-// RFC 9728 §5.1. Callers may also set it explicitly when the URL is known
-// out of band.
+// This setter does not validate the URL; callers using it directly are
+// trusted to pass a value obtained out of band. For values parsed from a
+// 401 WWW-Authenticate header, prefer HandleUnauthorizedResponse, which
+// applies origin validation before storing.
+//
+// Note: the first call to GetServerMetadata latches the resolved metadata
+// through a sync.Once. A PRM URL set after that first call is not applied
+// retroactively — set it (or let the transport's 401 handling set it)
+// before any code path that triggers metadata discovery.
 func (h *OAuthHandler) SetProtectedResourceMetadataURL(prmURL string) {
 	h.mu.Lock()
 	h.protectedResourceMetadataURL = prmURL
@@ -343,18 +348,67 @@ func (h *OAuthHandler) ProtectedResourceMetadataURL() string {
 	return h.protectedResourceMetadataURL
 }
 
-// HandleUnauthorizedResponse inspects a 401 response for an RFC 9728 §5.1
-// WWW-Authenticate challenge and, when it contains a resource_metadata
-// parameter, stores the URL so subsequent metadata discovery can use it.
-// It is safe to call with a nil response and is a no-op when the header
-// is absent or contains no resource_metadata parameter.
+// HandleUnauthorizedResponse inspects a 401 response for RFC 9728 §5.1
+// WWW-Authenticate challenges and, when one carries a resource_metadata
+// parameter whose URL shares the protected resource's origin, stores it
+// so subsequent metadata discovery can use it. It iterates every
+// WWW-Authenticate header line (a response can carry multiple challenges
+// — Basic, Bearer, etc. — each on its own line), takes the first
+// resource_metadata value that validates, and silently ignores headers
+// that are absent, malformed, or advertise an unrelated origin.
+//
+// Origin validation rejects URLs whose scheme or host differs from the
+// OAuth handler's configured base URL. This prevents a compromised or
+// misconfigured resource from redirecting clients to an attacker's
+// metadata endpoint.
+//
+// It is safe to call with a nil response.
 func (h *OAuthHandler) HandleUnauthorizedResponse(resp *http.Response) {
 	if resp == nil {
 		return
 	}
-	if u := extractResourceMetadataURL(resp.Header.Get("WWW-Authenticate")); u != "" {
-		h.SetProtectedResourceMetadataURL(u)
+	for _, header := range resp.Header.Values("WWW-Authenticate") {
+		candidate := extractResourceMetadataURL(header)
+		if candidate == "" {
+			continue
+		}
+		if err := h.validateAdvertisedPRMURL(candidate); err != nil {
+			continue
+		}
+		h.SetProtectedResourceMetadataURL(candidate)
+		return
 	}
+}
+
+// validateAdvertisedPRMURL enforces that a PRM URL advertised by the
+// resource (i.e. parsed from an untrusted WWW-Authenticate header) shares
+// the configured base URL's scheme and host. Returns a non-nil error when
+// the candidate is unparseable, carries a different scheme or host, or
+// when no base URL has been configured to validate against.
+//
+// RFC 9728 §3.2 requires the protected resource to serve its own metadata;
+// this check rejects attempts to redirect discovery to an unrelated
+// origin, which would otherwise let the resource point the client at an
+// attacker-controlled OAuth metadata endpoint.
+func (h *OAuthHandler) validateAdvertisedPRMURL(candidate string) error {
+	if h.baseURL == "" {
+		return errors.New("no base URL configured for origin validation")
+	}
+	base, err := url.Parse(h.baseURL)
+	if err != nil {
+		return fmt.Errorf("invalid base URL %q: %w", h.baseURL, err)
+	}
+	parsed, err := url.Parse(candidate)
+	if err != nil {
+		return fmt.Errorf("invalid advertised PRM URL %q: %w", candidate, err)
+	}
+	if !strings.EqualFold(parsed.Scheme, base.Scheme) {
+		return fmt.Errorf("advertised PRM URL scheme %q does not match base %q", parsed.Scheme, base.Scheme)
+	}
+	if !strings.EqualFold(parsed.Host, base.Host) {
+		return fmt.Errorf("advertised PRM URL host %q does not match base %q", parsed.Host, base.Host)
+	}
+	return nil
 }
 
 // GetExpectedState returns the expected state value (for testing purposes)
@@ -424,7 +478,8 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		// where the PRM endpoint sits under a path that origin-based
 		// construction cannot reach.
 		protectedResourceURL := h.ProtectedResourceMetadataURL()
-		if protectedResourceURL == "" {
+		prmFromAdvertisement := protectedResourceURL != ""
+		if !prmFromAdvertisement {
 			protectedResourceURL, err = buildWellKnownURL(baseURL, "oauth-protected-resource")
 			if err != nil {
 				h.metadataFetchErr = fmt.Errorf("failed to build protected resource URL: %w", err)
@@ -474,6 +529,24 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		var protectedResource OAuthProtectedResource
 		if err := json.NewDecoder(resp.Body).Decode(&protectedResource); err != nil {
 			h.metadataFetchErr = fmt.Errorf("failed to decode protected resource response: %w", err)
+			return
+		}
+
+		// RFC 9728 §3.3/§7.3: when metadata is fetched from a PRM URL the
+		// server advertised via WWW-Authenticate (an untrusted network
+		// input), the declared resource identifier MUST match the
+		// protected resource the client addressed — otherwise the
+		// response MUST NOT be used. This prevents a compromised resource
+		// from pointing clients at another resource's OAuth metadata.
+		// The check is scoped to the advertised path because the
+		// well-known origin-constructed path has already been validated
+		// by same-origin URL construction.
+		if prmFromAdvertisement && protectedResource.Resource != "" &&
+			!resourceIdentifiersEqual(protectedResource.Resource, baseURL) {
+			h.metadataFetchErr = fmt.Errorf(
+				"advertised protected resource metadata declares resource %q which does not match base URL %q",
+				protectedResource.Resource, baseURL,
+			)
 			return
 		}
 
@@ -615,10 +688,15 @@ func parseAuthParamValue(s string, i int) (string, int) {
 		var b strings.Builder
 		for i < len(s) {
 			c := s[i]
-			if c == '\\' && i+1 < len(s) {
-				b.WriteByte(s[i+1])
-				i += 2
-				continue
+			if c == '\\' {
+				if i+1 < len(s) {
+					b.WriteByte(s[i+1])
+					i += 2
+					continue
+				}
+				// Lone trailing backslash in a truncated quoted string:
+				// drop it rather than emitting a stray '\'.
+				return b.String(), i + 1
 			}
 			if c == '"' {
 				return b.String(), i + 1
@@ -633,6 +711,36 @@ func parseAuthParamValue(s string, i int) (string, int) {
 		i++
 	}
 	return s[start:i], i
+}
+
+// resourceIdentifiersEqual reports whether two OAuth protected resource
+// identifiers refer to the same resource for the purposes of RFC 9728 §3.3
+// equality checks. Scheme and host are compared case-insensitively and a
+// single trailing slash on either path is ignored; query, fragment, and
+// userinfo components are considered significant. Unparseable inputs
+// fall back to exact string equality.
+func resourceIdentifiersEqual(a, b string) bool {
+	ua, errA := url.Parse(a)
+	ub, errB := url.Parse(b)
+	if errA != nil || errB != nil {
+		return a == b
+	}
+	if !strings.EqualFold(ua.Scheme, ub.Scheme) {
+		return false
+	}
+	if !strings.EqualFold(ua.Host, ub.Host) {
+		return false
+	}
+	if strings.TrimSuffix(ua.Path, "/") != strings.TrimSuffix(ub.Path, "/") {
+		return false
+	}
+	if ua.RawQuery != ub.RawQuery {
+		return false
+	}
+	if ua.Fragment != ub.Fragment {
+		return false
+	}
+	return ua.User.String() == ub.User.String()
 }
 
 // isAuthTokenChar reports whether c is a valid RFC 9110 §5.6.2 token

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -353,9 +353,10 @@ func (h *OAuthHandler) ProtectedResourceMetadataURL() string {
 // parameter whose URL shares the protected resource's origin, stores it
 // so subsequent metadata discovery can use it. It iterates every
 // WWW-Authenticate header line (a response can carry multiple challenges
-// — Basic, Bearer, etc. — each on its own line), takes the first
-// resource_metadata value that validates, and silently ignores headers
-// that are absent, malformed, or advertise an unrelated origin.
+// — Basic, Bearer, etc. — each on its own line) and every
+// resource_metadata parameter within each line, takes the first
+// candidate that validates, and silently ignores headers that are
+// absent, malformed, or advertise an unrelated origin.
 //
 // Origin validation rejects URLs whose scheme or host differs from the
 // OAuth handler's configured base URL. This prevents a compromised or
@@ -368,15 +369,13 @@ func (h *OAuthHandler) HandleUnauthorizedResponse(resp *http.Response) {
 		return
 	}
 	for _, header := range resp.Header.Values("WWW-Authenticate") {
-		candidate := extractResourceMetadataURL(header)
-		if candidate == "" {
-			continue
+		for _, candidate := range extractResourceMetadataURLs(header) {
+			if err := h.validateAdvertisedPRMURL(candidate); err != nil {
+				continue
+			}
+			h.SetProtectedResourceMetadataURL(candidate)
+			return
 		}
-		if err := h.validateAdvertisedPRMURL(candidate); err != nil {
-			continue
-		}
-		h.SetProtectedResourceMetadataURL(candidate)
-		return
 	}
 }
 
@@ -536,18 +535,30 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		// server advertised via WWW-Authenticate (an untrusted network
 		// input), the declared resource identifier MUST match the
 		// protected resource the client addressed — otherwise the
-		// response MUST NOT be used. This prevents a compromised resource
-		// from pointing clients at another resource's OAuth metadata.
+		// response MUST NOT be used. An advertised PRM response that
+		// omits the resource field is also rejected: since the PRM
+		// endpoint may not share an origin with the protected resource,
+		// the response cannot be implicitly trusted without an explicit
+		// binding.
+		//
 		// The check is scoped to the advertised path because the
-		// well-known origin-constructed path has already been validated
-		// by same-origin URL construction.
-		if prmFromAdvertisement && protectedResource.Resource != "" &&
-			!resourceIdentifiersEqual(protectedResource.Resource, baseURL) {
-			h.metadataFetchErr = fmt.Errorf(
-				"advertised protected resource metadata declares resource %q which does not match base URL %q",
-				protectedResource.Resource, baseURL,
-			)
-			return
+		// well-known origin-constructed path is already bound to the
+		// protected resource by same-origin URL construction.
+		if prmFromAdvertisement {
+			if protectedResource.Resource == "" {
+				h.metadataFetchErr = fmt.Errorf(
+					"advertised protected resource metadata from %q omits required resource field",
+					protectedResourceURL,
+				)
+				return
+			}
+			if !resourceIdentifiersEqual(protectedResource.Resource, baseURL) {
+				h.metadataFetchErr = fmt.Errorf(
+					"advertised protected resource metadata declares resource %q which does not match base URL %q",
+					protectedResource.Resource, baseURL,
+				)
+				return
+			}
 		}
 
 		// RFC 8707: Capture the resource identifier for use in authorization requests.
@@ -635,13 +646,16 @@ func buildWellKnownURL(baseURL string, suffix string) (string, error) {
 	return root + "/.well-known/" + suffix + path, nil
 }
 
-// extractResourceMetadataURL returns the resource_metadata parameter value
-// from a WWW-Authenticate header per RFC 9728 §5.1, or an empty string when
-// the header is empty, no such parameter is present, or the value is
-// malformed. Parameter names are matched case-insensitively per
-// RFC 9110 §11.2; both quoted-string and token value forms are accepted.
-func extractResourceMetadataURL(header string) string {
+// extractResourceMetadataURLs returns every resource_metadata parameter
+// value from a WWW-Authenticate header per RFC 9728 §5.1, in the order
+// they appear. Returns an empty slice when the header is empty or no
+// such parameters are present. Parameter names are matched
+// case-insensitively per RFC 9110 §11.2; both quoted-string and token
+// value forms are accepted. Multiple occurrences are possible when a
+// single header value contains several Bearer challenges.
+func extractResourceMetadataURLs(header string) []string {
 	const target = "resource_metadata"
+	var out []string
 	i := 0
 	for i < len(header) {
 		// Advance to the next token start.
@@ -668,11 +682,11 @@ func extractResourceMetadataURL(header string) string {
 		}
 		value, next := parseAuthParamValue(header, i)
 		i = next
-		if strings.EqualFold(name, target) {
-			return value
+		if value != "" && strings.EqualFold(name, target) {
+			out = append(out, value)
 		}
 	}
-	return ""
+	return out
 }
 
 // parseAuthParamValue reads a single WWW-Authenticate parameter value
@@ -715,10 +729,13 @@ func parseAuthParamValue(s string, i int) (string, int) {
 
 // resourceIdentifiersEqual reports whether two OAuth protected resource
 // identifiers refer to the same resource for the purposes of RFC 9728 §3.3
-// equality checks. Scheme and host are compared case-insensitively and a
-// single trailing slash on either path is ignored; query, fragment, and
-// userinfo components are considered significant. Unparseable inputs
-// fall back to exact string equality.
+// equality checks. Scheme and host are compared case-insensitively per
+// RFC 3986 §3.1 / §3.2.2, and a single trailing slash on either path is
+// ignored because real-world OAuth deployments routinely emit the
+// resource with or without it for the same URL; rejecting that variant
+// would produce false positives on legitimate servers. Query, fragment,
+// and userinfo components are significant. Unparseable inputs fall back
+// to exact string equality.
 func resourceIdentifiersEqual(a, b string) bool {
 	ua, errA := url.Parse(a)
 	ub, errB := url.Parse(b)

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -680,8 +680,11 @@ func extractResourceMetadataURLs(header string) []string {
 		for i < len(header) && (header[i] == ' ' || header[i] == '\t') {
 			i++
 		}
-		value, next := parseAuthParamValue(header, i)
+		value, next, ok := parseAuthParamValue(header, i)
 		i = next
+		if !ok {
+			continue
+		}
 		if value != "" && strings.EqualFold(name, target) {
 			out = append(out, value)
 		}
@@ -691,11 +694,14 @@ func extractResourceMetadataURLs(header string) []string {
 
 // parseAuthParamValue reads a single WWW-Authenticate parameter value
 // starting at offset i: a quoted-string (with backslash escapes) when the
-// first byte is '"', otherwise a bare token. It returns the decoded value
-// and the index of the first byte after it.
-func parseAuthParamValue(s string, i int) (string, int) {
+// first byte is '"', otherwise a bare token. It returns the decoded
+// value, the index of the first byte after it, and whether the value
+// was well-formed. Truncated quoted strings (no closing '"') and lone
+// trailing backslashes yield ok=false so malformed input is rejected
+// rather than producing a partial value.
+func parseAuthParamValue(s string, i int) (string, int, bool) {
 	if i >= len(s) {
-		return "", i
+		return "", i, false
 	}
 	if s[i] == '"' {
 		i++
@@ -703,28 +709,29 @@ func parseAuthParamValue(s string, i int) (string, int) {
 		for i < len(s) {
 			c := s[i]
 			if c == '\\' {
-				if i+1 < len(s) {
-					b.WriteByte(s[i+1])
-					i += 2
-					continue
+				if i+1 >= len(s) {
+					// Lone trailing backslash — the quoted string was
+					// truncated mid-escape, so the value is malformed.
+					return "", i + 1, false
 				}
-				// Lone trailing backslash in a truncated quoted string:
-				// drop it rather than emitting a stray '\'.
-				return b.String(), i + 1
+				b.WriteByte(s[i+1])
+				i += 2
+				continue
 			}
 			if c == '"' {
-				return b.String(), i + 1
+				return b.String(), i + 1, true
 			}
 			b.WriteByte(c)
 			i++
 		}
-		return b.String(), i
+		// Reached end of input without a closing '"'.
+		return "", i, false
 	}
 	start := i
 	for i < len(s) && isAuthTokenChar(s[i]) {
 		i++
 	}
-	return s[start:i], i
+	return s[start:i], i, i > start
 }
 
 // resourceIdentifiersEqual reports whether two OAuth protected resource
@@ -748,7 +755,11 @@ func resourceIdentifiersEqual(a, b string) bool {
 	if !strings.EqualFold(ua.Host, ub.Host) {
 		return false
 	}
-	if strings.TrimSuffix(ua.Path, "/") != strings.TrimSuffix(ub.Path, "/") {
+	// Use EscapedPath rather than Path so percent-encoded reserved
+	// characters stay distinct from their decoded forms (e.g. "a%2Fb"
+	// must not compare equal to "a/b"), preserving RFC 3986 segment
+	// semantics.
+	if strings.TrimSuffix(ua.EscapedPath(), "/") != strings.TrimSuffix(ub.EscapedPath(), "/") {
 		return false
 	}
 	if ua.RawQuery != ub.RawQuery {

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -148,8 +148,9 @@ type OAuthHandler struct {
 	baseURL          string
 	resourceURL      string // RFC 8707 resource indicator; set from protected resource metadata
 
-	mu            sync.RWMutex // Protects expectedState
-	expectedState string       // Expected state value for CSRF protection
+	mu                           sync.RWMutex // Protects expectedState and protectedResourceMetadataURL
+	expectedState                string       // Expected state value for CSRF protection
+	protectedResourceMetadataURL string       // RFC 9728 §5.1: PRM URL advertised by the server via WWW-Authenticate
 }
 
 // NewOAuthHandler creates a new OAuth handler
@@ -318,6 +319,44 @@ func (h *OAuthHandler) SetBaseURL(baseURL string) {
 	h.baseURL = baseURL
 }
 
+// SetProtectedResourceMetadataURL stores the OAuth 2.0 Protected Resource
+// Metadata URL advertised by the server. When set, metadata discovery
+// fetches this URL in preference to constructing one from the base URL's
+// /.well-known/oauth-protected-resource path.
+//
+// The transport layer calls this automatically when a 401 response carries
+// a resource_metadata parameter in the WWW-Authenticate header per
+// RFC 9728 §5.1. Callers may also set it explicitly when the URL is known
+// out of band.
+func (h *OAuthHandler) SetProtectedResourceMetadataURL(prmURL string) {
+	h.mu.Lock()
+	h.protectedResourceMetadataURL = prmURL
+	h.mu.Unlock()
+}
+
+// ProtectedResourceMetadataURL returns the Protected Resource Metadata URL
+// that will be used during metadata discovery, or an empty string if none
+// has been set.
+func (h *OAuthHandler) ProtectedResourceMetadataURL() string {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.protectedResourceMetadataURL
+}
+
+// HandleUnauthorizedResponse inspects a 401 response for an RFC 9728 §5.1
+// WWW-Authenticate challenge and, when it contains a resource_metadata
+// parameter, stores the URL so subsequent metadata discovery can use it.
+// It is safe to call with a nil response and is a no-op when the header
+// is absent or contains no resource_metadata parameter.
+func (h *OAuthHandler) HandleUnauthorizedResponse(resp *http.Response) {
+	if resp == nil {
+		return
+	}
+	if u := extractResourceMetadataURL(resp.Header.Get("WWW-Authenticate")); u != "" {
+		h.SetProtectedResourceMetadataURL(u)
+	}
+}
+
 // GetExpectedState returns the expected state value (for testing purposes)
 func (h *OAuthHandler) GetExpectedState() string {
 	h.mu.RLock()
@@ -380,10 +419,17 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 			return
 		}
 
-		protectedResourceURL, err := buildWellKnownURL(baseURL, "oauth-protected-resource")
-		if err != nil {
-			h.metadataFetchErr = fmt.Errorf("failed to build protected resource URL: %w", err)
-			return
+		// Prefer a PRM URL advertised via WWW-Authenticate (RFC 9728 §5.1)
+		// when the server provided one; this is required for deployments
+		// where the PRM endpoint sits under a path that origin-based
+		// construction cannot reach.
+		protectedResourceURL := h.ProtectedResourceMetadataURL()
+		if protectedResourceURL == "" {
+			protectedResourceURL, err = buildWellKnownURL(baseURL, "oauth-protected-resource")
+			if err != nil {
+				h.metadataFetchErr = fmt.Errorf("failed to build protected resource URL: %w", err)
+				return
+			}
 		}
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, protectedResourceURL, nil)
 		if err != nil {
@@ -514,6 +560,90 @@ func buildWellKnownURL(baseURL string, suffix string) (string, error) {
 	}
 
 	return root + "/.well-known/" + suffix + path, nil
+}
+
+// extractResourceMetadataURL returns the resource_metadata parameter value
+// from a WWW-Authenticate header per RFC 9728 §5.1, or an empty string when
+// the header is empty, no such parameter is present, or the value is
+// malformed. Parameter names are matched case-insensitively per
+// RFC 9110 §11.2; both quoted-string and token value forms are accepted.
+func extractResourceMetadataURL(header string) string {
+	const target = "resource_metadata"
+	i := 0
+	for i < len(header) {
+		// Advance to the next token start.
+		for i < len(header) && !isAuthTokenChar(header[i]) {
+			i++
+		}
+		nameStart := i
+		for i < len(header) && isAuthTokenChar(header[i]) {
+			i++
+		}
+		name := header[nameStart:i]
+		// Skip optional whitespace between the name and '='.
+		for i < len(header) && (header[i] == ' ' || header[i] == '\t') {
+			i++
+		}
+		if i >= len(header) || header[i] != '=' {
+			// Name was a scheme token (e.g. "Bearer"), not a parameter.
+			continue
+		}
+		// Skip '=' and optional whitespace.
+		i++
+		for i < len(header) && (header[i] == ' ' || header[i] == '\t') {
+			i++
+		}
+		value, next := parseAuthParamValue(header, i)
+		i = next
+		if strings.EqualFold(name, target) {
+			return value
+		}
+	}
+	return ""
+}
+
+// parseAuthParamValue reads a single WWW-Authenticate parameter value
+// starting at offset i: a quoted-string (with backslash escapes) when the
+// first byte is '"', otherwise a bare token. It returns the decoded value
+// and the index of the first byte after it.
+func parseAuthParamValue(s string, i int) (string, int) {
+	if i >= len(s) {
+		return "", i
+	}
+	if s[i] == '"' {
+		i++
+		var b strings.Builder
+		for i < len(s) {
+			c := s[i]
+			if c == '\\' && i+1 < len(s) {
+				b.WriteByte(s[i+1])
+				i += 2
+				continue
+			}
+			if c == '"' {
+				return b.String(), i + 1
+			}
+			b.WriteByte(c)
+			i++
+		}
+		return b.String(), i
+	}
+	start := i
+	for i < len(s) && isAuthTokenChar(s[i]) {
+		i++
+	}
+	return s[start:i], i
+}
+
+// isAuthTokenChar reports whether c is a valid RFC 9110 §5.6.2 token
+// character — the character class used for scheme and parameter names in
+// WWW-Authenticate.
+func isAuthTokenChar(c byte) bool {
+	switch {
+	case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		return true
+	}
+	return strings.IndexByte("!#$%&'*+-.^_`|~", c) >= 0
 }
 
 // fetchMetadataFromURL fetches and parses OAuth server metadata from a URL

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -1921,6 +1921,24 @@ func TestOAuthHandler_HandleUnauthorizedResponse(t *testing.T) {
 			want: "",
 		},
 		{
+			name: "relative PRM URL is rejected",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{`Bearer resource_metadata="just-a-path"`},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "schemeless host-only PRM URL is rejected",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{`Bearer resource_metadata="example.com/mcp"`},
+				},
+			},
+			want: "",
+		},
+		{
 			name: "multiple WWW-Authenticate headers: picks first that validates",
 			response: &http.Response{
 				Header: http.Header{
@@ -1983,6 +2001,25 @@ func TestOAuthHandler_HandleUnauthorizedResponse_NoBaseURL(t *testing.T) {
 		},
 	})
 	assert.Equal(t, "", handler.ProtectedResourceMetadataURL())
+}
+
+// TestOAuthHandler_HandleUnauthorizedResponse_RelativeBaseURL verifies that
+// origin validation rejects advertised PRM URLs when the configured base URL
+// itself is a relative reference. Without this check, two empty
+// scheme/host strings would compare equal and bypass validation entirely.
+func TestOAuthHandler_HandleUnauthorizedResponse_RelativeBaseURL(t *testing.T) {
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+	})
+	handler.SetBaseURL("just-a-path") // misconfigured — not an absolute URL
+	handler.HandleUnauthorizedResponse(&http.Response{
+		Header: http.Header{
+			"Www-Authenticate": []string{`Bearer resource_metadata="also-just-a-path"`},
+		},
+	})
+	assert.Equal(t, "", handler.ProtectedResourceMetadataURL(),
+		"relative baseURL + relative candidate must not validate equal")
 }
 
 func TestResourceIdentifiersEqual(t *testing.T) {

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -1756,76 +1756,81 @@ func TestOAuthHandler_GetServerMetadata_AuthServerReturnsHTML(t *testing.T) {
 	assert.Equal(t, authServer.URL+"/register", metadata.RegistrationEndpoint)
 }
 
-func TestExtractResourceMetadataURL(t *testing.T) {
+func TestExtractResourceMetadataURLs(t *testing.T) {
 	cases := []struct {
 		name   string
 		header string
-		want   string
+		want   []string
 	}{
 		{
 			name:   "empty header",
 			header: "",
-			want:   "",
+			want:   nil,
 		},
 		{
 			name:   "bearer challenge with quoted resource_metadata",
 			header: `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/tenant"`,
-			want:   "https://example.com/.well-known/oauth-protected-resource/tenant",
+			want:   []string{"https://example.com/.well-known/oauth-protected-resource/tenant"},
 		},
 		{
 			name:   "bearer challenge with realm, error, and resource_metadata",
 			header: `Bearer realm="mcp", error="invalid_token", resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
-			want:   "https://example.com/.well-known/oauth-protected-resource",
+			want:   []string{"https://example.com/.well-known/oauth-protected-resource"},
 		},
 		{
 			name:   "parameter name matched case-insensitively",
 			header: `Bearer Resource_Metadata="https://example.com/prm"`,
-			want:   "https://example.com/prm",
+			want:   []string{"https://example.com/prm"},
 		},
 		{
 			name:   "unquoted token value",
 			header: `Bearer resource_metadata=abc123`,
-			want:   "abc123",
+			want:   []string{"abc123"},
 		},
 		{
 			name:   "quoted value with escaped quote",
 			header: `Bearer resource_metadata="https://example.com/with-\"quote\""`,
-			want:   `https://example.com/with-"quote"`,
+			want:   []string{`https://example.com/with-"quote"`},
 		},
 		{
 			name:   "value with tabs and extra whitespace",
 			header: "Bearer\tresource_metadata\t=\t\"https://example.com/prm\"",
-			want:   "https://example.com/prm",
+			want:   []string{"https://example.com/prm"},
 		},
 		{
 			name:   "no resource_metadata parameter",
 			header: `Bearer realm="mcp", error="invalid_token"`,
-			want:   "",
+			want:   nil,
 		},
 		{
 			name:   "word containing resource_metadata is not a match",
 			header: `Bearer realm="foo resource_metadata bar"`,
-			want:   "",
+			want:   nil,
 		},
 		{
 			name:   "missing equals after parameter name",
 			header: `Bearer resource_metadata`,
-			want:   "",
+			want:   nil,
 		},
 		{
 			name:   "truncated quoted value returns what was read",
 			header: `Bearer resource_metadata="https://example.com/prm`,
-			want:   "https://example.com/prm",
+			want:   []string{"https://example.com/prm"},
 		},
 		{
-			name:   "prefers first occurrence",
+			name:   "returns all occurrences in order",
 			header: `Bearer resource_metadata="https://example.com/a", resource_metadata="https://example.com/b"`,
-			want:   "https://example.com/a",
+			want:   []string{"https://example.com/a", "https://example.com/b"},
+		},
+		{
+			name:   "multiple Bearer challenges each with resource_metadata",
+			header: `Bearer realm="tenant-a", resource_metadata="https://example.com/a", Bearer realm="tenant-b", resource_metadata="https://example.com/b"`,
+			want:   []string{"https://example.com/a", "https://example.com/b"},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := extractResourceMetadataURL(tc.header)
+			got := extractResourceMetadataURLs(tc.header)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -1934,6 +1939,17 @@ func TestOAuthHandler_HandleUnauthorizedResponse(t *testing.T) {
 			},
 			want: "https://example.com/mcp/prm",
 		},
+		{
+			name: "single header with two resource_metadata params: bad first, good second",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{
+						`Bearer resource_metadata="https://attacker.example/evil", Bearer resource_metadata="https://example.com/mcp/prm"`,
+					},
+				},
+			},
+			want: "https://example.com/mcp/prm",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2022,6 +2038,39 @@ func TestOAuthHandler_GetServerMetadata_RejectsMismatchedResourceFromAdvertisedP
 	assert.Contains(t, err.Error(), "does not match base URL")
 }
 
+// TestOAuthHandler_GetServerMetadata_RejectsEmptyResourceFromAdvertisedPRM
+// verifies RFC 9728 compliance: because an advertised PRM URL may not
+// share an origin with the protected resource, the response MUST declare
+// its `resource` identifier explicitly. Omitting it leaves no way to bind
+// the metadata to the protected resource the client addressed, so the
+// response is rejected.
+func TestOAuthHandler_GetServerMetadata_RejectsEmptyResourceFromAdvertisedPRM(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/advertised-prm" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OAuthProtectedResource{
+				// Resource deliberately omitted
+				AuthorizationServers: []string{"https://attacker.example/oauth"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  NewMemoryTokenStore(),
+	})
+	handler.SetBaseURL(server.URL)
+	handler.SetProtectedResourceMetadataURL(server.URL + "/advertised-prm")
+
+	_, err := handler.GetServerMetadata(context.Background())
+	require.Error(t, err, "advertised PRM response without a resource field must be rejected")
+	assert.Contains(t, err.Error(), "omits required resource field")
+}
+
 // TestOAuthHandler_GetServerMetadata_AcceptsMatchingResourceFromAdvertisedPRM
 // verifies that an advertised PRM response whose `resource` identifier
 // matches the base URL is accepted and drives downstream discovery normally.
@@ -2077,6 +2126,7 @@ func TestOAuthHandler_GetServerMetadata_UsesAdvertisedPRMURL(t *testing.T) {
 			advertisedPRMRequested = true
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(OAuthProtectedResource{
+				Resource:             server.URL,
 				AuthorizationServers: []string{server.URL},
 			})
 		case "/.well-known/oauth-protected-resource":

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -1813,9 +1813,14 @@ func TestExtractResourceMetadataURLs(t *testing.T) {
 			want:   nil,
 		},
 		{
-			name:   "truncated quoted value returns what was read",
+			name:   "unterminated quoted value is rejected",
 			header: `Bearer resource_metadata="https://example.com/prm`,
-			want:   []string{"https://example.com/prm"},
+			want:   nil,
+		},
+		{
+			name:   "lone trailing backslash in quoted value is rejected",
+			header: `Bearer resource_metadata="https://example.com/prm\`,
+			want:   nil,
 		},
 		{
 			name:   "returns all occurrences in order",
@@ -1996,6 +2001,8 @@ func TestResourceIdentifiersEqual(t *testing.T) {
 		{"different query", "https://example.com/mcp?a=1", "https://example.com/mcp?a=2", false},
 		{"userinfo difference", "https://u@example.com/mcp", "https://example.com/mcp", false},
 		{"unparseable falls back to string equality", "://bad", "://bad", true},
+		{"encoded slash distinct from literal slash", "https://example.com/a%2Fb", "https://example.com/a/b", false},
+		{"both encoded equally", "https://example.com/a%2Fb", "https://example.com/a%2Fb", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -1755,3 +1755,193 @@ func TestOAuthHandler_GetServerMetadata_AuthServerReturnsHTML(t *testing.T) {
 	assert.Equal(t, authServer.URL+"/token", metadata.TokenEndpoint)
 	assert.Equal(t, authServer.URL+"/register", metadata.RegistrationEndpoint)
 }
+
+func TestExtractResourceMetadataURL(t *testing.T) {
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{
+			name:   "empty header",
+			header: "",
+			want:   "",
+		},
+		{
+			name:   "bearer challenge with quoted resource_metadata",
+			header: `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/tenant"`,
+			want:   "https://example.com/.well-known/oauth-protected-resource/tenant",
+		},
+		{
+			name:   "bearer challenge with realm, error, and resource_metadata",
+			header: `Bearer realm="mcp", error="invalid_token", resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
+			want:   "https://example.com/.well-known/oauth-protected-resource",
+		},
+		{
+			name:   "parameter name matched case-insensitively",
+			header: `Bearer Resource_Metadata="https://example.com/prm"`,
+			want:   "https://example.com/prm",
+		},
+		{
+			name:   "unquoted token value",
+			header: `Bearer resource_metadata=abc123`,
+			want:   "abc123",
+		},
+		{
+			name:   "quoted value with escaped quote",
+			header: `Bearer resource_metadata="https://example.com/with-\"quote\""`,
+			want:   `https://example.com/with-"quote"`,
+		},
+		{
+			name:   "value with tabs and extra whitespace",
+			header: "Bearer\tresource_metadata\t=\t\"https://example.com/prm\"",
+			want:   "https://example.com/prm",
+		},
+		{
+			name:   "no resource_metadata parameter",
+			header: `Bearer realm="mcp", error="invalid_token"`,
+			want:   "",
+		},
+		{
+			name:   "word containing resource_metadata is not a match",
+			header: `Bearer realm="foo resource_metadata bar"`,
+			want:   "",
+		},
+		{
+			name:   "missing equals after parameter name",
+			header: `Bearer resource_metadata`,
+			want:   "",
+		},
+		{
+			name:   "truncated quoted value returns what was read",
+			header: `Bearer resource_metadata="https://example.com/prm`,
+			want:   "https://example.com/prm",
+		},
+		{
+			name:   "prefers first occurrence",
+			header: `Bearer resource_metadata="https://example.com/a", resource_metadata="https://example.com/b"`,
+			want:   "https://example.com/a",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractResourceMetadataURL(tc.header)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestOAuthHandler_ProtectedResourceMetadataURL_SetGet(t *testing.T) {
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+	})
+
+	assert.Equal(t, "", handler.ProtectedResourceMetadataURL(), "should default to empty")
+
+	handler.SetProtectedResourceMetadataURL("https://example.com/prm")
+	assert.Equal(t, "https://example.com/prm", handler.ProtectedResourceMetadataURL())
+
+	handler.SetProtectedResourceMetadataURL("")
+	assert.Equal(t, "", handler.ProtectedResourceMetadataURL(), "empty value should clear")
+}
+
+func TestOAuthHandler_HandleUnauthorizedResponse(t *testing.T) {
+	cases := []struct {
+		name     string
+		response *http.Response
+		want     string
+	}{
+		{
+			name:     "nil response is a no-op",
+			response: nil,
+			want:     "",
+		},
+		{
+			name: "no WWW-Authenticate header leaves PRM unset",
+			response: &http.Response{
+				Header: http.Header{},
+			},
+			want: "",
+		},
+		{
+			name: "bearer challenge without resource_metadata leaves PRM unset",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{`Bearer realm="mcp"`},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "bearer challenge with resource_metadata stores the URL",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{`Bearer resource_metadata="https://example.com/prm"`},
+				},
+			},
+			want: "https://example.com/prm",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := NewOAuthHandler(OAuthConfig{
+				ClientID:    "test-client",
+				RedirectURI: "http://localhost/callback",
+			})
+			handler.HandleUnauthorizedResponse(tc.response)
+			assert.Equal(t, tc.want, handler.ProtectedResourceMetadataURL())
+		})
+	}
+}
+
+// TestOAuthHandler_GetServerMetadata_UsesAdvertisedPRMURL verifies that when
+// the server has advertised a Protected Resource Metadata URL via
+// WWW-Authenticate (RFC 9728 §5.1), discovery fetches that URL in preference
+// to the origin-based /.well-known/oauth-protected-resource construction.
+func TestOAuthHandler_GetServerMetadata_UsesAdvertisedPRMURL(t *testing.T) {
+	advertisedPRMRequested := false
+	wellKnownPRMRequested := false
+	authServerRequested := false
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/custom/prm-path":
+			advertisedPRMRequested = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OAuthProtectedResource{
+				AuthorizationServers: []string{server.URL},
+			})
+		case "/.well-known/oauth-protected-resource":
+			wellKnownPRMRequested = true
+			w.WriteHeader(http.StatusNotFound)
+		case "/.well-known/oauth-authorization-server":
+			authServerRequested = true
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+				Issuer:                server.URL,
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  NewMemoryTokenStore(),
+	})
+	handler.SetBaseURL(server.URL)
+	handler.SetProtectedResourceMetadataURL(server.URL + "/custom/prm-path")
+
+	metadata, err := handler.GetServerMetadata(context.Background())
+	require.NoError(t, err)
+	assert.True(t, advertisedPRMRequested, "advertised PRM URL should be fetched")
+	assert.False(t, wellKnownPRMRequested, "well-known PRM URL should be skipped when an advertised one is set")
+	assert.True(t, authServerRequested, "authorization-server metadata should still be fetched")
+	assert.Equal(t, server.URL+"/token", metadata.TokenEndpoint)
+}

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -1847,6 +1847,7 @@ func TestOAuthHandler_ProtectedResourceMetadataURL_SetGet(t *testing.T) {
 }
 
 func TestOAuthHandler_HandleUnauthorizedResponse(t *testing.T) {
+	const baseURL = "https://example.com/mcp"
 	cases := []struct {
 		name     string
 		response *http.Response
@@ -1874,13 +1875,64 @@ func TestOAuthHandler_HandleUnauthorizedResponse(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "bearer challenge with resource_metadata stores the URL",
+			name: "bearer challenge with same-origin resource_metadata stores the URL",
 			response: &http.Response{
 				Header: http.Header{
-					"Www-Authenticate": []string{`Bearer resource_metadata="https://example.com/prm"`},
+					"Www-Authenticate": []string{`Bearer resource_metadata="https://example.com/mcp/.well-known/oauth-protected-resource"`},
 				},
 			},
-			want: "https://example.com/prm",
+			want: "https://example.com/mcp/.well-known/oauth-protected-resource",
+		},
+		{
+			name: "cross-host PRM URL is rejected",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{`Bearer resource_metadata="https://attacker.example/evil-prm"`},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "scheme-downgraded PRM URL is rejected",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{`Bearer resource_metadata="http://example.com/prm"`},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "unparseable PRM URL is rejected",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{`Bearer resource_metadata="://not-a-url"`},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "multiple WWW-Authenticate headers: picks first that validates",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{
+						`Basic realm="mcp"`,
+						`Bearer realm="mcp", resource_metadata="https://example.com/mcp/prm"`,
+					},
+				},
+			},
+			want: "https://example.com/mcp/prm",
+		},
+		{
+			name: "multiple headers: skips cross-origin and takes the valid one",
+			response: &http.Response{
+				Header: http.Header{
+					"Www-Authenticate": []string{
+						`Bearer resource_metadata="https://attacker.example/evil"`,
+						`Bearer resource_metadata="https://example.com/mcp/prm"`,
+					},
+				},
+			},
+			want: "https://example.com/mcp/prm",
 		},
 	}
 	for _, tc := range cases {
@@ -1889,10 +1941,124 @@ func TestOAuthHandler_HandleUnauthorizedResponse(t *testing.T) {
 				ClientID:    "test-client",
 				RedirectURI: "http://localhost/callback",
 			})
+			handler.SetBaseURL(baseURL)
 			handler.HandleUnauthorizedResponse(tc.response)
 			assert.Equal(t, tc.want, handler.ProtectedResourceMetadataURL())
 		})
 	}
+}
+
+// TestOAuthHandler_HandleUnauthorizedResponse_NoBaseURL verifies that origin
+// validation refuses to accept an advertised PRM URL when no base URL has
+// been configured — otherwise there is nothing to validate against.
+func TestOAuthHandler_HandleUnauthorizedResponse_NoBaseURL(t *testing.T) {
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+	})
+	handler.HandleUnauthorizedResponse(&http.Response{
+		Header: http.Header{
+			"Www-Authenticate": []string{`Bearer resource_metadata="https://example.com/prm"`},
+		},
+	})
+	assert.Equal(t, "", handler.ProtectedResourceMetadataURL())
+}
+
+func TestResourceIdentifiersEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"identical", "https://example.com/mcp", "https://example.com/mcp", true},
+		{"scheme case-insensitive", "HTTPS://example.com/mcp", "https://example.com/mcp", true},
+		{"host case-insensitive", "https://Example.COM/mcp", "https://example.com/mcp", true},
+		{"trailing slash ignored", "https://example.com/mcp", "https://example.com/mcp/", true},
+		{"different host", "https://example.com/mcp", "https://other.example/mcp", false},
+		{"different scheme", "http://example.com/mcp", "https://example.com/mcp", false},
+		{"different path", "https://example.com/mcp", "https://example.com/other", false},
+		{"different query", "https://example.com/mcp?a=1", "https://example.com/mcp?a=2", false},
+		{"userinfo difference", "https://u@example.com/mcp", "https://example.com/mcp", false},
+		{"unparseable falls back to string equality", "://bad", "://bad", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resourceIdentifiersEqual(tc.a, tc.b))
+		})
+	}
+}
+
+// TestOAuthHandler_GetServerMetadata_RejectsMismatchedResourceFromAdvertisedPRM
+// verifies RFC 9728 §3.3 / §7.3: when metadata is fetched from a PRM URL the
+// server advertised via WWW-Authenticate and the response declares a
+// `resource` identifier that does not match the protected resource the
+// client addressed, the metadata MUST NOT be used. Without this check, a
+// compromised resource could impersonate another and redirect OAuth
+// discovery to an attacker's authorization server.
+func TestOAuthHandler_GetServerMetadata_RejectsMismatchedResourceFromAdvertisedPRM(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/advertised-prm" {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OAuthProtectedResource{
+				Resource:             "https://impersonated.example/mcp",
+				AuthorizationServers: []string{"https://attacker.example/oauth"},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  NewMemoryTokenStore(),
+	})
+	handler.SetBaseURL(server.URL)
+	handler.SetProtectedResourceMetadataURL(server.URL + "/advertised-prm")
+
+	_, err := handler.GetServerMetadata(context.Background())
+	require.Error(t, err, "mismatched resource identifier must be rejected")
+	assert.Contains(t, err.Error(), "does not match base URL")
+}
+
+// TestOAuthHandler_GetServerMetadata_AcceptsMatchingResourceFromAdvertisedPRM
+// verifies that an advertised PRM response whose `resource` identifier
+// matches the base URL is accepted and drives downstream discovery normally.
+func TestOAuthHandler_GetServerMetadata_AcceptsMatchingResourceFromAdvertisedPRM(t *testing.T) {
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/advertised-prm":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(OAuthProtectedResource{
+				Resource:             server.URL + "/",
+				AuthorizationServers: []string{server.URL},
+			})
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(AuthServerMetadata{
+				Issuer:                server.URL,
+				AuthorizationEndpoint: server.URL + "/authorize",
+				TokenEndpoint:         server.URL + "/token",
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	handler := NewOAuthHandler(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  NewMemoryTokenStore(),
+	})
+	handler.SetBaseURL(server.URL)
+	handler.SetProtectedResourceMetadataURL(server.URL + "/advertised-prm")
+
+	metadata, err := handler.GetServerMetadata(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, server.URL+"/token", metadata.TokenEndpoint)
 }
 
 // TestOAuthHandler_GetServerMetadata_UsesAdvertisedPRMURL verifies that when

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -209,6 +209,7 @@ func (c *SSE) Start(ctx context.Context) error {
 		// Handle unauthorized error
 		if resp.StatusCode == http.StatusUnauthorized {
 			if c.oauthHandler != nil {
+				c.oauthHandler.HandleUnauthorizedResponse(resp)
 				return &OAuthAuthorizationRequiredError{
 					Handler: c.oauthHandler,
 				}
@@ -486,6 +487,7 @@ func (c *SSE) SendRequest(
 		// Handle unauthorized error
 		if resp.StatusCode == http.StatusUnauthorized {
 			if c.oauthHandler != nil {
+				c.oauthHandler.HandleUnauthorizedResponse(resp)
 				return nil, &OAuthAuthorizationRequiredError{
 					Handler: c.oauthHandler,
 				}
@@ -634,6 +636,7 @@ func (c *SSE) SendNotification(ctx context.Context, notification mcp.JSONRPCNoti
 		// Handle unauthorized error
 		if resp.StatusCode == http.StatusUnauthorized {
 			if c.oauthHandler != nil {
+				c.oauthHandler.HandleUnauthorizedResponse(resp)
 				return &OAuthAuthorizationRequiredError{
 					Handler: c.oauthHandler,
 				}

--- a/client/transport/sse_oauth_test.go
+++ b/client/transport/sse_oauth_test.go
@@ -260,3 +260,82 @@ func TestSSE_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
 		t.Errorf("Expected transport base URL to retain query and fragment, got %q", transport.baseURL.String())
 	}
 }
+
+// TestSSE_WithOAuth_ExtractsPRMFromWWWAuthenticate verifies that a 401
+// response carrying a WWW-Authenticate header with a resource_metadata
+// parameter (RFC 9728 §5.1) stores the advertised URL on the OAuth handler
+// so subsequent metadata discovery can use it.
+func TestSSE_WithOAuth_ExtractsPRMFromWWWAuthenticate(t *testing.T) {
+	const advertisedPRM = "https://example.com/tenant-a/.well-known/oauth-protected-resource"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", error="invalid_token", resource_metadata="`+advertisedPRM+`"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	// Pre-populate a token so the transport reaches the server and the 401
+	// WWW-Authenticate path runs — with no token the transport short-circuits
+	// with OAuthAuthorizationRequiredError before any HTTP request is sent.
+	tokenStore := NewMemoryTokenStore()
+	_ = tokenStore.SaveToken(context.Background(), &Token{
+		AccessToken: "rejected-by-server",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+
+	transport, err := NewSSE(server.URL, WithOAuth(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  tokenStore,
+	}))
+	if err != nil {
+		t.Fatalf("Failed to create SSE: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = transport.Start(ctx)
+
+	var oauthErr *OAuthAuthorizationRequiredError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("Expected OAuthAuthorizationRequiredError, got %T: %v", err, err)
+	}
+	if got := transport.GetOAuthHandler().ProtectedResourceMetadataURL(); got != advertisedPRM {
+		t.Errorf("Expected PRM URL %q, got %q", advertisedPRM, got)
+	}
+}
+
+// TestSSE_WithOAuth_NoWWWAuthenticate_LeavesPRMUnset verifies that a 401
+// without a WWW-Authenticate header preserves the pre-RFC-9728 behaviour:
+// no PRM URL is captured and discovery falls back to origin-based paths.
+func TestSSE_WithOAuth_NoWWWAuthenticate_LeavesPRMUnset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	tokenStore := NewMemoryTokenStore()
+	_ = tokenStore.SaveToken(context.Background(), &Token{
+		AccessToken: "rejected-by-server",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+
+	transport, err := NewSSE(server.URL, WithOAuth(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  tokenStore,
+	}))
+	if err != nil {
+		t.Fatalf("Failed to create SSE: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_ = transport.Start(ctx)
+
+	if got := transport.GetOAuthHandler().ProtectedResourceMetadataURL(); got != "" {
+		t.Errorf("Expected PRM URL to remain empty, got %q", got)
+	}
+}

--- a/client/transport/sse_oauth_test.go
+++ b/client/transport/sse_oauth_test.go
@@ -266,13 +266,15 @@ func TestSSE_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
 // parameter (RFC 9728 §5.1) stores the advertised URL on the OAuth handler
 // so subsequent metadata discovery can use it.
 func TestSSE_WithOAuth_ExtractsPRMFromWWWAuthenticate(t *testing.T) {
-	const advertisedPRM = "https://example.com/tenant-a/.well-known/oauth-protected-resource"
-
+	var advertisedPRM string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", error="invalid_token", resource_metadata="`+advertisedPRM+`"`)
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer server.Close()
+	// Same-origin PRM URL: origin validation requires the advertised URL's
+	// scheme and host to match the protected resource's base URL.
+	advertisedPRM = server.URL + "/tenant-a/.well-known/oauth-protected-resource"
 
 	// Pre-populate a token so the transport reaches the server and the 401
 	// WWW-Authenticate path runs — with no token the transport short-circuits

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -303,6 +303,7 @@ func (c *StreamableHTTP) SendRequest(
 		// Handle unauthorized error
 		if resp.StatusCode == http.StatusUnauthorized {
 			if c.oauthHandler != nil {
+				c.oauthHandler.HandleUnauthorizedResponse(resp)
 				return nil, &OAuthAuthorizationRequiredError{
 					Handler: c.oauthHandler,
 				}
@@ -593,6 +594,7 @@ func (c *StreamableHTTP) SendNotification(ctx context.Context, notification mcp.
 		return nil
 	case http.StatusUnauthorized:
 		if c.oauthHandler != nil {
+			c.oauthHandler.HandleUnauthorizedResponse(resp)
 			return &OAuthAuthorizationRequiredError{
 				Handler: c.oauthHandler,
 			}

--- a/client/transport/streamable_http_oauth_test.go
+++ b/client/transport/streamable_http_oauth_test.go
@@ -245,13 +245,15 @@ func TestStreamableHTTP_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
 // parameter (RFC 9728 §5.1) stores the advertised URL on the OAuth handler
 // so subsequent metadata discovery can use it.
 func TestStreamableHTTP_WithOAuth_ExtractsPRMFromWWWAuthenticate(t *testing.T) {
-	const advertisedPRM = "https://example.com/tenant-a/.well-known/oauth-protected-resource"
-
+	var advertisedPRM string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", error="invalid_token", resource_metadata="`+advertisedPRM+`"`)
 		w.WriteHeader(http.StatusUnauthorized)
 	}))
 	defer server.Close()
+	// Same-origin PRM URL: origin validation requires the advertised URL's
+	// scheme and host to match the protected resource's base URL.
+	advertisedPRM = server.URL + "/tenant-a/.well-known/oauth-protected-resource"
 
 	// Pre-populate a token so the transport reaches the server and the 401
 	// WWW-Authenticate path runs — with no token the transport short-circuits

--- a/client/transport/streamable_http_oauth_test.go
+++ b/client/transport/streamable_http_oauth_test.go
@@ -239,3 +239,86 @@ func TestStreamableHTTP_WithOAuth_PreservesPathInBaseURL(t *testing.T) {
 		t.Errorf("Expected transport server URL to retain query and fragment, got %q", transport.serverURL.String())
 	}
 }
+
+// TestStreamableHTTP_WithOAuth_ExtractsPRMFromWWWAuthenticate verifies that a
+// 401 response carrying a WWW-Authenticate header with a resource_metadata
+// parameter (RFC 9728 §5.1) stores the advertised URL on the OAuth handler
+// so subsequent metadata discovery can use it.
+func TestStreamableHTTP_WithOAuth_ExtractsPRMFromWWWAuthenticate(t *testing.T) {
+	const advertisedPRM = "https://example.com/tenant-a/.well-known/oauth-protected-resource"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("WWW-Authenticate", `Bearer realm="mcp", error="invalid_token", resource_metadata="`+advertisedPRM+`"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	// Pre-populate a token so the transport reaches the server and the 401
+	// WWW-Authenticate path runs — with no token the transport short-circuits
+	// with OAuthAuthorizationRequiredError before any HTTP request is sent.
+	tokenStore := NewMemoryTokenStore()
+	_ = tokenStore.SaveToken(context.Background(), &Token{
+		AccessToken: "rejected-by-server",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+
+	transport, err := NewStreamableHTTP(server.URL, WithHTTPOAuth(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  tokenStore,
+	}))
+	if err != nil {
+		t.Fatalf("Failed to create StreamableHTTP: %v", err)
+	}
+
+	_, err = transport.SendRequest(context.Background(), JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(1),
+		Method:  "test",
+	})
+
+	var oauthErr *OAuthAuthorizationRequiredError
+	if !errors.As(err, &oauthErr) {
+		t.Fatalf("Expected OAuthAuthorizationRequiredError, got %T: %v", err, err)
+	}
+	if got := transport.GetOAuthHandler().ProtectedResourceMetadataURL(); got != advertisedPRM {
+		t.Errorf("Expected PRM URL %q, got %q", advertisedPRM, got)
+	}
+}
+
+// TestStreamableHTTP_WithOAuth_NoWWWAuthenticate_LeavesPRMUnset verifies that
+// a 401 without a WWW-Authenticate header preserves pre-RFC-9728 behaviour:
+// no PRM URL is captured and discovery falls back to origin-based paths.
+func TestStreamableHTTP_WithOAuth_NoWWWAuthenticate_LeavesPRMUnset(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	tokenStore := NewMemoryTokenStore()
+	_ = tokenStore.SaveToken(context.Background(), &Token{
+		AccessToken: "rejected-by-server",
+		TokenType:   "Bearer",
+		ExpiresAt:   time.Now().Add(1 * time.Hour),
+	})
+
+	transport, err := NewStreamableHTTP(server.URL, WithHTTPOAuth(OAuthConfig{
+		ClientID:    "test-client",
+		RedirectURI: "http://localhost/callback",
+		TokenStore:  tokenStore,
+	}))
+	if err != nil {
+		t.Fatalf("Failed to create StreamableHTTP: %v", err)
+	}
+
+	_, _ = transport.SendRequest(context.Background(), JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(1),
+		Method:  "test",
+	})
+
+	if got := transport.GetOAuthHandler().ProtectedResourceMetadataURL(); got != "" {
+		t.Errorf("Expected PRM URL to remain empty, got %q", got)
+	}
+}


### PR DESCRIPTION
## Description

Adds RFC 9728 §5.1 support for extracting the Protected Resource Metadata URL from the `WWW-Authenticate` header on 401 responses.

This is the remaining piece of the OAuth RFC-compliance work tracked in #697 after #761 and #775 landed the path-preservation fixes, and closes the specific ask in #688.

### Why

Per [RFC 9728 §5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1), a resource server that requires OAuth advertises its PRM URL to clients via:

```http
HTTP/1.1 401 Unauthorized
WWW-Authenticate: Bearer realm="mcp", error="invalid_token", resource_metadata="https://example.com/.well-known/oauth-protected-resource/tenant"
```

Clients that honour this header can discover the PRM endpoint in deployments where origin-based `/.well-known/oauth-protected-resource` construction can't reach it — for example, MCP servers sitting behind a shared gateway with path-based routing (Smithery, Cloudflare, Kubernetes Ingress by path, etc.). Without this support, DCR fails with 404, the authorization URL ends up with an empty `client_id`, and users have to set `AuthServerMetadataURL` manually.

### What changes

- **`client/transport/oauth.go`**
  - New `ProtectedResourceMetadataURL` field on `OAuthHandler`, guarded by the existing mutex.
  - Exported setter/getter: `SetProtectedResourceMetadataURL` / `ProtectedResourceMetadataURL`.
  - Exported `HandleUnauthorizedResponse(resp *http.Response)` — extracts `resource_metadata` from `WWW-Authenticate` and stores it. Safe on nil responses / missing headers.
  - New `extractResourceMetadataURL` helper — a small RFC 9110 §5.6.2 token + quoted-string parser that matches parameter names case-insensitively (RFC 9110 §11.2) and handles both quoted-string and token value forms.
  - `getServerMetadata` now prefers the stored PRM URL over the origin-based `/.well-known/oauth-protected-resource` construction when one has been advertised.
- **`client/transport/sse.go`, `client/transport/streamable_http.go`** — call `HandleUnauthorizedResponse(resp)` at all five 401 sites (SSE Start / SendRequest / SendNotification, StreamableHTTP SendRequest / SendNotification) so the PRM URL is captured wherever it's advertised.

### Backward compatibility

Fully backward compatible. When the server doesn't send a `resource_metadata` parameter, `HandleUnauthorizedResponse` is a no-op and metadata discovery falls through to the existing `buildWellKnownURL` path. No public-API breakage. Test `TestSSE_WithOAuth_NoWWWAuthenticate_LeavesPRMUnset` and its streamable-HTTP twin pin this behaviour.

### Tests

- `TestExtractResourceMetadataURL` — 12 subtests covering: empty header, quoted value, unquoted token, case-insensitive parameter name, escaped quotes in quoted value, tabs/whitespace handling, multiple parameters in a Bearer challenge, word-substring rejection, missing `=`, truncated quoted value, first-occurrence preference.
- `TestOAuthHandler_ProtectedResourceMetadataURL_SetGet` — setter/getter round-trip.
- `TestOAuthHandler_HandleUnauthorizedResponse` — 4 subtests: nil response, no header, header without the parameter, header with the parameter.
- `TestOAuthHandler_GetServerMetadata_UsesAdvertisedPRMURL` — end-to-end discovery: asserts the advertised URL is fetched instead of the well-known one.
- `TestSSE_WithOAuth_ExtractsPRMFromWWWAuthenticate` + `TestStreamableHTTP_WithOAuth_ExtractsPRMFromWWWAuthenticate` — transport-level: 401 + header → PRM URL stored on handler.
- `TestSSE_WithOAuth_NoWWWAuthenticate_LeavesPRMUnset` + streamable twin — backward-compat regression guard.

Validated locally with:

```bash
go test ./... -race -count=1           # all green
golangci-lint run ./client/transport/... # 0 issues
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly (godoc comments on all new exported symbols)

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification

- Link to relevant spec section: [MCP Authorization — resource_metadata in WWW-Authenticate](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization)
- Also aligns with [RFC 9728 §5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1) and [RFC 9110 §11.2](https://datatracker.ietf.org/doc/html/rfc9110#section-11.2)

- [x] Implementation follows the specification exactly

## Additional Information

The existing PR #718 attempted to cover this plus the path-preservation work in a single patch; this PR is scoped strictly to the WWW-Authenticate parsing that remained unmerged after #761 and #775. Happy to rebase or adjust scope on request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth now extracts and stores protected-resource metadata advertised in 401 WWW-Authenticate headers and prefers a validated advertised PRM URL during protected-resource discovery.
* **Behavior Change**
  * SSE and HTTP transports now invoke OAuth handling on 401 responses so advertised metadata is captured before returning unauthorized errors.
* **Tests**
  * Added comprehensive tests covering PRM parsing, validation, discovery behavior, and transport handling on 401 responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->