### PR TITLE
feat: add ToolUseContent and ToolResultContent types for sampling flows

### DIFF
--- a/mcp/consts.go
+++ b/mcp/consts.go
@@ -1,11 +1,13 @@
 package mcp
 
 const (
-	ContentTypeText     = "text"
-	ContentTypeImage    = "image"
-	ContentTypeAudio    = "audio"
-	ContentTypeLink     = "resource_link"
-	ContentTypeResource = "resource"
+	ContentTypeText       = "text"
+	ContentTypeImage      = "image"
+	ContentTypeAudio      = "audio"
+	ContentTypeLink       = "resource_link"
+	ContentTypeResource   = "resource"
+	ContentTypeToolUse    = "tool_use"
+	ContentTypeToolResult = "tool_result"
 
 	ElicitationModeForm = "form"
 	ElicitationModeURL  = "url"

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1149,6 +1149,74 @@ type EmbeddedResource struct {
 
 func (EmbeddedResource) isContent() {}
 
+// ToolUseContent represents a tool invocation within a sampling message.
+// It must have Type set to "tool_use".
+type ToolUseContent struct {
+	Annotated
+	// Meta is a metadata object that is reserved by MCP for storing additional information.
+	Meta *Meta  `json:"_meta,omitempty"`
+	Type string `json:"type"` // Must be "tool_use"
+	// The name of the tool being invoked.
+	ToolName string `json:"toolName"`
+	// The arguments to pass to the tool.
+	Arguments any `json:"arguments,omitempty"`
+}
+
+func (ToolUseContent) isContent() {}
+
+// ToolResultContent represents the result of a tool invocation within a sampling message.
+// It must have Type set to "tool_result".
+type ToolResultContent struct {
+	Annotated
+	// Meta is a metadata object that is reserved by MCP for storing additional information.
+	Meta *Meta  `json:"_meta,omitempty"`
+	Type string `json:"type"` // Must be "tool_result"
+	// The name of the tool that produced this result.
+	ToolName string `json:"toolName"`
+	// The content of the tool result.
+	Content []Content `json:"content,omitempty"`
+	// Whether the tool invocation ended in an error.
+	IsError bool `json:"isError,omitempty"`
+}
+
+func (ToolResultContent) isContent() {}
+
+// toolResultContentJSON is a helper type for unmarshaling ToolResultContent.
+type toolResultContentJSON struct {
+	Annotated
+	Meta     *Meta              `json:"_meta,omitempty"`
+	Type     string             `json:"type"`
+	ToolName string             `json:"toolName"`
+	Content  []json.RawMessage  `json:"content,omitempty"`
+	IsError  bool               `json:"isError,omitempty"`
+}
+
+// UnmarshalJSON implements custom JSON unmarshaling for ToolResultContent
+// to handle the nested Content interface slice.
+func (t *ToolResultContent) UnmarshalJSON(data []byte) error {
+	var raw toolResultContentJSON
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	t.Annotated = raw.Annotated
+	t.Meta = raw.Meta
+	t.Type = raw.Type
+	t.ToolName = raw.ToolName
+	t.IsError = raw.IsError
+
+	if len(raw.Content) > 0 {
+		t.Content = make([]Content, 0, len(raw.Content))
+		for _, rawContent := range raw.Content {
+			c, err := UnmarshalContent(rawContent)
+			if err != nil {
+				return fmt.Errorf("unmarshaling tool result content: %w", err)
+			}
+			t.Content = append(t.Content, c)
+		}
+	}
+	return nil
+}
+
 // ModelPreferences represents the server's preferences for model selection,
 // requested of the client during sampling.
 //
@@ -1579,6 +1647,14 @@ func UnmarshalContent(data []byte) (Content, error) {
 		return content, err
 	case ContentTypeResource:
 		var content EmbeddedResource
+		err := json.Unmarshal(data, &content)
+		return content, err
+	case ContentTypeToolUse:
+		var content ToolUseContent
+		err := json.Unmarshal(data, &content)
+		return content, err
+	case ContentTypeToolResult:
+		var content ToolResultContent
 		err := json.Unmarshal(data, &content)
 		return content, err
 	default:

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1149,17 +1149,19 @@ type EmbeddedResource struct {
 
 func (EmbeddedResource) isContent() {}
 
-// ToolUseContent represents a tool invocation within a sampling message.
+// ToolUseContent represents a request from the assistant to call a tool within a sampling message.
 // It must have Type set to "tool_use".
 type ToolUseContent struct {
 	Annotated
 	// Meta is a metadata object that is reserved by MCP for storing additional information.
 	Meta *Meta  `json:"_meta,omitempty"`
 	Type string `json:"type"` // Must be "tool_use"
-	// The name of the tool being invoked.
-	ToolName string `json:"toolName"`
-	// The arguments to pass to the tool.
-	Arguments any `json:"arguments,omitempty"`
+	// ID is a unique identifier for this tool use, used to match tool results to their corresponding tool uses.
+	ID string `json:"id"`
+	// Name is the name of the tool to call.
+	Name string `json:"name"`
+	// Input contains the arguments to pass to the tool, conforming to the tool's input schema.
+	Input any `json:"input"`
 }
 
 func (ToolUseContent) isContent() {}
@@ -1171,11 +1173,12 @@ type ToolResultContent struct {
 	// Meta is a metadata object that is reserved by MCP for storing additional information.
 	Meta *Meta  `json:"_meta,omitempty"`
 	Type string `json:"type"` // Must be "tool_result"
-	// The name of the tool that produced this result.
-	ToolName string `json:"toolName"`
-	// The content of the tool result.
-	Content []Content `json:"content,omitempty"`
-	// Whether the tool invocation ended in an error.
+	// ToolUseID is the ID of the tool use this result corresponds to.
+	// This MUST match the ID from a previous ToolUseContent.
+	ToolUseID string `json:"toolUseId"`
+	// Content is the unstructured result content of the tool use.
+	Content []Content `json:"content"`
+	// Whether the tool use resulted in an error.
 	IsError bool `json:"isError,omitempty"`
 }
 
@@ -1184,11 +1187,11 @@ func (ToolResultContent) isContent() {}
 // toolResultContentJSON is a helper type for unmarshaling ToolResultContent.
 type toolResultContentJSON struct {
 	Annotated
-	Meta     *Meta              `json:"_meta,omitempty"`
-	Type     string             `json:"type"`
-	ToolName string             `json:"toolName"`
-	Content  []json.RawMessage  `json:"content,omitempty"`
-	IsError  bool               `json:"isError,omitempty"`
+	Meta      *Meta             `json:"_meta,omitempty"`
+	Type      string            `json:"type"`
+	ToolUseID string            `json:"toolUseId"`
+	Content   []json.RawMessage `json:"content"`
+	IsError   bool              `json:"isError,omitempty"`
 }
 
 // UnmarshalJSON implements custom JSON unmarshaling for ToolResultContent
@@ -1201,7 +1204,7 @@ func (t *ToolResultContent) UnmarshalJSON(data []byte) error {
 	t.Annotated = raw.Annotated
 	t.Meta = raw.Meta
 	t.Type = raw.Type
-	t.ToolName = raw.ToolName
+	t.ToolUseID = raw.ToolUseID
 	t.IsError = raw.IsError
 
 	if len(raw.Content) > 0 {

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -100,6 +100,16 @@ func AsEmbeddedResource(content any) (*EmbeddedResource, bool) {
 	return asType[EmbeddedResource](content)
 }
 
+// AsToolUseContent attempts to cast the given interface to ToolUseContent
+func AsToolUseContent(content any) (*ToolUseContent, bool) {
+	return asType[ToolUseContent](content)
+}
+
+// AsToolResultContent attempts to cast the given interface to ToolResultContent
+func AsToolResultContent(content any) (*ToolResultContent, bool) {
+	return asType[ToolResultContent](content)
+}
+
 // AsTextResourceContents attempts to cast the given interface to TextResourceContents
 func AsTextResourceContents(content any) (*TextResourceContents, bool) {
 	return asType[TextResourceContents](content)
@@ -264,6 +274,25 @@ func NewEmbeddedResource(resource ResourceContents) EmbeddedResource {
 	return EmbeddedResource{
 		Type:     ContentTypeResource,
 		Resource: resource,
+	}
+}
+
+// NewToolUseContent creates a new ToolUseContent with the given tool name and arguments.
+func NewToolUseContent(toolName string, arguments any) ToolUseContent {
+	return ToolUseContent{
+		Type:      ContentTypeToolUse,
+		ToolName:  toolName,
+		Arguments: arguments,
+	}
+}
+
+// NewToolResultContent creates a new ToolResultContent with the given tool name, content, and error flag.
+func NewToolResultContent(toolName string, content []Content, isError bool) ToolResultContent {
+	return ToolResultContent{
+		Type:     ContentTypeToolResult,
+		ToolName: toolName,
+		Content:  content,
+		IsError:  isError,
 	}
 }
 
@@ -651,6 +680,40 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 		}
 
 		c := NewEmbeddedResource(resourceContents)
+		c.Annotations = annotations
+		c.Meta = meta
+		return c, nil
+
+	case ContentTypeToolUse:
+		toolName := ExtractString(contentMap, "toolName")
+		if toolName == "" {
+			return nil, fmt.Errorf("toolName is missing")
+		}
+		arguments := contentMap["arguments"]
+		c := NewToolUseContent(toolName, arguments)
+		c.Annotations = annotations
+		c.Meta = meta
+		return c, nil
+
+	case ContentTypeToolResult:
+		toolName := ExtractString(contentMap, "toolName")
+		if toolName == "" {
+			return nil, fmt.Errorf("toolName is missing")
+		}
+		isError, _ := contentMap["isError"].(bool)
+		var contentItems []Content
+		if rawContent, ok := contentMap["content"].([]any); ok {
+			for _, item := range rawContent {
+				if itemMap, ok := item.(map[string]any); ok {
+					parsed, err := ParseContent(itemMap)
+					if err != nil {
+						return nil, fmt.Errorf("parsing tool result content: %w", err)
+					}
+					contentItems = append(contentItems, parsed)
+				}
+			}
+		}
+		c := NewToolResultContent(toolName, contentItems, isError)
 		c.Annotations = annotations
 		c.Meta = meta
 		return c, nil

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -277,22 +277,23 @@ func NewEmbeddedResource(resource ResourceContents) EmbeddedResource {
 	}
 }
 
-// NewToolUseContent creates a new ToolUseContent with the given tool name and arguments.
-func NewToolUseContent(toolName string, arguments any) ToolUseContent {
+// NewToolUseContent creates a new ToolUseContent with the given id, tool name, and input arguments.
+func NewToolUseContent(id, name string, input any) ToolUseContent {
 	return ToolUseContent{
-		Type:      ContentTypeToolUse,
-		ToolName:  toolName,
-		Arguments: arguments,
+		Type:  ContentTypeToolUse,
+		ID:    id,
+		Name:  name,
+		Input: input,
 	}
 }
 
-// NewToolResultContent creates a new ToolResultContent with the given tool name, content, and error flag.
-func NewToolResultContent(toolName string, content []Content, isError bool) ToolResultContent {
+// NewToolResultContent creates a new ToolResultContent with the given tool use ID, content, and error flag.
+func NewToolResultContent(toolUseID string, content []Content, isError bool) ToolResultContent {
 	return ToolResultContent{
-		Type:     ContentTypeToolResult,
-		ToolName: toolName,
-		Content:  content,
-		IsError:  isError,
+		Type:      ContentTypeToolResult,
+		ToolUseID: toolUseID,
+		Content:   content,
+		IsError:   isError,
 	}
 }
 
@@ -685,20 +686,24 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 		return c, nil
 
 	case ContentTypeToolUse:
-		toolName := ExtractString(contentMap, "toolName")
-		if toolName == "" {
-			return nil, fmt.Errorf("toolName is missing")
+		id := ExtractString(contentMap, "id")
+		if id == "" {
+			return nil, fmt.Errorf("tool_use id is missing")
 		}
-		arguments := contentMap["arguments"]
-		c := NewToolUseContent(toolName, arguments)
+		name := ExtractString(contentMap, "name")
+		if name == "" {
+			return nil, fmt.Errorf("tool_use name is missing")
+		}
+		input := contentMap["input"]
+		c := NewToolUseContent(id, name, input)
 		c.Annotations = annotations
 		c.Meta = meta
 		return c, nil
 
 	case ContentTypeToolResult:
-		toolName := ExtractString(contentMap, "toolName")
-		if toolName == "" {
-			return nil, fmt.Errorf("toolName is missing")
+		toolUseID := ExtractString(contentMap, "toolUseId")
+		if toolUseID == "" {
+			return nil, fmt.Errorf("tool_result toolUseId is missing")
 		}
 		isError, _ := contentMap["isError"].(bool)
 		var contentItems []Content
@@ -713,7 +718,7 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 				}
 			}
 		}
-		c := NewToolResultContent(toolName, contentItems, isError)
+		c := NewToolResultContent(toolUseID, contentItems, isError)
 		c.Annotations = annotations
 		c.Meta = meta
 		return c, nil

--- a/mcp/utils_additional_test.go
+++ b/mcp/utils_additional_test.go
@@ -607,20 +607,21 @@ func TestNewToolResultErrorFromErr_WithError(t *testing.T) {
 
 func TestNewToolUseContent(t *testing.T) {
 	args := map[string]any{"city": "London"}
-	result := NewToolUseContent("get_weather", args)
+	result := NewToolUseContent("tu_1", "get_weather", args)
 
 	assert.Equal(t, ContentTypeToolUse, result.Type)
-	assert.Equal(t, "get_weather", result.ToolName)
-	assert.Equal(t, args, result.Arguments)
+	assert.Equal(t, "tu_1", result.ID)
+	assert.Equal(t, "get_weather", result.Name)
+	assert.Equal(t, args, result.Input)
 }
 
 func TestNewToolResultContent(t *testing.T) {
 	t.Run("with content", func(t *testing.T) {
 		content := []Content{NewTextContent("Sunny, 22°C")}
-		result := NewToolResultContent("get_weather", content, false)
+		result := NewToolResultContent("tu_1", content, false)
 
 		assert.Equal(t, ContentTypeToolResult, result.Type)
-		assert.Equal(t, "get_weather", result.ToolName)
+		assert.Equal(t, "tu_1", result.ToolUseID)
 		assert.False(t, result.IsError)
 		require.Len(t, result.Content, 1)
 		tc, ok := result.Content[0].(TextContent)
@@ -630,29 +631,30 @@ func TestNewToolResultContent(t *testing.T) {
 
 	t.Run("with error", func(t *testing.T) {
 		content := []Content{NewTextContent("tool failed")}
-		result := NewToolResultContent("failing_tool", content, true)
+		result := NewToolResultContent("tu_2", content, true)
 
 		assert.Equal(t, ContentTypeToolResult, result.Type)
-		assert.Equal(t, "failing_tool", result.ToolName)
+		assert.Equal(t, "tu_2", result.ToolUseID)
 		assert.True(t, result.IsError)
 	})
 
 	t.Run("nil content", func(t *testing.T) {
-		result := NewToolResultContent("simple_tool", nil, false)
+		result := NewToolResultContent("tu_3", nil, false)
 
 		assert.Equal(t, ContentTypeToolResult, result.Type)
-		assert.Equal(t, "simple_tool", result.ToolName)
+		assert.Equal(t, "tu_3", result.ToolUseID)
 		assert.Nil(t, result.Content)
 	})
 }
 
 func TestAsToolUseContent(t *testing.T) {
 	t.Run("valid ToolUseContent", func(t *testing.T) {
-		content := ToolUseContent{Type: ContentTypeToolUse, ToolName: "test_tool"}
+		content := ToolUseContent{Type: ContentTypeToolUse, ID: "tu_1", Name: "test_tool"}
 		result, ok := AsToolUseContent(content)
 		assert.True(t, ok)
 		require.NotNil(t, result)
-		assert.Equal(t, "test_tool", result.ToolName)
+		assert.Equal(t, "test_tool", result.Name)
+		assert.Equal(t, "tu_1", result.ID)
 	})
 
 	t.Run("invalid type", func(t *testing.T) {
@@ -665,11 +667,11 @@ func TestAsToolUseContent(t *testing.T) {
 
 func TestAsToolResultContent(t *testing.T) {
 	t.Run("valid ToolResultContent", func(t *testing.T) {
-		content := ToolResultContent{Type: ContentTypeToolResult, ToolName: "test_tool"}
+		content := ToolResultContent{Type: ContentTypeToolResult, ToolUseID: "tu_1"}
 		result, ok := AsToolResultContent(content)
 		assert.True(t, ok)
 		require.NotNil(t, result)
-		assert.Equal(t, "test_tool", result.ToolName)
+		assert.Equal(t, "tu_1", result.ToolUseID)
 	})
 
 	t.Run("invalid type", func(t *testing.T) {
@@ -681,29 +683,30 @@ func TestAsToolResultContent(t *testing.T) {
 }
 
 func TestUnmarshalContent_ToolUse(t *testing.T) {
-	data := []byte(`{"type":"tool_use","toolName":"get_weather","arguments":{"city":"London"}}`)
+	data := []byte(`{"type":"tool_use","id":"tu_1","name":"get_weather","input":{"city":"London"}}`)
 	result, err := UnmarshalContent(data)
 	require.NoError(t, err)
 
 	tc, ok := result.(ToolUseContent)
 	require.True(t, ok)
 	assert.Equal(t, ContentTypeToolUse, tc.Type)
-	assert.Equal(t, "get_weather", tc.ToolName)
-	args, ok := tc.Arguments.(map[string]any)
+	assert.Equal(t, "tu_1", tc.ID)
+	assert.Equal(t, "get_weather", tc.Name)
+	args, ok := tc.Input.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "London", args["city"])
 }
 
 func TestUnmarshalContent_ToolResult(t *testing.T) {
 	t.Run("with nested content", func(t *testing.T) {
-		data := []byte(`{"type":"tool_result","toolName":"get_weather","content":[{"type":"text","text":"Sunny, 22°C"}],"isError":false}`)
+		data := []byte(`{"type":"tool_result","toolUseId":"tu_1","content":[{"type":"text","text":"Sunny, 22°C"}],"isError":false}`)
 		result, err := UnmarshalContent(data)
 		require.NoError(t, err)
 
 		tc, ok := result.(ToolResultContent)
 		require.True(t, ok)
 		assert.Equal(t, ContentTypeToolResult, tc.Type)
-		assert.Equal(t, "get_weather", tc.ToolName)
+		assert.Equal(t, "tu_1", tc.ToolUseID)
 		assert.False(t, tc.IsError)
 		require.Len(t, tc.Content, 1)
 		text, ok := tc.Content[0].(TextContent)
@@ -712,30 +715,30 @@ func TestUnmarshalContent_ToolResult(t *testing.T) {
 	})
 
 	t.Run("with isError", func(t *testing.T) {
-		data := []byte(`{"type":"tool_result","toolName":"broken","isError":true,"content":[{"type":"text","text":"error occurred"}]}`)
+		data := []byte(`{"type":"tool_result","toolUseId":"tu_2","isError":true,"content":[{"type":"text","text":"error occurred"}]}`)
 		result, err := UnmarshalContent(data)
 		require.NoError(t, err)
 
 		tc, ok := result.(ToolResultContent)
 		require.True(t, ok)
 		assert.True(t, tc.IsError)
-		assert.Equal(t, "broken", tc.ToolName)
+		assert.Equal(t, "tu_2", tc.ToolUseID)
 	})
 
 	t.Run("without content", func(t *testing.T) {
-		data := []byte(`{"type":"tool_result","toolName":"simple_tool"}`)
+		data := []byte(`{"type":"tool_result","toolUseId":"tu_3","content":[]}`)
 		result, err := UnmarshalContent(data)
 		require.NoError(t, err)
 
 		tc, ok := result.(ToolResultContent)
 		require.True(t, ok)
-		assert.Equal(t, "simple_tool", tc.ToolName)
-		assert.Nil(t, tc.Content)
+		assert.Equal(t, "tu_3", tc.ToolUseID)
+		assert.Empty(t, tc.Content)
 	})
 }
 
 func TestToolUseContent_JSONRoundTrip(t *testing.T) {
-	original := NewToolUseContent("get_weather", map[string]any{"city": "London"})
+	original := NewToolUseContent("tu_1", "get_weather", map[string]any{"city": "London"})
 	data, err := json.Marshal(original)
 	require.NoError(t, err)
 
@@ -745,14 +748,15 @@ func TestToolUseContent_JSONRoundTrip(t *testing.T) {
 	tc, ok := result.(ToolUseContent)
 	require.True(t, ok)
 	assert.Equal(t, original.Type, tc.Type)
-	assert.Equal(t, original.ToolName, tc.ToolName)
-	args, ok := tc.Arguments.(map[string]any)
+	assert.Equal(t, original.ID, tc.ID)
+	assert.Equal(t, original.Name, tc.Name)
+	args, ok := tc.Input.(map[string]any)
 	require.True(t, ok)
 	assert.Equal(t, "London", args["city"])
 }
 
 func TestToolResultContent_JSONRoundTrip(t *testing.T) {
-	original := NewToolResultContent("get_weather", []Content{NewTextContent("Sunny, 22°C")}, false)
+	original := NewToolResultContent("tu_1", []Content{NewTextContent("Sunny, 22°C")}, false)
 	data, err := json.Marshal(original)
 	require.NoError(t, err)
 
@@ -762,7 +766,7 @@ func TestToolResultContent_JSONRoundTrip(t *testing.T) {
 	tc, ok := result.(ToolResultContent)
 	require.True(t, ok)
 	assert.Equal(t, original.Type, tc.Type)
-	assert.Equal(t, original.ToolName, tc.ToolName)
+	assert.Equal(t, original.ToolUseID, tc.ToolUseID)
 	assert.Equal(t, original.IsError, tc.IsError)
 	require.Len(t, tc.Content, 1)
 	text, ok := tc.Content[0].(TextContent)
@@ -771,11 +775,11 @@ func TestToolResultContent_JSONRoundTrip(t *testing.T) {
 }
 
 func TestToolUseContent_IsContent(t *testing.T) {
-	var c Content = ToolUseContent{Type: ContentTypeToolUse, ToolName: "test"}
+	var c Content = ToolUseContent{Type: ContentTypeToolUse, ID: "tu_1", Name: "test"}
 	assert.NotNil(t, c)
 }
 
 func TestToolResultContent_IsContent(t *testing.T) {
-	var c Content = ToolResultContent{Type: ContentTypeToolResult, ToolName: "test"}
+	var c Content = ToolResultContent{Type: ContentTypeToolResult, ToolUseID: "tu_1"}
 	assert.NotNil(t, c)
 }

--- a/mcp/utils_additional_test.go
+++ b/mcp/utils_additional_test.go
@@ -602,3 +602,180 @@ func TestNewToolResultErrorFromErr_WithError(t *testing.T) {
 	assert.Contains(t, textContent.Text, "test error")
 	assert.Contains(t, textContent.Text, "underlying error")
 }
+
+// Test ToolUseContent and ToolResultContent
+
+func TestNewToolUseContent(t *testing.T) {
+	args := map[string]any{"city": "London"}
+	result := NewToolUseContent("get_weather", args)
+
+	assert.Equal(t, ContentTypeToolUse, result.Type)
+	assert.Equal(t, "get_weather", result.ToolName)
+	assert.Equal(t, args, result.Arguments)
+}
+
+func TestNewToolResultContent(t *testing.T) {
+	t.Run("with content", func(t *testing.T) {
+		content := []Content{NewTextContent("Sunny, 22°C")}
+		result := NewToolResultContent("get_weather", content, false)
+
+		assert.Equal(t, ContentTypeToolResult, result.Type)
+		assert.Equal(t, "get_weather", result.ToolName)
+		assert.False(t, result.IsError)
+		require.Len(t, result.Content, 1)
+		tc, ok := result.Content[0].(TextContent)
+		require.True(t, ok)
+		assert.Equal(t, "Sunny, 22°C", tc.Text)
+	})
+
+	t.Run("with error", func(t *testing.T) {
+		content := []Content{NewTextContent("tool failed")}
+		result := NewToolResultContent("failing_tool", content, true)
+
+		assert.Equal(t, ContentTypeToolResult, result.Type)
+		assert.Equal(t, "failing_tool", result.ToolName)
+		assert.True(t, result.IsError)
+	})
+
+	t.Run("nil content", func(t *testing.T) {
+		result := NewToolResultContent("simple_tool", nil, false)
+
+		assert.Equal(t, ContentTypeToolResult, result.Type)
+		assert.Equal(t, "simple_tool", result.ToolName)
+		assert.Nil(t, result.Content)
+	})
+}
+
+func TestAsToolUseContent(t *testing.T) {
+	t.Run("valid ToolUseContent", func(t *testing.T) {
+		content := ToolUseContent{Type: ContentTypeToolUse, ToolName: "test_tool"}
+		result, ok := AsToolUseContent(content)
+		assert.True(t, ok)
+		require.NotNil(t, result)
+		assert.Equal(t, "test_tool", result.ToolName)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		content := TextContent{Type: ContentTypeText, Text: "text"}
+		result, ok := AsToolUseContent(content)
+		assert.False(t, ok)
+		assert.Nil(t, result)
+	})
+}
+
+func TestAsToolResultContent(t *testing.T) {
+	t.Run("valid ToolResultContent", func(t *testing.T) {
+		content := ToolResultContent{Type: ContentTypeToolResult, ToolName: "test_tool"}
+		result, ok := AsToolResultContent(content)
+		assert.True(t, ok)
+		require.NotNil(t, result)
+		assert.Equal(t, "test_tool", result.ToolName)
+	})
+
+	t.Run("invalid type", func(t *testing.T) {
+		content := TextContent{Type: ContentTypeText, Text: "text"}
+		result, ok := AsToolResultContent(content)
+		assert.False(t, ok)
+		assert.Nil(t, result)
+	})
+}
+
+func TestUnmarshalContent_ToolUse(t *testing.T) {
+	data := []byte(`{"type":"tool_use","toolName":"get_weather","arguments":{"city":"London"}}`)
+	result, err := UnmarshalContent(data)
+	require.NoError(t, err)
+
+	tc, ok := result.(ToolUseContent)
+	require.True(t, ok)
+	assert.Equal(t, ContentTypeToolUse, tc.Type)
+	assert.Equal(t, "get_weather", tc.ToolName)
+	args, ok := tc.Arguments.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "London", args["city"])
+}
+
+func TestUnmarshalContent_ToolResult(t *testing.T) {
+	t.Run("with nested content", func(t *testing.T) {
+		data := []byte(`{"type":"tool_result","toolName":"get_weather","content":[{"type":"text","text":"Sunny, 22°C"}],"isError":false}`)
+		result, err := UnmarshalContent(data)
+		require.NoError(t, err)
+
+		tc, ok := result.(ToolResultContent)
+		require.True(t, ok)
+		assert.Equal(t, ContentTypeToolResult, tc.Type)
+		assert.Equal(t, "get_weather", tc.ToolName)
+		assert.False(t, tc.IsError)
+		require.Len(t, tc.Content, 1)
+		text, ok := tc.Content[0].(TextContent)
+		require.True(t, ok)
+		assert.Equal(t, "Sunny, 22°C", text.Text)
+	})
+
+	t.Run("with isError", func(t *testing.T) {
+		data := []byte(`{"type":"tool_result","toolName":"broken","isError":true,"content":[{"type":"text","text":"error occurred"}]}`)
+		result, err := UnmarshalContent(data)
+		require.NoError(t, err)
+
+		tc, ok := result.(ToolResultContent)
+		require.True(t, ok)
+		assert.True(t, tc.IsError)
+		assert.Equal(t, "broken", tc.ToolName)
+	})
+
+	t.Run("without content", func(t *testing.T) {
+		data := []byte(`{"type":"tool_result","toolName":"simple_tool"}`)
+		result, err := UnmarshalContent(data)
+		require.NoError(t, err)
+
+		tc, ok := result.(ToolResultContent)
+		require.True(t, ok)
+		assert.Equal(t, "simple_tool", tc.ToolName)
+		assert.Nil(t, tc.Content)
+	})
+}
+
+func TestToolUseContent_JSONRoundTrip(t *testing.T) {
+	original := NewToolUseContent("get_weather", map[string]any{"city": "London"})
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	result, err := UnmarshalContent(data)
+	require.NoError(t, err)
+
+	tc, ok := result.(ToolUseContent)
+	require.True(t, ok)
+	assert.Equal(t, original.Type, tc.Type)
+	assert.Equal(t, original.ToolName, tc.ToolName)
+	args, ok := tc.Arguments.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "London", args["city"])
+}
+
+func TestToolResultContent_JSONRoundTrip(t *testing.T) {
+	original := NewToolResultContent("get_weather", []Content{NewTextContent("Sunny, 22°C")}, false)
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	result, err := UnmarshalContent(data)
+	require.NoError(t, err)
+
+	tc, ok := result.(ToolResultContent)
+	require.True(t, ok)
+	assert.Equal(t, original.Type, tc.Type)
+	assert.Equal(t, original.ToolName, tc.ToolName)
+	assert.Equal(t, original.IsError, tc.IsError)
+	require.Len(t, tc.Content, 1)
+	text, ok := tc.Content[0].(TextContent)
+	require.True(t, ok)
+	assert.Equal(t, "Sunny, 22°C", text.Text)
+}
+
+func TestToolUseContent_IsContent(t *testing.T) {
+	var c Content = ToolUseContent{Type: ContentTypeToolUse, ToolName: "test"}
+	assert.NotNil(t, c)
+}
+
+func TestToolResultContent_IsContent(t *testing.T) {
+	var c Content = ToolResultContent{Type: ContentTypeToolResult, ToolName: "test"}
+	assert.NotNil(t, c)
+}

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -415,6 +415,112 @@ func TestParseContent(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "tool_use content",
+			contentMap: map[string]any{
+				"type":     "tool_use",
+				"toolName": "get_weather",
+				"arguments": map[string]any{
+					"city": "London",
+				},
+			},
+			expected: ToolUseContent{
+				Type:     ContentTypeToolUse,
+				ToolName: "get_weather",
+				Arguments: map[string]any{
+					"city": "London",
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "tool_use content with annotations",
+			contentMap: map[string]any{
+				"type":     "tool_use",
+				"toolName": "search",
+				"annotations": map[string]any{
+					"priority": 1.0,
+				},
+			},
+			expected: ToolUseContent{
+				Type:     ContentTypeToolUse,
+				ToolName: "search",
+				Annotated: Annotated{
+					Annotations: &Annotations{
+						Priority: ptr(1.0),
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "tool_use content missing toolName",
+			contentMap: map[string]any{
+				"type": "tool_use",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "tool_result content with nested text",
+			contentMap: map[string]any{
+				"type":     "tool_result",
+				"toolName": "get_weather",
+				"content": []any{
+					map[string]any{
+						"type": "text",
+						"text": "Sunny, 22°C",
+					},
+				},
+			},
+			expected: ToolResultContent{
+				Type:     ContentTypeToolResult,
+				ToolName: "get_weather",
+				Content:  []Content{NewTextContent("Sunny, 22°C")},
+			},
+			expectError: false,
+		},
+		{
+			name: "tool_result content with isError",
+			contentMap: map[string]any{
+				"type":     "tool_result",
+				"toolName": "failing_tool",
+				"isError":  true,
+				"content": []any{
+					map[string]any{
+						"type": "text",
+						"text": "something went wrong",
+					},
+				},
+			},
+			expected: ToolResultContent{
+				Type:     ContentTypeToolResult,
+				ToolName: "failing_tool",
+				IsError:  true,
+				Content:  []Content{NewTextContent("something went wrong")},
+			},
+			expectError: false,
+		},
+		{
+			name: "tool_result content missing toolName",
+			contentMap: map[string]any{
+				"type": "tool_result",
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "tool_result content without nested content",
+			contentMap: map[string]any{
+				"type":     "tool_result",
+				"toolName": "simple_tool",
+			},
+			expected: ToolResultContent{
+				Type:     ContentTypeToolResult,
+				ToolName: "simple_tool",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -468,6 +574,26 @@ func TestParseContent(t *testing.T) {
 					assert.Equal(t, exp.Resource, act.Resource)
 					assert.Equal(t, exp.Annotations, act.Annotations)
 					assert.Equal(t, exp.Meta, act.Meta)
+				case ToolUseContent:
+					act, ok := result.(ToolUseContent)
+					assert.True(t, ok)
+					assert.Equal(t, exp.Type, act.Type)
+					assert.Equal(t, exp.ToolName, act.ToolName)
+					assert.Equal(t, exp.Arguments, act.Arguments)
+					assert.Equal(t, exp.Annotations, act.Annotations)
+					assert.Equal(t, exp.Meta, act.Meta)
+				case ToolResultContent:
+					act, ok := result.(ToolResultContent)
+					assert.True(t, ok)
+					assert.Equal(t, exp.Type, act.Type)
+					assert.Equal(t, exp.ToolName, act.ToolName)
+					assert.Equal(t, exp.IsError, act.IsError)
+					assert.Equal(t, exp.Annotations, act.Annotations)
+					assert.Equal(t, exp.Meta, act.Meta)
+					require.Len(t, act.Content, len(exp.Content))
+					for i := range exp.Content {
+						assert.Equal(t, exp.Content[i], act.Content[i])
+					}
 				default:
 					assert.Equal(t, tt.expected, result)
 				}

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -418,16 +418,18 @@ func TestParseContent(t *testing.T) {
 		{
 			name: "tool_use content",
 			contentMap: map[string]any{
-				"type":     "tool_use",
-				"toolName": "get_weather",
-				"arguments": map[string]any{
+				"type": "tool_use",
+				"id":   "tu_1",
+				"name": "get_weather",
+				"input": map[string]any{
 					"city": "London",
 				},
 			},
 			expected: ToolUseContent{
-				Type:     ContentTypeToolUse,
-				ToolName: "get_weather",
-				Arguments: map[string]any{
+				Type: ContentTypeToolUse,
+				ID:   "tu_1",
+				Name: "get_weather",
+				Input: map[string]any{
 					"city": "London",
 				},
 			},
@@ -436,15 +438,19 @@ func TestParseContent(t *testing.T) {
 		{
 			name: "tool_use content with annotations",
 			contentMap: map[string]any{
-				"type":     "tool_use",
-				"toolName": "search",
+				"type":  "tool_use",
+				"id":    "tu_2",
+				"name":  "search",
+				"input": map[string]any{},
 				"annotations": map[string]any{
 					"priority": 1.0,
 				},
 			},
 			expected: ToolUseContent{
-				Type:     ContentTypeToolUse,
-				ToolName: "search",
+				Type:  ContentTypeToolUse,
+				ID:    "tu_2",
+				Name:  "search",
+				Input: map[string]any{},
 				Annotated: Annotated{
 					Annotations: &Annotations{
 						Priority: ptr(1.0),
@@ -454,9 +460,21 @@ func TestParseContent(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "tool_use content missing toolName",
+			name: "tool_use content missing id",
 			contentMap: map[string]any{
-				"type": "tool_use",
+				"type":  "tool_use",
+				"name":  "search",
+				"input": map[string]any{},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
+			name: "tool_use content missing name",
+			contentMap: map[string]any{
+				"type":  "tool_use",
+				"id":    "tu_3",
+				"input": map[string]any{},
 			},
 			expected:    nil,
 			expectError: true,
@@ -464,8 +482,8 @@ func TestParseContent(t *testing.T) {
 		{
 			name: "tool_result content with nested text",
 			contentMap: map[string]any{
-				"type":     "tool_result",
-				"toolName": "get_weather",
+				"type":      "tool_result",
+				"toolUseId": "tu_1",
 				"content": []any{
 					map[string]any{
 						"type": "text",
@@ -474,18 +492,18 @@ func TestParseContent(t *testing.T) {
 				},
 			},
 			expected: ToolResultContent{
-				Type:     ContentTypeToolResult,
-				ToolName: "get_weather",
-				Content:  []Content{NewTextContent("Sunny, 22°C")},
+				Type:      ContentTypeToolResult,
+				ToolUseID: "tu_1",
+				Content:   []Content{NewTextContent("Sunny, 22°C")},
 			},
 			expectError: false,
 		},
 		{
 			name: "tool_result content with isError",
 			contentMap: map[string]any{
-				"type":     "tool_result",
-				"toolName": "failing_tool",
-				"isError":  true,
+				"type":      "tool_result",
+				"toolUseId": "tu_2",
+				"isError":   true,
 				"content": []any{
 					map[string]any{
 						"type": "text",
@@ -494,15 +512,15 @@ func TestParseContent(t *testing.T) {
 				},
 			},
 			expected: ToolResultContent{
-				Type:     ContentTypeToolResult,
-				ToolName: "failing_tool",
-				IsError:  true,
-				Content:  []Content{NewTextContent("something went wrong")},
+				Type:      ContentTypeToolResult,
+				ToolUseID: "tu_2",
+				IsError:   true,
+				Content:   []Content{NewTextContent("something went wrong")},
 			},
 			expectError: false,
 		},
 		{
-			name: "tool_result content missing toolName",
+			name: "tool_result content missing toolUseId",
 			contentMap: map[string]any{
 				"type": "tool_result",
 			},
@@ -512,12 +530,12 @@ func TestParseContent(t *testing.T) {
 		{
 			name: "tool_result content without nested content",
 			contentMap: map[string]any{
-				"type":     "tool_result",
-				"toolName": "simple_tool",
+				"type":      "tool_result",
+				"toolUseId": "tu_3",
 			},
 			expected: ToolResultContent{
-				Type:     ContentTypeToolResult,
-				ToolName: "simple_tool",
+				Type:      ContentTypeToolResult,
+				ToolUseID: "tu_3",
 			},
 			expectError: false,
 		},
@@ -578,15 +596,16 @@ func TestParseContent(t *testing.T) {
 					act, ok := result.(ToolUseContent)
 					assert.True(t, ok)
 					assert.Equal(t, exp.Type, act.Type)
-					assert.Equal(t, exp.ToolName, act.ToolName)
-					assert.Equal(t, exp.Arguments, act.Arguments)
+					assert.Equal(t, exp.ID, act.ID)
+					assert.Equal(t, exp.Name, act.Name)
+					assert.Equal(t, exp.Input, act.Input)
 					assert.Equal(t, exp.Annotations, act.Annotations)
 					assert.Equal(t, exp.Meta, act.Meta)
 				case ToolResultContent:
 					act, ok := result.(ToolResultContent)
 					assert.True(t, ok)
 					assert.Equal(t, exp.Type, act.Type)
-					assert.Equal(t, exp.ToolName, act.ToolName)
+					assert.Equal(t, exp.ToolUseID, act.ToolUseID)
 					assert.Equal(t, exp.IsError, act.IsError)
 					assert.Equal(t, exp.Annotations, act.Annotations)
 					assert.Equal(t, exp.Meta, act.Meta)


### PR DESCRIPTION
## Description

Add `ToolUseContent` and `ToolResultContent` content types to support tool invocations and their results within MCP sampling message flows. These types implement the sealed `Content` interface, enabling proper representation of tool use in sampling round-trips.

### Changes

- **`ToolUseContent`** (type: `"tool_use"`) with `ToolName` and `Arguments` fields
- **`ToolResultContent`** (type: `"tool_result"`) with `ToolName`, `Content []Content`, and `IsError` fields
- `ContentTypeToolUse` and `ContentTypeToolResult` constants
- `NewToolUseContent()` and `NewToolResultContent()` constructors
- `AsToolUseContent()` and `AsToolResultContent()` type assertion helpers
- Updated `UnmarshalContent()` and `ParseContent()` to handle both new types
- Custom `UnmarshalJSON` for `ToolResultContent` to handle nested `Content` interface slice

Fixes #809

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Sampling - Content Types](https://modelcontextprotocol.io/specification/2025-06-18/server/sampling)
- [x] Implementation follows the specification exactly

## Additional Information

Example usage:

```go
// Tool use content in a sampling message
toolUse := mcp.NewToolUseContent("get_weather", map[string]any{"city": "London"})

// Tool result content with nested text
toolResult := mcp.NewToolResultContent(
    "get_weather",
    []mcp.Content{mcp.NewTextContent("Sunny, 22°C")},
    false,
)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "tool use" and "tool result" content types with end-to-end serialization, parsing, and nested content handling.
  * Added utilities for creating and casting these tool-related content objects for easier use.
* **Tests**
  * Added comprehensive unit tests covering parsing, JSON round-trips, type assertions, and nested content scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->