### PR TITLE
fix: return error for non-object entries in tool_result content array

### DIFF
--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -708,14 +708,16 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 		isError, _ := contentMap["isError"].(bool)
 		var contentItems []Content
 		if rawContent, ok := contentMap["content"].([]any); ok {
-			for _, item := range rawContent {
-				if itemMap, ok := item.(map[string]any); ok {
-					parsed, err := ParseContent(itemMap)
-					if err != nil {
-						return nil, fmt.Errorf("parsing tool result content: %w", err)
-					}
-					contentItems = append(contentItems, parsed)
+			for i, item := range rawContent {
+				itemMap, ok := item.(map[string]any)
+				if !ok {
+					return nil, fmt.Errorf("tool_result content[%d]: expected object, got %T", i, item)
 				}
+				parsed, err := ParseContent(itemMap)
+				if err != nil {
+					return nil, fmt.Errorf("parsing tool result content[%d]: %w", i, err)
+				}
+				contentItems = append(contentItems, parsed)
 			}
 		}
 		c := NewToolResultContent(toolUseID, contentItems, isError)

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -528,6 +528,18 @@ func TestParseContent(t *testing.T) {
 			expectError: true,
 		},
 		{
+			name: "tool_result content with non-object entry in content array",
+			contentMap: map[string]any{
+				"type":      "tool_result",
+				"toolUseId": "tu_bad",
+				"content": []any{
+					"not an object",
+				},
+			},
+			expected:    nil,
+			expectError: true,
+		},
+		{
 			name: "tool_result content without nested content",
 			contentMap: map[string]any{
 				"type":      "tool_result",


### PR DESCRIPTION
ParseContent now validates each entry in ToolResultContent's nested content array and returns a diagnostic error with the index and actual type instead of silently skipping non-object entries.

Adds test case for non-object entry in content array.

## Description

<!-- Provide a concise description of the changes in this PR -->

Fixes #<issue_number> (if applicable)

## Type of Change

<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

<!-- If this PR implements a feature from the MCP specification, please answer the following -->

<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information

<!-- Any additional information that might be useful for reviewers -->

<!-- If not applicable, remove this section -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation for tool result content parsing. Error messages now identify the exact position of invalid elements within content arrays, improving debugging and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->