### PR TITLE
feat: add server-side OAuth protected resource metadata endpoint

### DIFF
--- a/server/protected_resource.go
+++ b/server/protected_resource.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// OAuthProtectedResourceMetadata holds OAuth 2.0 Protected Resource Metadata
+// as defined in RFC 9728. Served at /.well-known/oauth-protected-resource.
+type OAuthProtectedResourceMetadata struct {
+	// Resource is the protected resource's identifier URI (REQUIRED).
+	Resource string `json:"resource"`
+
+	// AuthorizationServers lists authorization server issuer URLs (RECOMMENDED).
+	AuthorizationServers []string `json:"authorization_servers,omitempty"`
+
+	// ScopesSupported lists OAuth scopes supported by this resource (OPTIONAL).
+	ScopesSupported []string `json:"scopes_supported,omitempty"`
+
+	// BearerMethodsSupported lists supported Bearer token presentation methods (OPTIONAL).
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+
+	// ResourceName is a human-readable name for the resource (OPTIONAL).
+	ResourceName *string `json:"resource_name,omitempty"`
+
+	// ResourceDocumentation is a URL pointing to documentation for this resource (OPTIONAL).
+	ResourceDocumentation *string `json:"resource_documentation,omitempty"`
+
+	// JwksURI is the URL of the JSON Web Key Set for verifying resource responses (OPTIONAL).
+	JwksURI *string `json:"jwks_uri,omitempty"`
+
+	// ResourceSigningAlgsSupported lists supported JWS signing algorithms (OPTIONAL).
+	ResourceSigningAlgsSupported []string `json:"resource_signing_alg_values_supported,omitempty"`
+
+	// ResourcePolicyURI is the URL of the resource's privacy policy (OPTIONAL).
+	ResourcePolicyURI *string `json:"resource_policy_uri,omitempty"`
+
+	// ResourceTosURI is the URL of the resource's terms of service (OPTIONAL).
+	ResourceTosURI *string `json:"resource_tos_uri,omitempty"`
+
+	// TLSClientCertificateBoundAccessTokens indicates support for mTLS-bound tokens (OPTIONAL).
+	TLSClientCertificateBoundAccessTokens *bool `json:"tls_client_certificate_bound_access_tokens,omitempty"`
+
+	// AuthorizationDetailsTypesSupported lists supported authorization_details types (OPTIONAL).
+	AuthorizationDetailsTypesSupported []string `json:"authorization_details_types_supported,omitempty"`
+
+	// DPoPSigningAlgsSupported lists JWS algorithms supported for DPoP proofs (OPTIONAL).
+	DPoPSigningAlgsSupported []string `json:"dpop_signing_alg_values_supported,omitempty"`
+
+	// DPoPBoundAccessTokensRequired indicates whether DPoP-bound tokens are required (OPTIONAL).
+	DPoPBoundAccessTokensRequired *bool `json:"dpop_bound_access_tokens_required,omitempty"`
+}
+
+// NewProtectedResourceMetadataHandler returns an http.Handler that serves RFC 9728
+// OAuth 2.0 Protected Resource Metadata at /.well-known/oauth-protected-resource.
+//
+// Use this for custom routing setups where you manage your own http.ServeMux:
+//
+//	mux.Handle("/.well-known/oauth-protected-resource",
+//	    server.NewProtectedResourceMetadataHandler(meta))
+func NewProtectedResourceMetadataHandler(metadata OAuthProtectedResourceMetadata) http.Handler {
+	if metadata.Resource == "" {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "protected resource metadata: Resource field is required", http.StatusInternalServerError)
+		})
+	}
+
+	// Pre-marshal once at construction time; the struct only contains
+	// JSON-serialisable types so this should never fail.
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "failed to marshal protected resource metadata", http.StatusInternalServerError)
+		})
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet && r.Method != http.MethodOptions {
+			w.Header().Set("Allow", "GET, OPTIONS")
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+	})
+}
+
+// WithProtectedResourceMetadata registers the /.well-known/oauth-protected-resource endpoint
+// when Start creates its internal mux. Has no effect when WithStreamableHTTPServer is used;
+// in that case register the handler manually via NewProtectedResourceMetadataHandler.
+func WithProtectedResourceMetadata(metadata OAuthProtectedResourceMetadata) StreamableHTTPOption {
+	return func(s *StreamableHTTPServer) {
+		s.protectedResourceMetadata = &metadata
+	}
+}
+
+// WithSSEProtectedResourceMetadata registers the /.well-known/oauth-protected-resource endpoint
+// when the SSE server's Start creates its internal http.Server. Has no effect when
+// WithHTTPServer is used; register the handler manually in that case.
+func WithSSEProtectedResourceMetadata(metadata OAuthProtectedResourceMetadata) SSEOption {
+	return func(s *SSEServer) {
+		s.protectedResourceMetadata = &metadata
+	}
+}

--- a/server/protected_resource_test.go
+++ b/server/protected_resource_test.go
@@ -1,0 +1,257 @@
+package server_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func resourceName(s string) *string { return &s }
+
+// --- NewProtectedResourceMetadataHandler (Option A) ---
+
+func TestNewProtectedResourceMetadataHandler_GET(t *testing.T) {
+	meta := server.OAuthProtectedResourceMetadata{
+		Resource:             "https://my-server.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+		ScopesSupported:      []string{"mcp:read", "mcp:write"},
+		ResourceName:         resourceName("My MCP Server"),
+	}
+
+	h := server.NewProtectedResourceMetadataHandler(meta)
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got server.OAuthProtectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode response body: %v", err)
+	}
+	if got.Resource != meta.Resource {
+		t.Errorf("Resource = %q, want %q", got.Resource, meta.Resource)
+	}
+	if len(got.AuthorizationServers) != 1 || got.AuthorizationServers[0] != "https://auth.example.com" {
+		t.Errorf("AuthorizationServers = %v, want [https://auth.example.com]", got.AuthorizationServers)
+	}
+	if len(got.ScopesSupported) != 2 {
+		t.Errorf("ScopesSupported = %v, want 2 entries", got.ScopesSupported)
+	}
+	if got.ResourceName == nil || *got.ResourceName != "My MCP Server" {
+		t.Errorf("ResourceName = %v, want 'My MCP Server'", got.ResourceName)
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_MethodNotAllowed(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.OAuthProtectedResourceMetadata{
+		Resource: "https://my-server.example.com",
+	})
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/.well-known/oauth-protected-resource", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			if rec.Code != http.StatusMethodNotAllowed {
+				t.Errorf("%s: expected 405, got %d", method, rec.Code)
+			}
+			if allow := rec.Header().Get("Allow"); allow == "" {
+				t.Errorf("%s: expected Allow header to be set", method)
+			}
+		})
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_OPTIONS(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.OAuthProtectedResourceMetadata{
+		Resource: "https://my-server.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("OPTIONS: expected 204, got %d", rec.Code)
+	}
+	if acao := rec.Header().Get("Access-Control-Allow-Origin"); acao != "*" {
+		t.Errorf("CORS origin header = %q, want *", acao)
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_CORSHeaders(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.OAuthProtectedResourceMetadata{
+		Resource: "https://my-server.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if acao := rec.Header().Get("Access-Control-Allow-Origin"); acao != "*" {
+		t.Errorf("CORS origin header = %q, want *", acao)
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_CacheControl(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.OAuthProtectedResourceMetadata{
+		Resource: "https://my-server.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if cc := rec.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_MinimalConfig(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.OAuthProtectedResourceMetadata{
+		Resource: "https://minimal.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+
+	var got server.OAuthProtectedResourceMetadata
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if got.Resource != "https://minimal.example.com" {
+		t.Errorf("Resource = %q, want https://minimal.example.com", got.Resource)
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_EmptyResource(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.OAuthProtectedResourceMetadata{})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Errorf("empty Resource: expected 500, got %d", rec.Code)
+	}
+}
+
+// --- WithProtectedResourceMetadata (StreamableHTTP / Option B) ---
+
+func TestStreamableHTTPServer_WithProtectedResourceMetadata(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	meta := server.OAuthProtectedResourceMetadata{
+		Resource:             "https://my-mcp-server.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+		ScopesSupported:      []string{"mcp:read"},
+	}
+
+	httpSrv := server.NewStreamableHTTPServer(mcpSrv,
+		server.WithProtectedResourceMetadata(meta),
+	)
+	ts := httptest.NewServer(httpSrv.HTTPHandler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+
+	var got server.OAuthProtectedResourceMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("failed to decode: %v", err)
+	}
+	if got.Resource != meta.Resource {
+		t.Errorf("Resource = %q, want %q", got.Resource, meta.Resource)
+	}
+	if len(got.AuthorizationServers) != 1 || got.AuthorizationServers[0] != meta.AuthorizationServers[0] {
+		t.Errorf("AuthorizationServers = %v, want %v", got.AuthorizationServers, meta.AuthorizationServers)
+	}
+}
+
+// --- Integration: verify /.well-known path doesn't interfere with /mcp ---
+
+func TestStreamableHTTPServer_WellKnownDoesNotBreakMCP(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	meta := server.OAuthProtectedResourceMetadata{
+		Resource: "https://my-server.example.com",
+	}
+
+	httpSrv := server.NewStreamableHTTPServer(mcpSrv,
+		server.WithProtectedResourceMetadata(meta),
+	)
+	ts := httptest.NewServer(httpSrv.HTTPHandler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	if err != nil {
+		t.Fatalf("GET well-known failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("well-known: expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		t.Errorf("well-known Content-Type = %q, want application/json", ct)
+	}
+}
+
+// --- WithSSEProtectedResourceMetadata (SSE / Option B) ---
+
+func TestSSEServer_WithSSEProtectedResourceMetadata(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	meta := server.OAuthProtectedResourceMetadata{
+		Resource:             "https://my-sse-server.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+	}
+
+	ts := server.NewTestServer(mcpSrv,
+		server.WithSSEProtectedResourceMetadata(meta),
+	)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	if err != nil {
+		t.Fatalf("GET failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	var got server.OAuthProtectedResourceMetadata
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Resource != meta.Resource {
+		t.Errorf("Resource = %q, want %q", got.Resource, meta.Resource)
+	}
+	if len(got.AuthorizationServers) != 1 || got.AuthorizationServers[0] != meta.AuthorizationServers[0] {
+		t.Errorf("AuthorizationServers = %v, want %v", got.AuthorizationServers, meta.AuthorizationServers)
+	}
+}

--- a/server/sse.go
+++ b/server/sse.go
@@ -199,6 +199,10 @@ type SSEServer struct {
 	keepAlive         bool
 	keepAliveInterval time.Duration
 
+	// protectedResourceMetadata, when non-nil, causes Start to automatically
+	// register /.well-known/oauth-protected-resource on the internal mux.
+	protectedResourceMetadata *OAuthProtectedResourceMetadata
+
 	mu sync.RWMutex
 }
 
@@ -354,11 +358,24 @@ func NewSSEServer(server *MCPServer, opts ...SSEOption) *SSEServer {
 	return s
 }
 
+// buildHandler returns the http.Handler used by Start and NewTestServer.
+// When protectedResourceMetadata is set it wraps the SSE server in a thin mux
+// that serves /.well-known/oauth-protected-resource alongside it.
+func (s *SSEServer) buildHandler() http.Handler {
+	if s.protectedResourceMetadata == nil {
+		return s
+	}
+	mux := http.NewServeMux()
+	mux.Handle("/.well-known/oauth-protected-resource",
+		NewProtectedResourceMetadataHandler(*s.protectedResourceMetadata))
+	mux.Handle("/", s)
+	return mux
+}
+
 // NewTestServer creates a test server for testing purposes
 func NewTestServer(server *MCPServer, opts ...SSEOption) *httptest.Server {
 	sseServer := NewSSEServer(server, opts...)
-
-	testServer := httptest.NewServer(sseServer)
+	testServer := httptest.NewServer(sseServer.buildHandler())
 	sseServer.baseURL = testServer.URL
 	return testServer
 }
@@ -370,9 +387,12 @@ func (s *SSEServer) Start(addr string) error {
 	if s.srv == nil {
 		s.srv = &http.Server{
 			Addr:    addr,
-			Handler: s,
+			Handler: s.buildHandler(),
 		}
 	} else {
+		if s.protectedResourceMetadata != nil {
+			log.Printf("INFO: WithSSEProtectedResourceMetadata has no effect when WithHTTPServer is used; register the handler manually via NewProtectedResourceMetadataHandler")
+		}
 		if s.srv.Addr == "" {
 			s.srv.Addr = addr
 		} else if s.srv.Addr != addr {

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -206,6 +206,10 @@ type StreamableHTTPServer struct {
 	sessionIdleTTL    time.Duration
 	sessionLastActive sync.Map // sessionID → *atomic.Int64 (unix nanos)
 	sweeperCancel     context.CancelFunc
+
+	// protectedResourceMetadata, when non-nil, causes Start to automatically
+	// register /.well-known/oauth-protected-resource on the internal mux
+	protectedResourceMetadata *OAuthProtectedResourceMetadata
 }
 
 // NewStreamableHTTPServer creates a new streamable-http server instance
@@ -256,6 +260,17 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 	}
 }
 
+// buildInternalMux constructs the ServeMux used by Start and NewTestStreamableHTTPServer.
+func (s *StreamableHTTPServer) buildInternalMux() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.Handle(s.endpointPath, s)
+	if s.protectedResourceMetadata != nil {
+		mux.Handle("/.well-known/oauth-protected-resource",
+			NewProtectedResourceMetadataHandler(*s.protectedResourceMetadata))
+	}
+	return mux
+}
+
 // Start begins serving the http server on the specified address and path
 // (endpointPath). like:
 //
@@ -263,13 +278,14 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 func (s *StreamableHTTPServer) Start(addr string) error {
 	s.mu.Lock()
 	if s.httpServer == nil {
-		mux := http.NewServeMux()
-		mux.Handle(s.endpointPath, s)
 		s.httpServer = &http.Server{
 			Addr:    addr,
-			Handler: mux,
+			Handler: s.buildInternalMux(),
 		}
 	} else {
+		if s.protectedResourceMetadata != nil {
+			s.logger.Infof("WithProtectedResourceMetadata has no effect when WithStreamableHTTPServer is used; register the handler manually via NewProtectedResourceMetadataHandler")
+		}
 		if s.httpServer.Addr == "" {
 			s.httpServer.Addr = addr
 		} else if s.httpServer.Addr != addr {
@@ -1531,11 +1547,18 @@ func (s *InsecureStatefulSessionIdManager) Terminate(sessionID string) (isNotAll
 	return false, nil
 }
 
+// HTTPHandler returns the fully configured http.Handler that Start would use,
+// including the /.well-known/oauth-protected-resource route when
+// WithProtectedResourceMetadata is set. Useful for embedding the server
+// in a custom http.Server or for integration testing.
+func (s *StreamableHTTPServer) HTTPHandler() http.Handler {
+	return s.buildInternalMux()
+}
+
 // NewTestStreamableHTTPServer creates a test server for testing purposes
 func NewTestStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *httptest.Server {
-	sseServer := NewStreamableHTTPServer(server, opts...)
-	testServer := httptest.NewServer(sseServer)
-	return testServer
+	s := NewStreamableHTTPServer(server, opts...)
+	return httptest.NewServer(s)
 }
 
 // isJSONEmpty reports whether the provided JSON value is "empty":

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -1555,8 +1555,12 @@ func (s *StreamableHTTPServer) HTTPHandler() http.Handler {
 	return s.buildInternalMux()
 }
 
-// NewTestStreamableHTTPServer creates a test server for testing purposes
+// NewTestStreamableHTTPServer creates a test server for testing purposes.
+// It defaults the endpoint path to "/" so that requests to the bare test
+// server URL are routed correctly. WithProtectedResourceMetadata is also
+// honoured because HTTPHandler() includes the full internal mux.
 func NewTestStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *httptest.Server {
+	opts = append([]StreamableHTTPOption{WithEndpointPath("/")}, opts...)
 	s := NewStreamableHTTPServer(server, opts...)
 	return httptest.NewServer(s.HTTPHandler())
 }

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -1558,7 +1558,7 @@ func (s *StreamableHTTPServer) HTTPHandler() http.Handler {
 // NewTestStreamableHTTPServer creates a test server for testing purposes
 func NewTestStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *httptest.Server {
 	s := NewStreamableHTTPServer(server, opts...)
-	return httptest.NewServer(s)
+	return httptest.NewServer(s.HTTPHandler())
 }
 
 // isJSONEmpty reports whether the provided JSON value is "empty":


### PR DESCRIPTION
## Description

add server-side OAuth protected resource metadata endpoint

Fixes #814

## Type of Change

<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [ ] My code follows the code style of this project
- [ ] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

<!-- If this PR implements a feature from the MCP specification, please answer the following -->

<!-- If not applicable, remove this section -->

- [ ] This PR implements a feature defined in the MCP specification
- [ ] Link to relevant spec section: [Link text](https://modelcontextprotocol.io/specification/path-to-section)
- [ ] Implementation follows the specification exactly

## Additional Information

<!-- Any additional information that might be useful for reviewers -->

<!-- If not applicable, remove this section -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.0 Protected Resource Metadata at /.well-known/oauth-protected-resource — GET returns JSON (Content-Type: application/json, Cache-Control: no-store), OPTIONS returns 204, CORS enabled; unsupported methods return 405 with Allow. Empty/invalid resource configuration yields a 500 error.
  * Server options to register this metadata for streamable HTTP and SSE servers.
* **Tests**
  * Comprehensive tests for GET/OPTIONS/method handling, headers, minimal/empty-resource cases, and integration with server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->