### PR TITLE
feat: add RFC 8707 resource parameter to OAuth authorization, token exchange, and refresh requests

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -143,7 +143,8 @@ type OAuthHandler struct {
 	serverMetadata   *AuthServerMetadata
 	metadataFetchErr error
 	metadataOnce     sync.Once
-	baseURL          string
+	baseURL          string // scheme://host for well-known discovery
+	serverURL        string // full MCP server URL including path
 	resourceURI      string // RFC 8707 resource parameter for token audience binding
 
 	mu            sync.RWMutex // Protects expectedState
@@ -318,9 +319,26 @@ func (h *OAuthHandler) GetResourceURI() string {
 	return h.resourceURI
 }
 
-// SetBaseURL sets the base URL for the API server
+// SetBaseURL sets the base URL (scheme://host) for well-known metadata discovery.
 func (h *OAuthHandler) SetBaseURL(baseURL string) {
 	h.baseURL = baseURL
+}
+
+// SetServerURL sets the full MCP server URL including path.
+// This is used as the default RFC 8707 resource parameter when Protected
+// Resource Metadata is not available.
+func (h *OAuthHandler) SetServerURL(serverURL string) {
+	h.serverURL = serverURL
+}
+
+// defaultResourceURI returns the best available resource URI when Protected
+// Resource Metadata is not available. Prefers the full server URL (including
+// path) over the base URL (scheme://host only).
+func (h *OAuthHandler) defaultResourceURI() string {
+	if h.serverURL != "" {
+		return h.serverURL
+	}
+	return h.baseURL
 }
 
 // GetExpectedState returns the expected state value (for testing purposes)
@@ -374,9 +392,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		// If AuthServerMetadataURL is explicitly provided, use it directly
 		if h.config.AuthServerMetadataURL != "" {
 			h.fetchMetadataFromURL(ctx, h.config.AuthServerMetadataURL)
-			if h.baseURL != "" {
-				h.resourceURI = h.baseURL
-			}
+			h.resourceURI = h.defaultResourceURI()
 			return
 		}
 
@@ -408,7 +424,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 
 		// If we can't get the protected resource metadata, try OAuth Authorization Server discovery
 		if resp.StatusCode != http.StatusOK {
-			h.resourceURI = baseURL
+			h.resourceURI = h.defaultResourceURI()
 			h.fetchMetadataFromURL(ctx, baseURL+"/.well-known/oauth-authorization-server")
 			if h.serverMetadata != nil {
 				return
@@ -431,11 +447,11 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		}
 
 		// Store the resource URI from PRM for RFC 8707 resource parameter.
-		// Fall back to baseURL if not present in the metadata.
+		// Fall back to the full server URL if not present in the metadata.
 		if protectedResource.Resource != "" {
 			h.resourceURI = protectedResource.Resource
 		} else {
-			h.resourceURI = baseURL
+			h.resourceURI = h.defaultResourceURI()
 		}
 
 		// If no authorization servers are specified, fall back to default endpoints

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -144,6 +144,7 @@ type OAuthHandler struct {
 	metadataFetchErr error
 	metadataOnce     sync.Once
 	baseURL          string
+	resourceURI      string // RFC 8707 resource parameter for token audience binding
 
 	mu            sync.RWMutex // Protects expectedState
 	expectedState string       // Expected state value for CSRF protection
@@ -216,6 +217,11 @@ func (h *OAuthHandler) refreshToken(ctx context.Context, refreshToken string) (*
 	data.Set("client_id", h.config.ClientID)
 	if h.config.ClientSecret != "" {
 		data.Set("client_secret", h.config.ClientSecret)
+	}
+
+	// RFC 8707: include the resource parameter to bind the token to the target MCP server
+	if h.resourceURI != "" {
+		data.Set("resource", h.resourceURI)
 	}
 
 	req, err := http.NewRequestWithContext(
@@ -305,6 +311,13 @@ func (h *OAuthHandler) GetClientSecret() string {
 	return h.config.ClientSecret
 }
 
+// GetResourceURI returns the RFC 8707 resource URI for the target MCP server.
+// This is populated during metadata discovery from the Protected Resource Metadata
+// document, or falls back to the base URL of the MCP server.
+func (h *OAuthHandler) GetResourceURI() string {
+	return h.resourceURI
+}
+
 // SetBaseURL sets the base URL for the API server
 func (h *OAuthHandler) SetBaseURL(baseURL string) {
 	h.baseURL = baseURL
@@ -361,6 +374,9 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		// If AuthServerMetadataURL is explicitly provided, use it directly
 		if h.config.AuthServerMetadataURL != "" {
 			h.fetchMetadataFromURL(ctx, h.config.AuthServerMetadataURL)
+			if h.baseURL != "" {
+				h.resourceURI = h.baseURL
+			}
 			return
 		}
 
@@ -392,6 +408,7 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 
 		// If we can't get the protected resource metadata, try OAuth Authorization Server discovery
 		if resp.StatusCode != http.StatusOK {
+			h.resourceURI = baseURL
 			h.fetchMetadataFromURL(ctx, baseURL+"/.well-known/oauth-authorization-server")
 			if h.serverMetadata != nil {
 				return
@@ -411,6 +428,14 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		if err := json.NewDecoder(resp.Body).Decode(&protectedResource); err != nil {
 			h.metadataFetchErr = fmt.Errorf("failed to decode protected resource response: %w", err)
 			return
+		}
+
+		// Store the resource URI from PRM for RFC 8707 resource parameter.
+		// Fall back to baseURL if not present in the metadata.
+		if protectedResource.Resource != "" {
+			h.resourceURI = protectedResource.Resource
+		} else {
+			h.resourceURI = baseURL
 		}
 
 		// If no authorization servers are specified, fall back to default endpoints
@@ -654,6 +679,11 @@ func (h *OAuthHandler) ProcessAuthorizationResponse(ctx context.Context, code, s
 		data.Set("code_verifier", codeVerifier)
 	}
 
+	// RFC 8707: include the resource parameter to bind the token to the target MCP server
+	if h.resourceURI != "" {
+		data.Set("resource", h.resourceURI)
+	}
+
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
@@ -732,6 +762,11 @@ func (h *OAuthHandler) GetAuthorizationURL(ctx context.Context, state, codeChall
 	if h.config.PKCEEnabled && codeChallenge != "" {
 		params.Set("code_challenge", codeChallenge)
 		params.Set("code_challenge_method", "S256")
+	}
+
+	// RFC 8707: include the resource parameter to bind the token to the target MCP server
+	if h.resourceURI != "" {
+		params.Set("resource", h.resourceURI)
 	}
 
 	return metadata.AuthorizationEndpoint + "?" + params.Encode(), nil

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -116,6 +116,7 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 		// Extract base URL from server URL for metadata discovery
 		baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
 		smc.oauthHandler.SetBaseURL(baseURL)
+		smc.oauthHandler.SetServerURL(parsedURL.String())
 	}
 
 	return smc, nil

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -165,6 +165,7 @@ func NewStreamableHTTP(serverURL string, options ...StreamableHTTPCOption) (*Str
 		// Extract base URL from server URL for metadata discovery
 		baseURL := fmt.Sprintf("%s://%s", parsedURL.Scheme, parsedURL.Host)
 		smc.oauthHandler.SetBaseURL(baseURL)
+		smc.oauthHandler.SetServerURL(parsedURL.String())
 	}
 
 	return smc, nil


### PR DESCRIPTION
## Description

Add RFC 8707 `resource` parameter support to OAuth authorization requests, token exchanges, and token refresh requests per the MCP Authorization specification.

Previously, the OAuth client never included the `resource` parameter in any request, violating a MUST-level requirement. This change:

- Discovers the resource URI from [Protected Resource Metadata (RFC 9728)](https://datatracker.ietf.org/doc/html/rfc9728) when available
- Falls back to the full MCP server URL (including path) as the resource identifier when PRM is unavailable, matching the [Canonical Server URI](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri) definition
- Includes the `resource` parameter in all three OAuth request types:
  - Authorization URL ([GetAuthorizationURL](cci:1://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:757:0-788:1))
  - Token exchange ([ProcessAuthorizationResponse](cci:1://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:659:0-755:1))
  - Token refresh ([refreshToken](cci:1://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:207:0-285:1))

### Files changed

- [client/transport/oauth.go](cci:7://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:0:0-0:0) — Added `serverURL`, `resourceURI` fields; [SetServerURL](cci:1://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:326:0-331:1), [GetResourceURI](cci:1://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:314:0-319:1), [defaultResourceURI](cci:1://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/oauth.go:333:0-341:1) methods; `resource` param in auth/token/refresh requests
- [client/transport/streamable_http.go](cci:7://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/streamable_http.go:0:0-0:0) — Pass full server URL to OAuth handler
- [client/transport/sse.go](cci:7://file:///Users/mariachrysafis/Documents/mcp-go/client/transport/sse.go:0:0-0:0) — Pass full server URL to OAuth handler

## Type of Change

- [x] MCP spec compatibility implementation

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec sections:
  - [Resource Indicators (RFC 8707)](https://datatracker.ietf.org/doc/html/rfc8707) — Defines the `resource` parameter for OAuth
  - [MCP Authorization — Resource Parameter](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#resource-parameter-implementation) — MCP clients MUST include the `resource` parameter in both authorization requests and token requests
  - [MCP Authorization — Canonical Server URI](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#canonical-server-uri) — Defines how the resource identifier is derived from the MCP server URL
  - [Protected Resource Metadata (RFC 9728)](https://datatracker.ietf.org/doc/html/rfc9728) — Discovery mechanism for the `resource` field
- [x] Implementation follows the specification exactly

## Additional Information

The official [Go MCP SDK](https://github.com/modelcontextprotocol/go-sdk) implements this identically — the `resource` parameter is sourced from PRM's `resource` field when available, and falls back to the full MCP server URL otherwise. See [[auth/authorization_code.go](cci:7://file:///Users/mariachrysafis/Documents/go-sdk/auth/authorization_code.go:0:0-0:0)](https://github.com/modelcontextprotocol/go-sdk/blob/main/auth/authorization_code.go) in the official SDK for reference.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth tokens now bind to specific MCP servers through resource URI tracking, ensuring proper token scoping during authorization, token exchange, and token refresh operations for improved security and resource isolation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->