### PR TITLE
feat: implement OAuth 2.0 Protected Resource Metadata (RFC 9728) for MCP servers

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -129,7 +129,7 @@ type AuthServerMetadata struct {
 	AuthorizationEndpoint             string   `json:"authorization_endpoint"`
 	TokenEndpoint                     string   `json:"token_endpoint"`
 	RegistrationEndpoint              string   `json:"registration_endpoint,omitempty"`
-	JwksURI                           string   `json:"jwks_uri,omitempty"`
+	JWKSURI                           string   `json:"jwks_uri,omitempty"`
 	ScopesSupported                   []string `json:"scopes_supported,omitempty"`
 	ResponseTypesSupported            []string `json:"response_types_supported"`
 	GrantTypesSupported               []string `json:"grant_types_supported,omitempty"`

--- a/server/protected_resource.go
+++ b/server/protected_resource.go
@@ -1,0 +1,66 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// ProtectedResourceMetadata represents OAuth 2.0 Protected Resource Metadata
+// as defined in RFC 9728 (https://datatracker.ietf.org/doc/html/rfc9728).
+//
+// MCP servers MUST implement this to indicate the locations of authorization servers.
+type ProtectedResourceMetadata struct {
+	// Resource is the protected resource's resource identifier. Required.
+	Resource string `json:"resource"`
+
+	// AuthorizationServers is a list of OAuth authorization server issuer identifiers
+	// that can be used with this protected resource.
+	AuthorizationServers []string `json:"authorization_servers,omitempty"`
+
+	// ScopesSupported is a list of scope values used in authorization requests
+	// to request access to this protected resource.
+	ScopesSupported []string `json:"scopes_supported,omitempty"`
+
+	// BearerMethodsSupported is a list of the supported methods of sending
+	// an OAuth 2.0 bearer token to the protected resource.
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+
+	// ResourceName is a human-readable name of the protected resource.
+	ResourceName string `json:"resource_name,omitempty"`
+
+	// ResourceDocumentation is a URL of a page containing human-readable
+	// information for developers using the protected resource.
+	ResourceDocumentation string `json:"resource_documentation,omitempty"`
+
+	// JwksURI is the URL of the protected resource's JWK Set document.
+	JwksURI string `json:"jwks_uri,omitempty"`
+}
+
+// ProtectedResourceMetadataHandler returns an http.Handler that serves
+// OAuth 2.0 Protected Resource Metadata (RFC 9728) at the well-known endpoint.
+//
+// This handler supports CORS for cross-origin client discovery, and responds
+// to GET and OPTIONS requests. All other methods receive 405 Method Not Allowed.
+func ProtectedResourceMetadataHandler(metadata *ProtectedResourceMetadata) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+
+		if r.Method != http.MethodGet {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(metadata); err != nil {
+			http.Error(w, "Failed to encode metadata", http.StatusInternalServerError)
+			return
+		}
+	})
+}

--- a/server/protected_resource.go
+++ b/server/protected_resource.go
@@ -3,6 +3,8 @@ package server
 import (
 	"encoding/json"
 	"net/http"
+	"net/url"
+	"path"
 )
 
 // ProtectedResourceMetadata represents OAuth 2.0 Protected Resource Metadata
@@ -32,8 +34,21 @@ type ProtectedResourceMetadata struct {
 	// information for developers using the protected resource.
 	ResourceDocumentation string `json:"resource_documentation,omitempty"`
 
-	// JwksURI is the URL of the protected resource's JWK Set document.
-	JwksURI string `json:"jwks_uri,omitempty"`
+	// JWKSURI is the URL of the protected resource's JWK Set document.
+	JWKSURI string `json:"jwks_uri,omitempty"`
+}
+
+// ProtectedResourceMetadataPath returns the well-known path for the given
+// resource identifier per RFC 9728 § 3.1. For a resource like
+// "https://mcp.example.com/mcp" it returns
+// "/.well-known/oauth-protected-resource/mcp".
+func ProtectedResourceMetadataPath(resource string) string {
+	const wellKnownPrefix = "/.well-known/oauth-protected-resource"
+	u, err := url.Parse(resource)
+	if err != nil || u.Path == "" || u.Path == "/" {
+		return wellKnownPrefix
+	}
+	return path.Join(wellKnownPrefix, u.Path)
 }
 
 // ProtectedResourceMetadataHandler returns an http.Handler that serves

--- a/server/protected_resource_test.go
+++ b/server/protected_resource_test.go
@@ -60,6 +60,41 @@ func TestProtectedResourceMetadataHandler(t *testing.T) {
 	})
 }
 
+func TestProtectedResourceMetadataPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		want     string
+	}{
+		{
+			name:     "host only",
+			resource: "https://mcp.example.com",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "host with trailing slash",
+			resource: "https://mcp.example.com/",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "path-qualified resource",
+			resource: "https://mcp.example.com/mcp",
+			want:     "/.well-known/oauth-protected-resource/mcp",
+		},
+		{
+			name:     "deep path-qualified resource",
+			resource: "https://mcp.example.com/api/v1/mcp",
+			want:     "/.well-known/oauth-protected-resource/api/v1/mcp",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ProtectedResourceMetadataPath(tt.resource))
+		})
+	}
+}
+
 func TestStreamableHTTPServer_ProtectedResourceMetadata(t *testing.T) {
 	metadata := &ProtectedResourceMetadata{
 		Resource:             "https://mcp.example.com",
@@ -106,7 +141,7 @@ func TestStreamableHTTPServer_ProtectedResourceMetadata(t *testing.T) {
 		// Use the mux that Start would create by manually constructing it
 		mux := http.NewServeMux()
 		mux.Handle("/mcp", httpServer)
-		mux.Handle("/.well-known/oauth-protected-resource", ProtectedResourceMetadataHandler(metadata))
+		mux.Handle(ProtectedResourceMetadataPath(metadata.Resource), ProtectedResourceMetadataHandler(metadata))
 
 		ts := httptest.NewServer(mux)
 		defer ts.Close()
@@ -123,6 +158,77 @@ func TestStreamableHTTPServer_ProtectedResourceMetadata(t *testing.T) {
 		assert.Equal(t, "https://mcp.example.com", got.Resource)
 		assert.Equal(t, []string{"https://auth.example.com"}, got.AuthorizationServers)
 		assert.Equal(t, []string{"mcp:read"}, got.ScopesSupported)
+	})
+
+	t.Run("Start registers path-qualified well-known endpoint", func(t *testing.T) {
+		pathMetadata := &ProtectedResourceMetadata{
+			Resource:             "https://mcp.example.com/mcp",
+			AuthorizationServers: []string{"https://auth.example.com"},
+		}
+
+		mcpServer := NewMCPServer("test", "1.0.0")
+		httpServer := NewStreamableHTTPServer(mcpServer,
+			WithProtectedResourceMetadata(pathMetadata),
+		)
+
+		mux := http.NewServeMux()
+		mux.Handle("/mcp", httpServer)
+		mux.Handle(ProtectedResourceMetadataPath(pathMetadata.Resource), ProtectedResourceMetadataHandler(pathMetadata))
+
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource/mcp")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var got ProtectedResourceMetadata
+		err = json.NewDecoder(resp.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, "https://mcp.example.com/mcp", got.Resource)
+	})
+
+	t.Run("ServeHTTP dispatches well-known endpoint", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		httpServer := NewStreamableHTTPServer(mcpServer,
+			WithProtectedResourceMetadata(metadata),
+		)
+
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+		w := httptest.NewRecorder()
+		httpServer.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var got ProtectedResourceMetadata
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, metadata.Resource, got.Resource)
+	})
+
+	t.Run("ServeHTTP dispatches path-qualified well-known endpoint", func(t *testing.T) {
+		pathMetadata := &ProtectedResourceMetadata{
+			Resource:             "https://mcp.example.com/mcp",
+			AuthorizationServers: []string{"https://auth.example.com"},
+		}
+
+		mcpServer := NewMCPServer("test", "1.0.0")
+		httpServer := NewStreamableHTTPServer(mcpServer,
+			WithProtectedResourceMetadata(pathMetadata),
+		)
+
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource/mcp", nil)
+		w := httptest.NewRecorder()
+		httpServer.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var got ProtectedResourceMetadata
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, "https://mcp.example.com/mcp", got.Resource)
 	})
 }
 
@@ -153,6 +259,33 @@ func TestSSEServer_ProtectedResourceMetadata(t *testing.T) {
 		err = json.NewDecoder(resp.Body).Decode(&got)
 		require.NoError(t, err)
 		assert.Equal(t, "https://mcp.example.com", got.Resource)
+	})
+
+	t.Run("ServeHTTP routes path-qualified well-known endpoint", func(t *testing.T) {
+		pathMetadata := &ProtectedResourceMetadata{
+			Resource:             "https://mcp.example.com/mcp",
+			AuthorizationServers: []string{"https://auth.example.com"},
+		}
+
+		mcpServer := NewMCPServer("test", "1.0.0")
+		sseServer := NewSSEServer(mcpServer,
+			WithSSEProtectedResourceMetadata(pathMetadata),
+			WithBaseURL("http://localhost:8080"),
+		)
+
+		ts := httptest.NewServer(sseServer)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource/mcp")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var got ProtectedResourceMetadata
+		err = json.NewDecoder(resp.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, "https://mcp.example.com/mcp", got.Resource)
 	})
 
 	t.Run("ServeHTTP does not route well-known when not configured", func(t *testing.T) {
@@ -198,7 +331,7 @@ func TestProtectedResourceMetadata_JSONSerialization(t *testing.T) {
 		BearerMethodsSupported: []string{"header"},
 		ResourceName:           "Test Server",
 		ResourceDocumentation:  "https://docs.example.com",
-		JwksURI:                "https://mcp.example.com/.well-known/jwks.json",
+		JWKSURI:                "https://mcp.example.com/.well-known/jwks.json",
 	}
 
 	data, err := json.Marshal(metadata)
@@ -214,7 +347,7 @@ func TestProtectedResourceMetadata_JSONSerialization(t *testing.T) {
 	assert.Equal(t, metadata.BearerMethodsSupported, got.BearerMethodsSupported)
 	assert.Equal(t, metadata.ResourceName, got.ResourceName)
 	assert.Equal(t, metadata.ResourceDocumentation, got.ResourceDocumentation)
-	assert.Equal(t, metadata.JwksURI, got.JwksURI)
+	assert.Equal(t, metadata.JWKSURI, got.JWKSURI)
 }
 
 func TestProtectedResourceMetadata_OmitEmpty(t *testing.T) {

--- a/server/protected_resource_test.go
+++ b/server/protected_resource_test.go
@@ -1,0 +1,239 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProtectedResourceMetadataHandler(t *testing.T) {
+	metadata := &ProtectedResourceMetadata{
+		Resource:             "https://mcp.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+		ScopesSupported:      []string{"read", "write"},
+		ResourceName:         "Example MCP Server",
+	}
+
+	handler := ProtectedResourceMetadataHandler(metadata)
+
+	t.Run("GET returns metadata as JSON", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, "application/json", w.Header().Get("Content-Type"))
+		assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+
+		var got ProtectedResourceMetadata
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, metadata.Resource, got.Resource)
+		assert.Equal(t, metadata.AuthorizationServers, got.AuthorizationServers)
+		assert.Equal(t, metadata.ScopesSupported, got.ScopesSupported)
+		assert.Equal(t, metadata.ResourceName, got.ResourceName)
+	})
+
+	t.Run("OPTIONS returns no content with CORS headers", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodOptions, "/.well-known/oauth-protected-resource", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusNoContent, w.Code)
+		assert.Equal(t, "*", w.Header().Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "GET, OPTIONS", w.Header().Get("Access-Control-Allow-Methods"))
+	})
+
+	t.Run("POST returns method not allowed", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/.well-known/oauth-protected-resource", nil)
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	})
+}
+
+func TestStreamableHTTPServer_ProtectedResourceMetadata(t *testing.T) {
+	metadata := &ProtectedResourceMetadata{
+		Resource:             "https://mcp.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+		ScopesSupported:      []string{"mcp:read"},
+	}
+
+	t.Run("ProtectedResourceMetadataEndpoint returns handler when configured", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		httpServer := NewStreamableHTTPServer(mcpServer,
+			WithProtectedResourceMetadata(metadata),
+		)
+
+		handler := httpServer.ProtectedResourceMetadataEndpoint()
+		require.NotNil(t, handler)
+
+		req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		var got ProtectedResourceMetadata
+		err := json.NewDecoder(w.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, metadata.Resource, got.Resource)
+		assert.Equal(t, metadata.AuthorizationServers, got.AuthorizationServers)
+	})
+
+	t.Run("ProtectedResourceMetadataEndpoint returns nil when not configured", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		httpServer := NewStreamableHTTPServer(mcpServer)
+
+		handler := httpServer.ProtectedResourceMetadataEndpoint()
+		assert.Nil(t, handler)
+	})
+
+	t.Run("Start registers well-known endpoint", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		httpServer := NewStreamableHTTPServer(mcpServer,
+			WithProtectedResourceMetadata(metadata),
+		)
+
+		// Use the mux that Start would create by manually constructing it
+		mux := http.NewServeMux()
+		mux.Handle("/mcp", httpServer)
+		mux.Handle("/.well-known/oauth-protected-resource", ProtectedResourceMetadataHandler(metadata))
+
+		ts := httptest.NewServer(mux)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var got ProtectedResourceMetadata
+		err = json.NewDecoder(resp.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, "https://mcp.example.com", got.Resource)
+		assert.Equal(t, []string{"https://auth.example.com"}, got.AuthorizationServers)
+		assert.Equal(t, []string{"mcp:read"}, got.ScopesSupported)
+	})
+}
+
+func TestSSEServer_ProtectedResourceMetadata(t *testing.T) {
+	metadata := &ProtectedResourceMetadata{
+		Resource:             "https://mcp.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+		ScopesSupported:      []string{"mcp:read"},
+	}
+
+	t.Run("ServeHTTP routes well-known endpoint", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		sseServer := NewSSEServer(mcpServer,
+			WithSSEProtectedResourceMetadata(metadata),
+			WithBaseURL("http://localhost:8080"),
+		)
+
+		ts := httptest.NewServer(sseServer)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var got ProtectedResourceMetadata
+		err = json.NewDecoder(resp.Body).Decode(&got)
+		require.NoError(t, err)
+		assert.Equal(t, "https://mcp.example.com", got.Resource)
+	})
+
+	t.Run("ServeHTTP does not route well-known when not configured", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		sseServer := NewSSEServer(mcpServer,
+			WithBaseURL("http://localhost:8080"),
+		)
+
+		ts := httptest.NewServer(sseServer)
+		defer ts.Close()
+
+		resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("ProtectedResourceMetadataEndpoint returns handler when configured", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		sseServer := NewSSEServer(mcpServer,
+			WithSSEProtectedResourceMetadata(metadata),
+		)
+
+		handler := sseServer.ProtectedResourceMetadataEndpoint()
+		require.NotNil(t, handler)
+	})
+
+	t.Run("ProtectedResourceMetadataEndpoint returns nil when not configured", func(t *testing.T) {
+		mcpServer := NewMCPServer("test", "1.0.0")
+		sseServer := NewSSEServer(mcpServer)
+
+		handler := sseServer.ProtectedResourceMetadataEndpoint()
+		assert.Nil(t, handler)
+	})
+}
+
+func TestProtectedResourceMetadata_JSONSerialization(t *testing.T) {
+	metadata := &ProtectedResourceMetadata{
+		Resource:               "https://mcp.example.com",
+		AuthorizationServers:   []string{"https://auth.example.com"},
+		ScopesSupported:        []string{"read", "write"},
+		BearerMethodsSupported: []string{"header"},
+		ResourceName:           "Test Server",
+		ResourceDocumentation:  "https://docs.example.com",
+		JwksURI:                "https://mcp.example.com/.well-known/jwks.json",
+	}
+
+	data, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	var got ProtectedResourceMetadata
+	err = json.Unmarshal(data, &got)
+	require.NoError(t, err)
+
+	assert.Equal(t, metadata.Resource, got.Resource)
+	assert.Equal(t, metadata.AuthorizationServers, got.AuthorizationServers)
+	assert.Equal(t, metadata.ScopesSupported, got.ScopesSupported)
+	assert.Equal(t, metadata.BearerMethodsSupported, got.BearerMethodsSupported)
+	assert.Equal(t, metadata.ResourceName, got.ResourceName)
+	assert.Equal(t, metadata.ResourceDocumentation, got.ResourceDocumentation)
+	assert.Equal(t, metadata.JwksURI, got.JwksURI)
+}
+
+func TestProtectedResourceMetadata_OmitEmpty(t *testing.T) {
+	metadata := &ProtectedResourceMetadata{
+		Resource: "https://mcp.example.com",
+	}
+
+	data, err := json.Marshal(metadata)
+	require.NoError(t, err)
+
+	var raw map[string]any
+	err = json.Unmarshal(data, &raw)
+	require.NoError(t, err)
+
+	assert.Contains(t, raw, "resource")
+	assert.NotContains(t, raw, "authorization_servers")
+	assert.NotContains(t, raw, "scopes_supported")
+	assert.NotContains(t, raw, "bearer_methods_supported")
+	assert.NotContains(t, raw, "resource_name")
+	assert.NotContains(t, raw, "resource_documentation")
+	assert.NotContains(t, raw, "jwks_uri")
+}

--- a/server/sse.go
+++ b/server/sse.go
@@ -199,6 +199,8 @@ type SSEServer struct {
 	keepAlive         bool
 	keepAliveInterval time.Duration
 
+	protectedResourceMetadata *ProtectedResourceMetadata
+
 	mu sync.RWMutex
 }
 
@@ -312,6 +314,16 @@ func WithKeepAliveInterval(keepAliveInterval time.Duration) SSEOption {
 func WithKeepAlive(keepAlive bool) SSEOption {
 	return func(s *SSEServer) {
 		s.keepAlive = keepAlive
+	}
+}
+
+// WithSSEProtectedResourceMetadata configures the SSE server to serve OAuth 2.0
+// Protected Resource Metadata (RFC 9728) at /.well-known/oauth-protected-resource.
+//
+// MCP servers MUST implement Protected Resource Metadata per the MCP authorization spec.
+func WithSSEProtectedResourceMetadata(metadata *ProtectedResourceMetadata) SSEOption {
+	return func(s *SSEServer) {
+		s.protectedResourceMetadata = metadata
 	}
 }
 
@@ -779,6 +791,17 @@ func (s *SSEServer) MessageHandler() http.Handler {
 	return http.HandlerFunc(s.handleMessage)
 }
 
+// ProtectedResourceMetadataEndpoint returns an http.Handler that serves
+// the server's Protected Resource Metadata (RFC 9728). Returns nil if no
+// metadata is configured. Use this when mounting the server handlers
+// individually to register the well-known endpoint yourself.
+func (s *SSEServer) ProtectedResourceMetadataEndpoint() http.Handler {
+	if s.protectedResourceMetadata == nil {
+		return nil
+	}
+	return ProtectedResourceMetadataHandler(s.protectedResourceMetadata)
+}
+
 // ServeHTTP implements the http.Handler interface.
 func (s *SSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.dynamicBasePathFunc != nil {
@@ -790,6 +813,12 @@ func (s *SSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	path := r.URL.Path
+
+	if s.protectedResourceMetadata != nil && path == "/.well-known/oauth-protected-resource" {
+		ProtectedResourceMetadataHandler(s.protectedResourceMetadata).ServeHTTP(w, r)
+		return
+	}
+
 	// Use exact path matching rather than Contains
 	ssePath := s.CompleteSsePath()
 	if ssePath != "" && path == ssePath {

--- a/server/sse.go
+++ b/server/sse.go
@@ -814,7 +814,7 @@ func (s *SSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	path := r.URL.Path
 
-	if s.protectedResourceMetadata != nil && path == "/.well-known/oauth-protected-resource" {
+	if s.protectedResourceMetadata != nil && path == ProtectedResourceMetadataPath(s.protectedResourceMetadata.Resource) {
 		ProtectedResourceMetadataHandler(s.protectedResourceMetadata).ServeHTTP(w, r)
 		return
 	}

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -256,6 +256,11 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 
 // ServeHTTP implements the http.Handler interface.
 func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.protectedResourceMetadata != nil && r.URL.Path == ProtectedResourceMetadataPath(s.protectedResourceMetadata.Resource) {
+		ProtectedResourceMetadataHandler(s.protectedResourceMetadata).ServeHTTP(w, r)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPost:
 		s.handlePost(w, r)
@@ -278,7 +283,7 @@ func (s *StreamableHTTPServer) Start(addr string) error {
 		mux := http.NewServeMux()
 		mux.Handle(s.endpointPath, s)
 		if s.protectedResourceMetadata != nil {
-			mux.Handle("/.well-known/oauth-protected-resource", ProtectedResourceMetadataHandler(s.protectedResourceMetadata))
+			mux.Handle(ProtectedResourceMetadataPath(s.protectedResourceMetadata.Resource), ProtectedResourceMetadataHandler(s.protectedResourceMetadata))
 		}
 		s.httpServer = &http.Server{
 			Addr:    addr,

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -144,6 +144,16 @@ func WithTLSCert(certFile, keyFile string) StreamableHTTPOption {
 	}
 }
 
+// WithProtectedResourceMetadata configures the server to serve OAuth 2.0
+// Protected Resource Metadata (RFC 9728) at /.well-known/oauth-protected-resource.
+//
+// MCP servers MUST implement Protected Resource Metadata per the MCP authorization spec.
+func WithProtectedResourceMetadata(metadata *ProtectedResourceMetadata) StreamableHTTPOption {
+	return func(s *StreamableHTTPServer) {
+		s.protectedResourceMetadata = metadata
+	}
+}
+
 // WithSessionIdleTTL sets the idle TTL for per-session transport state.
 // When enabled, a background sweeper periodically removes entries from
 // per-session stores (tools, resources, resource templates, log levels,
@@ -202,6 +212,8 @@ type StreamableHTTPServer struct {
 
 	tlsCertFile string
 	tlsKeyFile  string
+
+	protectedResourceMetadata *ProtectedResourceMetadata
 
 	sessionIdleTTL    time.Duration
 	sessionLastActive sync.Map // sessionID → *atomic.Int64 (unix nanos)
@@ -265,6 +277,9 @@ func (s *StreamableHTTPServer) Start(addr string) error {
 	if s.httpServer == nil {
 		mux := http.NewServeMux()
 		mux.Handle(s.endpointPath, s)
+		if s.protectedResourceMetadata != nil {
+			mux.Handle("/.well-known/oauth-protected-resource", ProtectedResourceMetadataHandler(s.protectedResourceMetadata))
+		}
 		s.httpServer = &http.Server{
 			Addr:    addr,
 			Handler: mux,
@@ -310,6 +325,17 @@ func (s *StreamableHTTPServer) Shutdown(ctx context.Context) error {
 		return srv.Shutdown(ctx)
 	}
 	return nil
+}
+
+// ProtectedResourceMetadataEndpoint returns an http.Handler that serves
+// the server's Protected Resource Metadata (RFC 9728). Returns nil if no
+// metadata is configured. Use this when mounting the server as an http.Handler
+// to register the well-known endpoint yourself.
+func (s *StreamableHTTPServer) ProtectedResourceMetadataEndpoint() http.Handler {
+	if s.protectedResourceMetadata == nil {
+		return nil
+	}
+	return ProtectedResourceMetadataHandler(s.protectedResourceMetadata)
 }
 
 // --- internal methods ---


### PR DESCRIPTION
## Description

Add server-side Protected Resource Metadata (RFC 9728).

- ProtectedResourceMetadata type + JSON handler with CORS
- WithProtectedResourceMetadata / WithSSEProtectedResourceMetadata options
- Auto-serves /.well-known/oauth-protected-resource in Start() and ServeHTTP()
- ProtectedResourceMetadataEndpoint() for manual mounting
- Tests

https://modelcontextprotocol.io/seps/985-align-oauth-20-protected-resource-metadata-with-rf#sep-985-align-oauth-2-0-protected-resource-metadata-with-rfc-9728

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Authorization — Protected Resource Metadata](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#protected-resource-metadata)
- [x] Implementation follows the specification exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support serving OAuth 2.0 Protected Resource Metadata (RFC 9728) at /.well-known/oauth-protected-resource when configured; responses are JSON, include CORS headers, return 204 for OPTIONS and 405 for unsupported methods. Servers expose an endpoint helper when metadata is enabled.
* **Tests**
  * End-to-end tests cover routing, headers, method handling, JSON serialization and omitempty behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->