### PR TITLE
Handle non-compliant JSON-RPC error responses where error is a string

### DIFF
--- a/mcp/error_unmarshal_test.go
+++ b/mcp/error_unmarshal_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestJSONRPCErrorDetails_UnmarshalJSON verifies that JSONRPCErrorDetails handles
+// both spec-compliant object errors and non-compliant string errors from servers like Slack.
 func TestJSONRPCErrorDetails_UnmarshalJSON(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -61,7 +63,8 @@ func TestJSONRPCErrorDetails_UnmarshalJSON(t *testing.T) {
 	}
 }
 
-// Verify that a full JSON-RPC response with a string error field unmarshals correctly.
+// TestJSONRPCResponse_StringError verifies that a full JSON-RPC response with a
+// string error field unmarshals correctly when using JSONRPCErrorDetails.
 func TestJSONRPCResponse_StringError(t *testing.T) {
 	raw := `{"jsonrpc":"2.0","id":1,"error":"cursor_invalid"}`
 

--- a/mcp/error_unmarshal_test.go
+++ b/mcp/error_unmarshal_test.go
@@ -3,6 +3,9 @@ package mcp
 import (
 	"encoding/json"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestJSONRPCErrorDetails_UnmarshalJSON(t *testing.T) {
@@ -48,20 +51,12 @@ func TestJSONRPCErrorDetails_UnmarshalJSON(t *testing.T) {
 			var details JSONRPCErrorDetails
 			err := json.Unmarshal([]byte(tt.input), &details)
 			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
+				require.Error(t, err)
 				return
 			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if details.Code != tt.wantCode {
-				t.Errorf("code = %d, want %d", details.Code, tt.wantCode)
-			}
-			if details.Message != tt.wantMessage {
-				t.Errorf("message = %q, want %q", details.Message, tt.wantMessage)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantCode, details.Code)
+			assert.Equal(t, tt.wantMessage, details.Message)
 		})
 	}
 }
@@ -71,22 +66,14 @@ func TestJSONRPCResponse_StringError(t *testing.T) {
 	raw := `{"jsonrpc":"2.0","id":1,"error":"cursor_invalid"}`
 
 	type response struct {
-		JSONRPC string                `json:"jsonrpc"`
-		ID      int                   `json:"id"`
-		Error   *JSONRPCErrorDetails  `json:"error"`
+		JSONRPC string               `json:"jsonrpc"`
+		ID      int                  `json:"id"`
+		Error   *JSONRPCErrorDetails `json:"error"`
 	}
 
 	var resp response
-	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
-		t.Fatalf("unmarshal failed: %v", err)
-	}
-	if resp.Error == nil {
-		t.Fatal("expected error to be non-nil")
-	}
-	if resp.Error.Code != INTERNAL_ERROR {
-		t.Errorf("code = %d, want %d", resp.Error.Code, INTERNAL_ERROR)
-	}
-	if resp.Error.Message != "cursor_invalid" {
-		t.Errorf("message = %q, want %q", resp.Error.Message, "cursor_invalid")
-	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+	require.NotNil(t, resp.Error)
+	assert.Equal(t, INTERNAL_ERROR, resp.Error.Code)
+	assert.Equal(t, "cursor_invalid", resp.Error.Message)
 }

--- a/mcp/error_unmarshal_test.go
+++ b/mcp/error_unmarshal_test.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestJSONRPCErrorDetails_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantCode    int
+		wantMessage string
+		wantErr     bool
+	}{
+		{
+			name:        "standard object",
+			input:       `{"code": -32600, "message": "invalid request"}`,
+			wantCode:    -32600,
+			wantMessage: "invalid request",
+		},
+		{
+			name:        "string error from non-compliant server",
+			input:       `"cursor_invalid"`,
+			wantCode:    INTERNAL_ERROR,
+			wantMessage: "cursor_invalid",
+		},
+		{
+			name:        "object with data field",
+			input:       `{"code": -32603, "message": "something failed", "data": {"detail": "more info"}}`,
+			wantCode:    -32603,
+			wantMessage: "something failed",
+		},
+		{
+			name:    "number is rejected",
+			input:   `42`,
+			wantErr: true,
+		},
+		{
+			name:    "array is rejected",
+			input:   `["bad"]`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var details JSONRPCErrorDetails
+			err := json.Unmarshal([]byte(tt.input), &details)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if details.Code != tt.wantCode {
+				t.Errorf("code = %d, want %d", details.Code, tt.wantCode)
+			}
+			if details.Message != tt.wantMessage {
+				t.Errorf("message = %q, want %q", details.Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+// Verify that a full JSON-RPC response with a string error field unmarshals correctly.
+func TestJSONRPCResponse_StringError(t *testing.T) {
+	raw := `{"jsonrpc":"2.0","id":1,"error":"cursor_invalid"}`
+
+	type response struct {
+		JSONRPC string                `json:"jsonrpc"`
+		ID      int                   `json:"id"`
+		Error   *JSONRPCErrorDetails  `json:"error"`
+	}
+
+	var resp response
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	if resp.Error == nil {
+		t.Fatal("expected error to be non-nil")
+	}
+	if resp.Error.Code != INTERNAL_ERROR {
+		t.Errorf("code = %d, want %d", resp.Error.Code, INTERNAL_ERROR)
+	}
+	if resp.Error.Message != "cursor_invalid" {
+		t.Errorf("message = %q, want %q", resp.Error.Message, "cursor_invalid")
+	}
+}

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -400,6 +400,25 @@ type JSONRPCErrorDetails struct {
 	Data any `json:"data,omitempty"`
 }
 
+// UnmarshalJSON handles both the standard JSON-RPC error object
+// ({"code": -32600, "message": "..."}) and non-compliant servers that
+// return the error as a plain string (e.g. "cursor_invalid").
+func (e *JSONRPCErrorDetails) UnmarshalJSON(data []byte) error {
+	// Try the spec-compliant object shape first.
+	type plain JSONRPCErrorDetails
+	if err := json.Unmarshal(data, (*plain)(e)); err == nil {
+		return nil
+	}
+	// Some servers (e.g. Slack MCP) return a bare string.
+	var msg string
+	if err := json.Unmarshal(data, &msg); err != nil {
+		return fmt.Errorf("error field is neither an object nor a string: %w", err)
+	}
+	e.Code = INTERNAL_ERROR
+	e.Message = msg
+	return nil
+}
+
 // Standard JSON-RPC error codes
 const (
 	// PARSE_ERROR indicates invalid JSON was received by the server.


### PR DESCRIPTION
## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Description

Some MCP servers (e.g. Slack) return the JSON-RPC `error` field as a plain string instead of the spec-required `{code, message, data}` object:

```json
{"jsonrpc": "2.0", "id": 1, "error": "cursor_invalid"}
```

`json.Unmarshal` fails because `JSONRPCErrorDetails` expects an object, and the original error message is lost. The client sees `"failed to decode response"` instead of the actual upstream error.

This adds a custom `UnmarshalJSON` on `JSONRPCErrorDetails` that:

1. Tries the standard object shape first — no behavior change for compliant servers
2. Falls back to bare string — wraps as `{Code: INTERNAL_ERROR, Message: "<the string>"}`
3. Rejects anything else (numbers, arrays) with an error

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix works
- [x] New and existing unit tests pass locally with my changes

## Validation

```
go test ./mcp/ -run "TestJSONRPCErrorDetails_UnmarshalJSON|TestJSONRPCResponse_StringError" -v
go test ./...
```