### PR TITLE
fix(examples): redirect hook output to stderr in everything server

### DIFF
--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -34,31 +35,33 @@ const (
 func NewMCPServer() *server.MCPServer {
 	hooks := &server.Hooks{}
 
+	// All hook output goes to stderr. In stdio mode, stdout is the JSON-RPC
+	// transport; writing to stdout from hooks corrupts the protocol stream.
 	hooks.AddBeforeAny(func(ctx context.Context, id any, method mcp.MCPMethod, message any) {
-		fmt.Printf("beforeAny: %s, %v, %v\n", method, id, message)
+		fmt.Fprintf(os.Stderr, "beforeAny: %s, %v, %v\n", method, id, message)
 	})
 	hooks.AddOnSuccess(func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any) {
-		fmt.Printf("onSuccess: %s, %v, %v, %v\n", method, id, message, result)
+		fmt.Fprintf(os.Stderr, "onSuccess: %s, %v, %v, %v\n", method, id, message, result)
 	})
 	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
-		fmt.Printf("onError: %s, %v, %v, %v\n", method, id, message, err)
+		fmt.Fprintf(os.Stderr, "onError: %s, %v, %v, %v\n", method, id, message, err)
 	})
 	hooks.AddBeforeInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest) {
-		fmt.Printf("beforeInitialize: %v, %v\n", id, message)
+		fmt.Fprintf(os.Stderr, "beforeInitialize: %v, %v\n", id, message)
 	})
 	hooks.AddOnRequestInitialization(func(ctx context.Context, id any, message any) error {
-		fmt.Printf("AddOnRequestInitialization: %v, %v\n", id, message)
+		fmt.Fprintf(os.Stderr, "AddOnRequestInitialization: %v, %v\n", id, message)
 		// authorization verification and other preprocessing tasks are performed.
 		return nil
 	})
 	hooks.AddAfterInitialize(func(ctx context.Context, id any, message *mcp.InitializeRequest, result *mcp.InitializeResult) {
-		fmt.Printf("afterInitialize: %v, %v, %v\n", id, message, result)
+		fmt.Fprintf(os.Stderr, "afterInitialize: %v, %v, %v\n", id, message, result)
 	})
 	hooks.AddAfterCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest, result any) {
-		fmt.Printf("afterCallTool: %v, %v, %v\n", id, message, result)
+		fmt.Fprintf(os.Stderr, "afterCallTool: %v, %v, %v\n", id, message, result)
 	})
 	hooks.AddBeforeCallTool(func(ctx context.Context, id any, message *mcp.CallToolRequest) {
-		fmt.Printf("beforeCallTool: %v, %v\n", id, message)
+		fmt.Fprintf(os.Stderr, "beforeCallTool: %v, %v\n", id, message)
 	})
 
 	mcpServer := server.NewMCPServer(


### PR DESCRIPTION
## Summary

- All 8 `fmt.Printf` calls in the everything server's hooks wrote to stdout
- In stdio mode, stdout is the JSON-RPC transport, so hook output corrupts the protocol stream
- The `longRunningOperation` tool's `time.Sleep` creates a timing window that makes this reliably reproducible, but any hook firing during a tool call can trigger it
- Fix: redirect all hook output to `fmt.Fprintf(os.Stderr, ...)`

## Test plan

- [x] `go build ./examples/everything/` passes
- [x] Verified with [mcp-assert](https://github.com/blackwell-systems/mcp-assert): `longRunningOperation` no longer crashes the stdio transport

Fixes #826

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hook logging output redirection to prevent interference with JSON-RPC communication in stdio mode. Hook logs are now properly separated from the primary output stream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->