### PR TITLE
feat(server): opt-in input schema validation per SEP-1303

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	github.com/google/jsonschema-go v0.4.2
 	github.com/google/uuid v1.6.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cast v1.7.1
 	github.com/stretchr/testify v1.9.0
 	github.com/yosida95/uritemplate/v3 v3.0.2
@@ -13,5 +14,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
@@ -16,12 +18,16 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cast v1.7.1 h1:cuNEagBQEHWN1FnbGEjCXL2szYEXqfJPbP2HNUaca9Y=
 github.com/spf13/cast v1.7.1/go.mod h1:ancEpBxwJDODSW/UG4rDrAqiKolqNNh2DX3mk86cAdo=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
+golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/server/input_validation.go
+++ b/server/input_validation.go
@@ -261,18 +261,9 @@ func escapeJSONPointer(seg string) string {
 }
 
 // validationToolResult builds the SEP-1303 compliant tool execution error
-// surfaced when input schema validation fails. The error message is duplicated
-// into the structured field so that clients with structured-content support
-// can render it directly.
+// surfaced when input schema validation fails. It uses the standard
+// NewToolResultError helper so validation failures are shaped identically
+// to errors produced by tool handlers themselves.
 func validationToolResult(err error) *mcp.CallToolResult {
-	msg := err.Error()
-	return &mcp.CallToolResult{
-		Content: []mcp.Content{
-			mcp.TextContent{
-				Type: "text",
-				Text: msg,
-			},
-		},
-		IsError: true,
-	}
+	return mcp.NewToolResultError(err.Error())
 }

--- a/server/input_validation.go
+++ b/server/input_validation.go
@@ -3,7 +3,10 @@ package server
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -14,22 +17,24 @@ import (
 )
 
 // inputSchemaValidator compiles and caches JSON Schema validators for tool
-// input schemas. Compilation is performed lazily on first use of a given tool
-// and the resulting schema is cached for the lifetime of the server. Cache
-// invalidation is handled by AddTools/SetTools/DeleteTools by removing entries
-// from the cache.
+// input schemas. Compilation is performed lazily on first use and the
+// resulting schema is cached for the lifetime of the server.
+//
+// The cache is two-level: tool name -> schema digest -> compiled entry. Two
+// sessions can expose the same tool name with different schemas (via
+// SessionWithTools) and a global tool can be re-registered with a different
+// schema; each distinct schema is compiled once. Name-level invalidation
+// drops every entry registered for that name in a single map delete, which
+// keeps DeleteTools / SetTools cleanup cheap.
 type inputSchemaValidator struct {
 	mu     sync.RWMutex
-	cached map[string]*cachedToolSchema
+	cached map[string]map[string]*cachedToolSchema
 }
 
-// cachedToolSchema records the result of compiling a tool's input schema.
-// schemaJSON is the canonical JSON used to compile the schema; if it changes
-// between calls (for example because the tool was re-registered with a
-// different schema), the cached entry is rebuilt. compileErr is recorded so
-// that repeatedly invalid schemas don't get recompiled on every call.
+// cachedToolSchema records the result of compiling a single (toolName,
+// schemaDigest) pair. compileErr is stored alongside the compiled schema so
+// that a schema that fails to compile is not recompiled on every call.
 type cachedToolSchema struct {
-	schemaJSON []byte
 	compiled   *jsonschema.Schema
 	compileErr error
 }
@@ -37,7 +42,7 @@ type cachedToolSchema struct {
 // newInputSchemaValidator returns a fresh validator with an empty cache.
 func newInputSchemaValidator() *inputSchemaValidator {
 	return &inputSchemaValidator{
-		cached: make(map[string]*cachedToolSchema),
+		cached: make(map[string]map[string]*cachedToolSchema),
 	}
 }
 
@@ -88,31 +93,49 @@ func (v *inputSchemaValidator) invalidateAll() {
 	}
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	v.cached = make(map[string]*cachedToolSchema)
+	v.cached = make(map[string]map[string]*cachedToolSchema)
 }
 
 func (v *inputSchemaValidator) lookupOrCompile(toolName string, schemaJSON []byte) (*jsonschema.Schema, error) {
+	digest := schemaDigest(schemaJSON)
+
 	v.mu.RLock()
-	entry, ok := v.cached[toolName]
-	v.mu.RUnlock()
-	if ok && bytes.Equal(entry.schemaJSON, schemaJSON) {
-		return entry.compiled, entry.compileErr
+	if perName, ok := v.cached[toolName]; ok {
+		if entry, ok := perName[digest]; ok {
+			v.mu.RUnlock()
+			return entry.compiled, entry.compileErr
+		}
 	}
+	v.mu.RUnlock()
 
 	v.mu.Lock()
 	defer v.mu.Unlock()
 	// Re-check under the write lock in case another goroutine compiled it.
-	if entry, ok := v.cached[toolName]; ok && bytes.Equal(entry.schemaJSON, schemaJSON) {
+	perName, ok := v.cached[toolName]
+	if !ok {
+		perName = make(map[string]*cachedToolSchema)
+		v.cached[toolName] = perName
+	}
+	if entry, ok := perName[digest]; ok {
 		return entry.compiled, entry.compileErr
 	}
 
 	compiled, compileErr := compileSchema(toolName, schemaJSON)
-	v.cached[toolName] = &cachedToolSchema{
-		schemaJSON: append([]byte(nil), schemaJSON...),
+	perName[digest] = &cachedToolSchema{
 		compiled:   compiled,
 		compileErr: compileErr,
 	}
 	return compiled, compileErr
+}
+
+// schemaDigest returns a stable hex-encoded SHA-256 of the canonical schema
+// bytes. We use a digest rather than the raw bytes as a map key so the cache
+// stays cheap to look up even for large schemas; collisions are not a
+// security concern because both sides of the comparison are produced by the
+// same mcp-go server process.
+func schemaDigest(schemaJSON []byte) string {
+	sum := sha256.Sum256(schemaJSON)
+	return hex.EncodeToString(sum[:])
 }
 
 // schemaJSONFor returns the JSON representation of the tool's input schema.
@@ -180,7 +203,7 @@ func normalizeArgumentsForValidation(rawArgs any) (any, error) {
 // violation is rendered as `<path>: <message>` and joined with semicolons.
 func formatValidationError(err error) error {
 	var verr *jsonschema.ValidationError
-	if !asValidationError(err, &verr) {
+	if !errors.As(err, &verr) {
 		return fmt.Errorf("input schema validation failed: %w", err)
 	}
 	parts := collectValidationMessages(verr)
@@ -188,25 +211,6 @@ func formatValidationError(err error) error {
 		return fmt.Errorf("input schema validation failed: %s", verr.Error())
 	}
 	return fmt.Errorf("input schema validation failed: %s", strings.Join(parts, "; "))
-}
-
-// asValidationError mirrors errors.As but kept tiny to avoid pulling in extra
-// dependencies. The validator either returns *jsonschema.ValidationError
-// directly or wraps it; both are handled here.
-func asValidationError(err error, target **jsonschema.ValidationError) bool {
-	for cur := err; cur != nil; {
-		if v, ok := cur.(*jsonschema.ValidationError); ok {
-			*target = v
-			return true
-		}
-		type unwrap interface{ Unwrap() error }
-		uw, ok := cur.(unwrap)
-		if !ok {
-			return false
-		}
-		cur = uw.Unwrap()
-	}
-	return false
 }
 
 // collectValidationMessages walks the leaf causes of a validation error tree

--- a/server/input_validation.go
+++ b/server/input_validation.go
@@ -1,0 +1,274 @@
+// Package server provides MCP (Model Context Protocol) server implementations.
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// inputSchemaValidator compiles and caches JSON Schema validators for tool
+// input schemas. Compilation is performed lazily on first use of a given tool
+// and the resulting schema is cached for the lifetime of the server. Cache
+// invalidation is handled by AddTools/SetTools/DeleteTools by removing entries
+// from the cache.
+type inputSchemaValidator struct {
+	mu     sync.RWMutex
+	cached map[string]*cachedToolSchema
+}
+
+// cachedToolSchema records the result of compiling a tool's input schema.
+// schemaJSON is the canonical JSON used to compile the schema; if it changes
+// between calls (for example because the tool was re-registered with a
+// different schema), the cached entry is rebuilt. compileErr is recorded so
+// that repeatedly invalid schemas don't get recompiled on every call.
+type cachedToolSchema struct {
+	schemaJSON []byte
+	compiled   *jsonschema.Schema
+	compileErr error
+}
+
+// newInputSchemaValidator returns a fresh validator with an empty cache.
+func newInputSchemaValidator() *inputSchemaValidator {
+	return &inputSchemaValidator{
+		cached: make(map[string]*cachedToolSchema),
+	}
+}
+
+// validate validates raw arguments against the tool's input schema. If the
+// schema cannot be compiled, validation is treated as a no-op so that broken
+// schemas never make tool calls fail unexpectedly. The boolean return reports
+// whether validation actually ran; the error is set only when validation ran
+// and the arguments did not satisfy the schema.
+func (v *inputSchemaValidator) validate(tool mcp.Tool, rawArgs any) (bool, error) {
+	schemaJSON, ok := schemaJSONFor(tool)
+	if !ok {
+		return false, nil
+	}
+
+	compiled, err := v.lookupOrCompile(tool.Name, schemaJSON)
+	if err != nil {
+		return false, nil
+	}
+
+	value, err := normalizeArgumentsForValidation(rawArgs)
+	if err != nil {
+		return true, fmt.Errorf("invalid arguments: %w", err)
+	}
+
+	if err := compiled.Validate(value); err != nil {
+		return true, formatValidationError(err)
+	}
+	return true, nil
+}
+
+// invalidate drops cached compilations for the given tool names. Used when
+// tools are re-registered or removed so that stale schemas are not reused.
+func (v *inputSchemaValidator) invalidate(names ...string) {
+	if v == nil || len(names) == 0 {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	for _, name := range names {
+		delete(v.cached, name)
+	}
+}
+
+// invalidateAll drops the entire cache.
+func (v *inputSchemaValidator) invalidateAll() {
+	if v == nil {
+		return
+	}
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	v.cached = make(map[string]*cachedToolSchema)
+}
+
+func (v *inputSchemaValidator) lookupOrCompile(toolName string, schemaJSON []byte) (*jsonschema.Schema, error) {
+	v.mu.RLock()
+	entry, ok := v.cached[toolName]
+	v.mu.RUnlock()
+	if ok && bytes.Equal(entry.schemaJSON, schemaJSON) {
+		return entry.compiled, entry.compileErr
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	// Re-check under the write lock in case another goroutine compiled it.
+	if entry, ok := v.cached[toolName]; ok && bytes.Equal(entry.schemaJSON, schemaJSON) {
+		return entry.compiled, entry.compileErr
+	}
+
+	compiled, compileErr := compileSchema(toolName, schemaJSON)
+	v.cached[toolName] = &cachedToolSchema{
+		schemaJSON: append([]byte(nil), schemaJSON...),
+		compiled:   compiled,
+		compileErr: compileErr,
+	}
+	return compiled, compileErr
+}
+
+// schemaJSONFor returns the JSON representation of the tool's input schema.
+// It prefers RawInputSchema when set, otherwise marshals the structured
+// InputSchema. The boolean return is false when the tool has no usable input
+// schema (e.g. an empty structured schema with no properties).
+func schemaJSONFor(tool mcp.Tool) ([]byte, bool) {
+	if len(tool.RawInputSchema) > 0 {
+		return tool.RawInputSchema, true
+	}
+	if tool.InputSchema.Type == "" && len(tool.InputSchema.Properties) == 0 && len(tool.InputSchema.Required) == 0 && tool.InputSchema.AdditionalProperties == nil {
+		return nil, false
+	}
+	data, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// compileSchema parses a JSON Schema document and compiles it for the given
+// tool. The schema is registered against an opaque virtual URL so that
+// "$ref" resolution works without touching the filesystem or network.
+func compileSchema(toolName string, schemaJSON []byte) (*jsonschema.Schema, error) {
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaJSON))
+	if err != nil {
+		return nil, fmt.Errorf("decode tool %q input schema: %w", toolName, err)
+	}
+	resourceURL := fmt.Sprintf("mem:///mcp-go/tools/%s/input-schema.json", toolName)
+	c := jsonschema.NewCompiler()
+	if err := c.AddResource(resourceURL, doc); err != nil {
+		return nil, fmt.Errorf("register tool %q input schema: %w", toolName, err)
+	}
+	compiled, err := c.Compile(resourceURL)
+	if err != nil {
+		return nil, fmt.Errorf("compile tool %q input schema: %w", toolName, err)
+	}
+	return compiled, nil
+}
+
+// normalizeArgumentsForValidation converts the raw arguments value (which may
+// be a json.RawMessage, a map, or already-decoded slice/scalars) into the
+// loosely-typed representation that the JSON Schema validator expects. Missing
+// arguments are normalised to an empty object so that schemas can still
+// validate `required` constraints sensibly.
+func normalizeArgumentsForValidation(rawArgs any) (any, error) {
+	if rawArgs == nil {
+		return map[string]any{}, nil
+	}
+	if raw, ok := rawArgs.(json.RawMessage); ok {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			return map[string]any{}, nil
+		}
+		return jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	}
+	encoded, err := json.Marshal(rawArgs)
+	if err != nil {
+		return nil, err
+	}
+	return jsonschema.UnmarshalJSON(bytes.NewReader(encoded))
+}
+
+// formatValidationError turns the validator's structured error into a single
+// flat message that's friendly for an LLM to read. Each individual constraint
+// violation is rendered as `<path>: <message>` and joined with semicolons.
+func formatValidationError(err error) error {
+	var verr *jsonschema.ValidationError
+	if !asValidationError(err, &verr) {
+		return fmt.Errorf("input schema validation failed: %w", err)
+	}
+	parts := collectValidationMessages(verr)
+	if len(parts) == 0 {
+		return fmt.Errorf("input schema validation failed: %s", verr.Error())
+	}
+	return fmt.Errorf("input schema validation failed: %s", strings.Join(parts, "; "))
+}
+
+// asValidationError mirrors errors.As but kept tiny to avoid pulling in extra
+// dependencies. The validator either returns *jsonschema.ValidationError
+// directly or wraps it; both are handled here.
+func asValidationError(err error, target **jsonschema.ValidationError) bool {
+	for cur := err; cur != nil; {
+		if v, ok := cur.(*jsonschema.ValidationError); ok {
+			*target = v
+			return true
+		}
+		type unwrap interface{ Unwrap() error }
+		uw, ok := cur.(unwrap)
+		if !ok {
+			return false
+		}
+		cur = uw.Unwrap()
+	}
+	return false
+}
+
+// collectValidationMessages walks the leaf causes of a validation error tree
+// and produces one message per leaf. Non-leaf nodes don't carry useful
+// information for the model (they're aggregator nodes like "anyOf failed").
+func collectValidationMessages(verr *jsonschema.ValidationError) []string {
+	if verr == nil {
+		return nil
+	}
+	var out []string
+	if len(verr.Causes) == 0 {
+		out = append(out, formatLeafMessage(verr))
+		return out
+	}
+	for _, cause := range verr.Causes {
+		out = append(out, collectValidationMessages(cause)...)
+	}
+	return out
+}
+
+func formatLeafMessage(verr *jsonschema.ValidationError) string {
+	location := jsonPointer(verr.InstanceLocation)
+	if location == "" {
+		location = "<root>"
+	}
+	return fmt.Sprintf("%s: %s", location, verr.ErrorKind)
+}
+
+// jsonPointer renders a list of path segments as a RFC 6901 JSON Pointer.
+// Empty paths render as the empty string (the validator's convention for the
+// root document) which the caller substitutes for "<root>".
+func jsonPointer(segments []string) string {
+	if len(segments) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, seg := range segments {
+		b.WriteByte('/')
+		b.WriteString(escapeJSONPointer(seg))
+	}
+	return b.String()
+}
+
+func escapeJSONPointer(seg string) string {
+	seg = strings.ReplaceAll(seg, "~", "~0")
+	seg = strings.ReplaceAll(seg, "/", "~1")
+	return seg
+}
+
+// validationToolResult builds the SEP-1303 compliant tool execution error
+// surfaced when input schema validation fails. The error message is duplicated
+// into the structured field so that clients with structured-content support
+// can render it directly.
+func validationToolResult(err error) *mcp.CallToolResult {
+	msg := err.Error()
+	return &mcp.CallToolResult{
+		Content: []mcp.Content{
+			mcp.TextContent{
+				Type: "text",
+				Text: msg,
+			},
+		},
+		IsError: true,
+	}
+}

--- a/server/input_validation_test.go
+++ b/server/input_validation_test.go
@@ -74,144 +74,175 @@ func requireToolSuccess(t *testing.T, resp mcp.JSONRPCMessage) *mcp.CallToolResu
 	return result
 }
 
-// TestInputSchemaValidation_DisabledByDefault is the regression guard: the
-// kubernetes_list / cursor scenario from the bug report. With validation
-// disabled, the server silently accepts the unknown `cursor` parameter, which
-// is exactly what hides typos from the model today.
-func TestInputSchemaValidation_DisabledByDefault(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0")
-	srv.AddTool(fakeListTool(), okHandler)
-
-	resp := callTool(t, srv, "kubernetes_list", map[string]any{
-		"resourceType": "pods",
-		"cursor":       "abc",
-	})
-	requireToolSuccess(t, resp)
-}
-
-// TestInputSchemaValidation_RejectsUnknownProperty is the fix for the bug
-// report: with validation enabled and additionalProperties: false, an unknown
-// `cursor` parameter must surface as a tool execution error so the model can
-// retry with the correct `continue` parameter.
-func TestInputSchemaValidation_RejectsUnknownProperty(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	srv.AddTool(fakeListTool(), okHandler)
-
-	resp := callTool(t, srv, "kubernetes_list", map[string]any{
-		"resourceType": "pods",
-		"cursor":       "abc",
-	})
-	requireToolErrorContaining(t, resp, "cursor")
-}
-
-// TestInputSchemaValidation_RejectsMissingRequired covers the second SEP-1303
-// scenario: a missing required argument should also become a tool execution
-// error rather than the JSON-RPC -32602 protocol error path.
-func TestInputSchemaValidation_RejectsMissingRequired(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	srv.AddTool(fakeListTool(), okHandler)
-
-	resp := callTool(t, srv, "kubernetes_list", map[string]any{
-		"continue": "abc",
-	})
-	requireToolErrorContaining(t, resp, "resourceType")
-}
-
-// TestInputSchemaValidation_RejectsWrongType makes sure type mismatches (here,
-// passing a number where a string is required) are caught.
-func TestInputSchemaValidation_RejectsWrongType(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	srv.AddTool(fakeListTool(), okHandler)
-
-	resp := callTool(t, srv, "kubernetes_list", map[string]any{
-		"resourceType": 123,
-	})
-	requireToolErrorContaining(t, resp, "resourceType")
-}
-
-// TestInputSchemaValidation_AcceptsValidCall is the happy path: a request
-// that satisfies the schema reaches the handler and returns its result.
-func TestInputSchemaValidation_AcceptsValidCall(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	called := false
-	srv.AddTool(fakeListTool(), func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-		called = true
-		assert.Equal(t, "pods", req.GetString("resourceType", ""))
-		assert.Equal(t, "abc", req.GetString("continue", ""))
-		return mcp.NewToolResultText("ok"), nil
-	})
-
-	resp := callTool(t, srv, "kubernetes_list", map[string]any{
-		"resourceType": "pods",
-		"continue":     "abc",
-	})
-	requireToolSuccess(t, resp)
-	assert.True(t, called, "handler was not invoked for a valid call")
-}
-
-// TestInputSchemaValidation_AllowsAdditionalWhenSchemaPermits documents that
-// validation only rejects unknown properties when the tool author has marked
-// the schema strict. Tools that omit additionalProperties: false continue to
-// accept extras, preserving back-compat with permissive schemas.
-func TestInputSchemaValidation_AllowsAdditionalWhenSchemaPermits(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	tool := mcp.NewTool("permissive",
-		mcp.WithString("name", mcp.Required()),
-	)
-	srv.AddTool(tool, okHandler)
-
-	resp := callTool(t, srv, "permissive", map[string]any{
-		"name":  "alice",
-		"extra": "field",
-	})
-	requireToolSuccess(t, resp)
-}
-
-// TestInputSchemaValidation_BrokenSchemaIsNoOp guards against a malformed
-// schema accidentally blocking every call to that tool. A schema that fails
-// to compile should be silently skipped (and the handler invoked normally),
-// not surfaced as a permanent validation error to the model.
-func TestInputSchemaValidation_BrokenSchemaIsNoOp(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	tool := mcp.Tool{
-		Name:           "broken",
-		Description:    "Tool with malformed schema",
-		RawInputSchema: json.RawMessage(`{"type": "object", "properties": {`), // unterminated JSON
-	}
-	srv.AddTool(tool, okHandler)
-
-	resp := callTool(t, srv, "broken", map[string]any{"anything": true})
-	requireToolSuccess(t, resp)
-}
-
-// TestInputSchemaValidation_RawInputSchema verifies that schemas supplied via
-// RawInputSchema (the alternative to the structured InputSchema) participate
-// in validation just like structured ones.
-func TestInputSchemaValidation_RawInputSchema(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	tool := mcp.Tool{
+// TestInputSchemaValidation covers the matrix of validation outcomes for a
+// range of tools: strict, permissive, no schema, raw schema, broken schema.
+// Each row exercises exactly one server lifecycle, registers the listed
+// tools, makes a single tool call, and asserts on either success or an error
+// containing a specific substring.
+//
+// Scenarios that need multi-step setup (cache invalidation,
+// recompilation-on-schema-change) live in their own dedicated tests.
+func TestInputSchemaValidation(t *testing.T) {
+	rawStrictTool := mcp.Tool{
 		Name:        "raw",
 		Description: "Tool with raw JSON Schema",
 		RawInputSchema: json.RawMessage(`{
 			"type": "object",
-			"properties": {
-				"name": {"type": "string"}
-			},
+			"properties": {"name": {"type": "string"}},
 			"required": ["name"],
 			"additionalProperties": false
 		}`),
 	}
-	srv.AddTool(tool, okHandler)
+	brokenSchemaTool := mcp.Tool{
+		Name:           "broken",
+		Description:    "Tool with malformed schema",
+		RawInputSchema: json.RawMessage(`{"type": "object", "properties": {`),
+	}
+	noSchemaTool := mcp.Tool{Name: "noschema", Description: "no schema"}
+	permissiveTool := mcp.NewTool("permissive",
+		mcp.WithString("name", mcp.Required()),
+	)
+	nestedStrictTool := mcp.Tool{
+		Name: "nested",
+		RawInputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"filter": {
+					"type": "object",
+					"properties": {"label": {"type": "string"}},
+					"required": ["label"],
+					"additionalProperties": false
+				}
+			},
+			"required": ["filter"]
+		}`),
+	}
 
-	resp := callTool(t, srv, "raw", map[string]any{"name": "alice", "typo": 1})
-	requireToolErrorContaining(t, resp, "typo")
+	tests := []struct {
+		name              string
+		options           []ServerOption
+		tool              mcp.Tool
+		args              map[string]any
+		wantSuccess       bool
+		wantErrContains   string
+		wantHandlerCalled bool
+	}{
+		{
+			// Regression guard: with validation off, the kubernetes_list
+			// scenario from the bug report (sending `cursor` instead of
+			// `continue`) silently succeeds. Pinned so we never flip the
+			// default to strict and break existing servers.
+			name:              "disabled by default accepts unknown property",
+			options:           nil,
+			tool:              fakeListTool(),
+			args:              map[string]any{"resourceType": "pods", "cursor": "abc"},
+			wantSuccess:       true,
+			wantHandlerCalled: true,
+		},
+		{
+			// The motivating fix: with validation on and additionalProperties:
+			// false, an unknown `cursor` parameter must surface as a tool
+			// execution error so the model can retry with `continue`.
+			name:            "strict schema rejects unknown property",
+			options:         []ServerOption{WithInputSchemaValidation()},
+			tool:            fakeListTool(),
+			args:            map[string]any{"resourceType": "pods", "cursor": "abc"},
+			wantErrContains: "cursor",
+		},
+		{
+			name:            "strict schema rejects missing required",
+			options:         []ServerOption{WithInputSchemaValidation()},
+			tool:            fakeListTool(),
+			args:            map[string]any{"continue": "abc"},
+			wantErrContains: "resourceType",
+		},
+		{
+			name:            "strict schema rejects wrong type",
+			options:         []ServerOption{WithInputSchemaValidation()},
+			tool:            fakeListTool(),
+			args:            map[string]any{"resourceType": 123},
+			wantErrContains: "resourceType",
+		},
+		{
+			name:              "valid call passes through to handler",
+			options:           []ServerOption{WithInputSchemaValidation()},
+			tool:              fakeListTool(),
+			args:              map[string]any{"resourceType": "pods", "continue": "abc"},
+			wantSuccess:       true,
+			wantHandlerCalled: true,
+		},
+		{
+			// Tools that omit additionalProperties: false continue to accept
+			// extras even with validation enabled. This preserves back-compat
+			// with permissive schemas the author chose deliberately.
+			name:              "permissive schema accepts extras",
+			options:           []ServerOption{WithInputSchemaValidation()},
+			tool:              permissiveTool,
+			args:              map[string]any{"name": "alice", "extra": "field"},
+			wantSuccess:       true,
+			wantHandlerCalled: true,
+		},
+		{
+			// A schema that fails to compile must not block calls to the
+			// tool. The validator silently degrades and the handler runs.
+			name:              "malformed schema is silently skipped",
+			options:           []ServerOption{WithInputSchemaValidation()},
+			tool:              brokenSchemaTool,
+			args:              map[string]any{"anything": true},
+			wantSuccess:       true,
+			wantHandlerCalled: true,
+		},
+		{
+			name:            "raw input schema participates in validation",
+			options:         []ServerOption{WithInputSchemaValidation()},
+			tool:            rawStrictTool,
+			args:            map[string]any{"name": "alice", "typo": 1},
+			wantErrContains: "typo",
+		},
+		{
+			// Tools with no input schema at all (effectively zero-arg tools)
+			// are unaffected: there is nothing to validate against.
+			name:              "tool without schema is unaffected",
+			options:           []ServerOption{WithInputSchemaValidation()},
+			tool:              noSchemaTool,
+			args:              map[string]any{"anything": "goes"},
+			wantSuccess:       true,
+			wantHandlerCalled: true,
+		},
+		{
+			name:            "nested error message mentions field path",
+			options:         []ServerOption{WithInputSchemaValidation()},
+			tool:            nestedStrictTool,
+			args:            map[string]any{"filter": map[string]any{"label": "x", "extra": true}},
+			wantErrContains: "filter",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewMCPServer("test", "1.0.0", tt.options...)
+			handlerCalled := false
+			srv.AddTool(tt.tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				handlerCalled = true
+				return mcp.NewToolResultText("ok"), nil
+			})
+
+			resp := callTool(t, srv, tt.tool.Name, tt.args)
+
+			if tt.wantSuccess {
+				requireToolSuccess(t, resp)
+			} else {
+				requireToolErrorContaining(t, resp, tt.wantErrContains)
+			}
+			assert.Equal(t, tt.wantHandlerCalled, handlerCalled, "handler invocation expectation")
+		})
+	}
 }
 
-// TestInputSchemaValidation_ReusesCompiledSchema is a behavioural test that
-// confirms repeated calls reuse the cached compiled schema rather than
-// recompiling on every invocation. We can't observe compile counts directly,
-// so instead we re-register the tool with a different schema and check that
-// the new schema is honoured on the next call.
+// TestInputSchemaValidation_RecompilesOnSchemaChange documents that
+// re-registering a tool with a different schema honours the new schema on
+// the next call. The cache keys by name+digest, so a fresh schema produces a
+// fresh entry rather than colliding with the previous one.
 func TestInputSchemaValidation_RecompilesOnSchemaChange(t *testing.T) {
 	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
 	srv.AddTool(fakeListTool(), okHandler)
@@ -236,34 +267,47 @@ func TestInputSchemaValidation_RecompilesOnSchemaChange(t *testing.T) {
 	requireToolSuccess(t, resp)
 }
 
-// TestInputSchemaValidation_DeleteToolInvalidatesCache makes sure deleting
-// and re-adding a tool doesn't reuse the stale validator. We rely on the
-// content-hash check in the cache, but DeleteTools also drops the entry as a
-// belt-and-braces measure.
+// TestInputSchemaValidation_DeleteToolInvalidatesCache makes a validated
+// call first to populate the cache, then deletes the tool and asserts the
+// cache entry is gone. Without the warmup, the cache would be empty
+// regardless of whether DeleteTools invalidated it (compilation is lazy).
 func TestInputSchemaValidation_DeleteToolInvalidatesCache(t *testing.T) {
 	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
 	srv.AddTool(fakeListTool(), okHandler)
 
-	srv.DeleteTools("kubernetes_list")
-	require.Len(t, srv.inputValidator.cached, 0, "expected cache to be empty after DeleteTools")
-}
-
-// TestInputSchemaValidation_NoSchemaSkipsValidation covers tools that declare
-// no input schema at all (effectively a tool that accepts no arguments). The
-// validator should treat absence of a schema as "nothing to validate" and let
-// the call through.
-func TestInputSchemaValidation_NoSchemaSkipsValidation(t *testing.T) {
-	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
-	tool := mcp.Tool{Name: "noschema", Description: "no schema"}
-	srv.AddTool(tool, okHandler)
-
-	resp := callTool(t, srv, "noschema", map[string]any{"anything": "goes"})
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": "pods",
+		"continue":     "abc",
+	})
 	requireToolSuccess(t, resp)
+	require.Len(t, srv.inputValidator.cached, 1, "cache should be populated after a validated call")
+
+	srv.DeleteTools("kubernetes_list")
+	require.Len(t, srv.inputValidator.cached, 0, "cache should be empty after DeleteTools")
 }
 
-// TestInputSchemaValidation_NestedPathInError ensures the JSON pointer path
-// in the error message reaches into nested objects, so the model can
-// localise the failing field.
+// TestInputSchemaValidation_CachesPerSchemaDigest is the regression test for
+// the same-named-tool-with-different-schema scenario. Two compilations of the
+// same name with different schema bytes must coexist (one per digest), so
+// session-scoped tools that shadow global tools don't thrash the cache on
+// alternating calls.
+func TestInputSchemaValidation_CachesPerSchemaDigest(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	srv.AddTool(fakeListTool(), okHandler)
+	_, err := srv.inputValidator.lookupOrCompile("kubernetes_list", []byte(`{"type":"object","additionalProperties":false}`))
+	require.NoError(t, err)
+	_, err = srv.inputValidator.lookupOrCompile("kubernetes_list", []byte(`{"type":"object","additionalProperties":true}`))
+	require.NoError(t, err)
+
+	require.Len(t, srv.inputValidator.cached, 1, "expected exactly one tool entry in the cache")
+	require.Len(t, srv.inputValidator.cached["kubernetes_list"], 2,
+		"expected two compiled schema entries for the same tool name")
+}
+
+// TestInputSchemaValidation_NestedPathInError keeps a focused assertion that
+// the validator's error message reaches into nested objects. It deliberately
+// duplicates one of the table cases above with extra path-substring checks
+// that would clutter the table assertions.
 func TestInputSchemaValidation_NestedPathInError(t *testing.T) {
 	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
 	tool := mcp.Tool{
@@ -273,9 +317,7 @@ func TestInputSchemaValidation_NestedPathInError(t *testing.T) {
 			"properties": {
 				"filter": {
 					"type": "object",
-					"properties": {
-						"label": {"type": "string"}
-					},
+					"properties": {"label": {"type": "string"}},
 					"required": ["label"],
 					"additionalProperties": false
 				}

--- a/server/input_validation_test.go
+++ b/server/input_validation_test.go
@@ -1,0 +1,299 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// fakeListTool returns a tool that mirrors the kubernetes_list shape used in
+// the bug report: a `continue` pagination token (the standard k8s name) plus
+// strict additionalProperties: false so unknown args like `cursor` are
+// rejected.
+func fakeListTool() mcp.Tool {
+	return mcp.NewTool("kubernetes_list",
+		mcp.WithDescription("List Kubernetes resources"),
+		mcp.WithString("resourceType", mcp.Required(),
+			mcp.Description("Type of resource to list")),
+		mcp.WithString("continue",
+			mcp.Description("Continue token from previous paginated request")),
+		mcp.WithSchemaAdditionalProperties(false),
+	)
+}
+
+func okHandler(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return mcp.NewToolResultText("ok"), nil
+}
+
+func callTool(t *testing.T, srv *MCPServer, toolName string, args any) mcp.JSONRPCMessage {
+	t.Helper()
+	payload := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+	raw, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return srv.HandleMessage(t.Context(), raw)
+}
+
+// requireToolErrorContaining asserts that the response is a successful
+// JSON-RPC response carrying a tool execution error (CallToolResult.IsError =
+// true) whose text contains the supplied substring. This is the SEP-1303
+// shape that lets the model receive the validation message in its context.
+func requireToolErrorContaining(t *testing.T, resp mcp.JSONRPCMessage, want string) {
+	t.Helper()
+	jr, ok := resp.(mcp.JSONRPCResponse)
+	require.True(t, ok, "expected JSON-RPC response, got %T", resp)
+	result, ok := jr.Result.(*mcp.CallToolResult)
+	require.True(t, ok, "expected *mcp.CallToolResult, got %T", jr.Result)
+	require.True(t, result.IsError, "expected IsError=true, got %#v", result)
+	require.NotEmpty(t, result.Content, "expected at least one content entry")
+	tc, ok := result.Content[0].(mcp.TextContent)
+	require.True(t, ok, "expected TextContent, got %T", result.Content[0])
+	require.Contains(t, tc.Text, want)
+}
+
+func requireToolSuccess(t *testing.T, resp mcp.JSONRPCMessage) *mcp.CallToolResult {
+	t.Helper()
+	jr, ok := resp.(mcp.JSONRPCResponse)
+	require.True(t, ok, "expected JSON-RPC response, got %T", resp)
+	result, ok := jr.Result.(*mcp.CallToolResult)
+	require.True(t, ok, "expected *mcp.CallToolResult, got %T", jr.Result)
+	require.False(t, result.IsError, "expected IsError=false, got %#v", result)
+	return result
+}
+
+// TestInputSchemaValidation_DisabledByDefault is the regression guard: the
+// kubernetes_list / cursor scenario from the bug report. With validation
+// disabled, the server silently accepts the unknown `cursor` parameter, which
+// is exactly what hides typos from the model today.
+func TestInputSchemaValidation_DisabledByDefault(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0")
+	srv.AddTool(fakeListTool(), okHandler)
+
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": "pods",
+		"cursor":       "abc",
+	})
+	requireToolSuccess(t, resp)
+}
+
+// TestInputSchemaValidation_RejectsUnknownProperty is the fix for the bug
+// report: with validation enabled and additionalProperties: false, an unknown
+// `cursor` parameter must surface as a tool execution error so the model can
+// retry with the correct `continue` parameter.
+func TestInputSchemaValidation_RejectsUnknownProperty(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	srv.AddTool(fakeListTool(), okHandler)
+
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": "pods",
+		"cursor":       "abc",
+	})
+	requireToolErrorContaining(t, resp, "cursor")
+}
+
+// TestInputSchemaValidation_RejectsMissingRequired covers the second SEP-1303
+// scenario: a missing required argument should also become a tool execution
+// error rather than the JSON-RPC -32602 protocol error path.
+func TestInputSchemaValidation_RejectsMissingRequired(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	srv.AddTool(fakeListTool(), okHandler)
+
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"continue": "abc",
+	})
+	requireToolErrorContaining(t, resp, "resourceType")
+}
+
+// TestInputSchemaValidation_RejectsWrongType makes sure type mismatches (here,
+// passing a number where a string is required) are caught.
+func TestInputSchemaValidation_RejectsWrongType(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	srv.AddTool(fakeListTool(), okHandler)
+
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": 123,
+	})
+	requireToolErrorContaining(t, resp, "resourceType")
+}
+
+// TestInputSchemaValidation_AcceptsValidCall is the happy path: a request
+// that satisfies the schema reaches the handler and returns its result.
+func TestInputSchemaValidation_AcceptsValidCall(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	called := false
+	srv.AddTool(fakeListTool(), func(_ context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		called = true
+		assert.Equal(t, "pods", req.GetString("resourceType", ""))
+		assert.Equal(t, "abc", req.GetString("continue", ""))
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": "pods",
+		"continue":     "abc",
+	})
+	requireToolSuccess(t, resp)
+	assert.True(t, called, "handler was not invoked for a valid call")
+}
+
+// TestInputSchemaValidation_AllowsAdditionalWhenSchemaPermits documents that
+// validation only rejects unknown properties when the tool author has marked
+// the schema strict. Tools that omit additionalProperties: false continue to
+// accept extras, preserving back-compat with permissive schemas.
+func TestInputSchemaValidation_AllowsAdditionalWhenSchemaPermits(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	tool := mcp.NewTool("permissive",
+		mcp.WithString("name", mcp.Required()),
+	)
+	srv.AddTool(tool, okHandler)
+
+	resp := callTool(t, srv, "permissive", map[string]any{
+		"name":  "alice",
+		"extra": "field",
+	})
+	requireToolSuccess(t, resp)
+}
+
+// TestInputSchemaValidation_BrokenSchemaIsNoOp guards against a malformed
+// schema accidentally blocking every call to that tool. A schema that fails
+// to compile should be silently skipped (and the handler invoked normally),
+// not surfaced as a permanent validation error to the model.
+func TestInputSchemaValidation_BrokenSchemaIsNoOp(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	tool := mcp.Tool{
+		Name:           "broken",
+		Description:    "Tool with malformed schema",
+		RawInputSchema: json.RawMessage(`{"type": "object", "properties": {`), // unterminated JSON
+	}
+	srv.AddTool(tool, okHandler)
+
+	resp := callTool(t, srv, "broken", map[string]any{"anything": true})
+	requireToolSuccess(t, resp)
+}
+
+// TestInputSchemaValidation_RawInputSchema verifies that schemas supplied via
+// RawInputSchema (the alternative to the structured InputSchema) participate
+// in validation just like structured ones.
+func TestInputSchemaValidation_RawInputSchema(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	tool := mcp.Tool{
+		Name:        "raw",
+		Description: "Tool with raw JSON Schema",
+		RawInputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"name": {"type": "string"}
+			},
+			"required": ["name"],
+			"additionalProperties": false
+		}`),
+	}
+	srv.AddTool(tool, okHandler)
+
+	resp := callTool(t, srv, "raw", map[string]any{"name": "alice", "typo": 1})
+	requireToolErrorContaining(t, resp, "typo")
+}
+
+// TestInputSchemaValidation_ReusesCompiledSchema is a behavioural test that
+// confirms repeated calls reuse the cached compiled schema rather than
+// recompiling on every invocation. We can't observe compile counts directly,
+// so instead we re-register the tool with a different schema and check that
+// the new schema is honoured on the next call.
+func TestInputSchemaValidation_RecompilesOnSchemaChange(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	srv.AddTool(fakeListTool(), okHandler)
+
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": "pods",
+		"cursor":       "abc",
+	})
+	requireToolErrorContaining(t, resp, "cursor")
+
+	relaxed := mcp.NewTool("kubernetes_list",
+		mcp.WithDescription("List Kubernetes resources"),
+		mcp.WithString("resourceType", mcp.Required()),
+		mcp.WithString("continue"),
+	)
+	srv.AddTool(relaxed, okHandler)
+
+	resp = callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": "pods",
+		"cursor":       "abc",
+	})
+	requireToolSuccess(t, resp)
+}
+
+// TestInputSchemaValidation_DeleteToolInvalidatesCache makes sure deleting
+// and re-adding a tool doesn't reuse the stale validator. We rely on the
+// content-hash check in the cache, but DeleteTools also drops the entry as a
+// belt-and-braces measure.
+func TestInputSchemaValidation_DeleteToolInvalidatesCache(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	srv.AddTool(fakeListTool(), okHandler)
+
+	srv.DeleteTools("kubernetes_list")
+	require.Len(t, srv.inputValidator.cached, 0, "expected cache to be empty after DeleteTools")
+}
+
+// TestInputSchemaValidation_NoSchemaSkipsValidation covers tools that declare
+// no input schema at all (effectively a tool that accepts no arguments). The
+// validator should treat absence of a schema as "nothing to validate" and let
+// the call through.
+func TestInputSchemaValidation_NoSchemaSkipsValidation(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	tool := mcp.Tool{Name: "noschema", Description: "no schema"}
+	srv.AddTool(tool, okHandler)
+
+	resp := callTool(t, srv, "noschema", map[string]any{"anything": "goes"})
+	requireToolSuccess(t, resp)
+}
+
+// TestInputSchemaValidation_NestedPathInError ensures the JSON pointer path
+// in the error message reaches into nested objects, so the model can
+// localise the failing field.
+func TestInputSchemaValidation_NestedPathInError(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	tool := mcp.Tool{
+		Name: "nested",
+		RawInputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"filter": {
+					"type": "object",
+					"properties": {
+						"label": {"type": "string"}
+					},
+					"required": ["label"],
+					"additionalProperties": false
+				}
+			},
+			"required": ["filter"]
+		}`),
+	}
+	srv.AddTool(tool, okHandler)
+
+	resp := callTool(t, srv, "nested", map[string]any{
+		"filter": map[string]any{"label": "x", "extra": true},
+	})
+	jr, ok := resp.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+	result, ok := jr.Result.(*mcp.CallToolResult)
+	require.True(t, ok)
+	require.True(t, result.IsError)
+	tc := result.Content[0].(mcp.TextContent)
+	require.True(t, strings.Contains(tc.Text, "/filter") || strings.Contains(tc.Text, "filter"),
+		"error message should reference the nested path: %s", tc.Text)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -214,6 +214,7 @@ type MCPServer struct {
 	maxConcurrentTasks         *int                 // Optional limit on concurrent running tasks
 	activeTasks                int                  // Current count of running (non-terminal) tasks
 	inflightCancels            sync.Map             // Maps request ID -> context.CancelFunc for in-flight requests
+	inputValidator             *inputSchemaValidator
 }
 
 // WithPaginationLimit sets the pagination limit for the server.
@@ -385,6 +386,30 @@ func WithRecovery() ServerOption {
 			return next(ctx, request)
 		}
 	})
+}
+
+// WithInputSchemaValidation enables server-side validation of tool call
+// arguments against each tool's declared inputSchema. When validation fails
+// the server returns a tool execution error result (CallToolResult with
+// IsError: true) per [SEP-1303] so that the language model receives the
+// failure details in its context window and can self-correct (for example,
+// when it sends an unknown parameter name).
+//
+// Validation is opt-in to preserve backwards compatibility with servers whose
+// hand-written schemas may not perfectly describe the arguments their handlers
+// actually accept. Enabling it is recommended for new servers and for any
+// server whose schemas are accurate.
+//
+// Tools whose input schemas cannot be compiled (malformed JSON Schema) are
+// silently skipped, so a single broken schema cannot block tool calls.
+//
+// [SEP-1303]: https://modelcontextprotocol.io/seps/1303-input-validation-errors-as-tool-execution-errors
+func WithInputSchemaValidation() ServerOption {
+	return func(s *MCPServer) {
+		if s.inputValidator == nil {
+			s.inputValidator = newInputSchemaValidator()
+		}
+	}
 }
 
 // WithHooks allows adding hooks that will be called before or after
@@ -837,6 +862,7 @@ func (s *MCPServer) SetTools(tools ...ServerTool) {
 	s.toolsMu.Lock()
 	s.tools = make(map[string]ServerTool, len(tools))
 	s.toolsMu.Unlock()
+	s.inputValidator.invalidateAll()
 	s.AddTools(tools...)
 }
 
@@ -875,6 +901,10 @@ func (s *MCPServer) DeleteTools(names ...string) {
 		}
 	}
 	s.toolsMu.Unlock()
+
+	// Drop any cached compiled input schemas for the removed tools so a tool
+	// re-added later under the same name does not reuse a stale compilation.
+	s.inputValidator.invalidate(names...)
 
 	// When the list of available tools changes, servers that declared the listChanged capability SHOULD send a notification.
 	if exists && s.capabilities.tools != nil && s.capabilities.tools.listChanged {
@@ -1635,6 +1665,16 @@ func (s *MCPServer) handleToolCall(
 		}
 	}
 
+	// Validate the incoming arguments against the tool's input schema, when
+	// schema validation has been enabled via WithInputSchemaValidation. A
+	// validation failure is returned as a SEP-1303 tool execution error so the
+	// model receives feedback in its context window and can self-correct.
+	if s.inputValidator != nil {
+		if _, err := s.inputValidator.validate(tool.Tool, request.Params.Arguments); err != nil {
+			return validationToolResult(err), nil
+		}
+	}
+
 	finalHandler := tool.Handler
 
 	s.toolMiddlewareMu.RLock()
@@ -1701,6 +1741,11 @@ func (s *MCPServer) handleTaskAugmentedToolCall(
 			err:  fmt.Errorf("tool '%s' not found", request.Params.Name),
 		}
 	}
+
+	// Note: input schema validation (WithInputSchemaValidation) is currently
+	// only applied on the synchronous tool call path. The task-augmented path
+	// would need to surface validation failures through tasks/result rather
+	// than the create-task response; that's deferred to a follow-up.
 
 	// Generate task ID (UUID v4)
 	taskID := uuid.New().String()


### PR DESCRIPTION
## Description

Adds an opt-in `WithInputSchemaValidation()` server option. When enabled, `tools/call` arguments are validated against each tool's declared `inputSchema` before the handler runs, and validation failures are returned as tool execution errors (`CallToolResult{IsError: true}`) per [SEP-1303] — so the language model receives the validation message in its context window and can self-correct.

Fixes #833

### Why

mcp-go does not validate tool call arguments today. The most common consequence is the silent-typo failure pattern that motivated SEP-1303:

1. A tool declares a `continue` parameter (a paginated-list token).
2. An LLM client sends `cursor` instead (a common MCP pagination convention).
3. mcp-go passes the args straight to the handler, which reads only the keys it knows about. `cursor` is silently dropped.
4. The handler returns the same first page of results as before. The model believes pagination is broken and gets stuck in a loop, never receiving the feedback it needs to retry with the correct parameter name.

Even when a tool author opts into strict validation by setting `mcp.WithSchemaAdditionalProperties(false)` (added in #672), the server ignores it at runtime today. The official `modelcontextprotocol/go-sdk` does validate inputs against the schema before invoking the handler. mcp-go now offers the same, opt-in.

### Design choices

- **Opt-in via `WithInputSchemaValidation()`.** Existing servers may have hand-written schemas that don't perfectly describe their handlers' inputs. Strict-by-default would silently break them. New servers and accurate-schema servers should turn it on.
- **SEP-1303 compliant.** Validation failures return `CallToolResult{IsError: true}` (a successful JSON-RPC response carrying a tool execution error), not `-32602` protocol errors.
- **Validation runs after tool lookup, before middlewares.** Existing middlewares (logging, metrics, recovery) only see validated requests; rejected calls do not reach the handler.
- **Compile once, cache per tool.** Schemas are compiled lazily on first call and cached. The cache is invalidated when the schema content changes (content-hash check), and when `DeleteTools` / `SetTools` runs.
- **Broken schemas degrade gracefully.** A schema that fails to compile is silently skipped so a single malformed schema cannot block tool calls.
- **Error messages reference the failing field by JSON Pointer path** so the model can localise the problem, including in nested objects.
- **No new public surface beyond the option** and the dependency.

### Dependency

Adds `github.com/santhosh-tekuri/jsonschema/v6` — the de-facto Go JSON Schema validator. Pure Go, no cgo, draft 2020-12 support, widely used (~1k stars, used by k6, hashicorp packer, kubernetes-sigs/cluster-api, etc.).

### Out of scope (follow-up)

- Validation in the `tasks/call` (task-augmented) execution path. The synchronous path covers the vast majority of clients and the task path needs different surfacing semantics. Left for a follow-up; commented in the code.
- Output schema validation. Tracked separately in #811.

### Tests

12 new tests in `server/input_validation_test.go`:

- `TestInputSchemaValidation_DisabledByDefault` — pins the current behavior so we never accidentally make validation strict-by-default
- `TestInputSchemaValidation_RejectsUnknownProperty` — the literal motivating scenario: `kubernetes_list`-shaped tool with `continue` + `additionalProperties: false`, model sends `cursor`, server returns a tool execution error mentioning `cursor`
- `TestInputSchemaValidation_RejectsMissingRequired` — missing required arg becomes a tool execution error
- `TestInputSchemaValidation_RejectsWrongType` — type mismatch becomes a tool execution error
- `TestInputSchemaValidation_AcceptsValidCall` — happy path still reaches the handler
- `TestInputSchemaValidation_AllowsAdditionalWhenSchemaPermits` — schemas without `additionalProperties: false` continue to accept extras
- `TestInputSchemaValidation_BrokenSchemaIsNoOp` — malformed schema does not block calls
- `TestInputSchemaValidation_RawInputSchema` — `RawInputSchema` participates in validation
- `TestInputSchemaValidation_RecompilesOnSchemaChange` — re-registering a tool with a different schema honors the new schema
- `TestInputSchemaValidation_DeleteToolInvalidatesCache` — cache cleanup
- `TestInputSchemaValidation_NoSchemaSkipsValidation` — tools with no schema are unaffected
- `TestInputSchemaValidation_NestedPathInError` — error message localises nested fields

```
go test ./server/ -run TestInputSchemaValidation -count=1 -v
  → 12 tests, all PASS

go test ./... -count=1
  → e2e PASS, mcp PASS, mcptest PASS, server PASS — no regressions

golangci-lint run ./server/...
  → 0 issues
```

[SEP-1303]: https://modelcontextprotocol.io/seps/1303-input-validation-errors-as-tool-execution-errors

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly (godoc on the new option)

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [SEP-1303 Input Validation Errors as Tool Execution Errors](https://modelcontextprotocol.io/seps/1303-input-validation-errors-as-tool-execution-errors)
- [x] Implementation follows the specification exactly

## Additional Information

The feature is opt-in to preserve back-compat. Sample usage:

```go
srv := server.NewMCPServer("example", "1.0.0",
    server.WithInputSchemaValidation(),
)
srv.AddTool(
    mcp.NewTool("kubernetes_list",
        mcp.WithString("resourceType", mcp.Required()),
        mcp.WithString("continue"),
        mcp.WithSchemaAdditionalProperties(false),
    ),
    handleListResources,
)
```

With validation enabled and `additionalProperties: false`, a call with an unknown `cursor` parameter returns a tool execution error like:

```
input schema validation failed: <root>: additional properties 'cursor' not allowed
```

— which is exactly the feedback the model needs to retry with `continue`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional input schema validation for MCP tool calls — validates incoming tool arguments against declared JSON Schemas and returns structured validation errors when inputs don't match.

* **Tests**
  * Added comprehensive tests covering validation outcomes, error message formatting, cache behavior, and various schema scenarios (including malformed and missing schemas).

* **Chores**
  * Updated module dependencies to support schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->