### PR TITLE
fix(examples): return isError for input validation instead of internal error

### DIFF
--- a/examples/everything/main.go
+++ b/examples/everything/main.go
@@ -356,7 +356,7 @@ func handleEchoTool(
 	arguments := request.GetArguments()
 	message, ok := arguments["message"].(string)
 	if !ok {
-		return nil, fmt.Errorf("invalid message argument")
+		return mcp.NewToolResultError("invalid message argument: expected string"), nil
 	}
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -376,7 +376,7 @@ func handleAddTool(
 	a, ok1 := arguments["a"].(float64)
 	b, ok2 := arguments["b"].(float64)
 	if !ok1 || !ok2 {
-		return nil, fmt.Errorf("invalid number arguments")
+		return mcp.NewToolResultError("invalid number arguments: expected numeric values for 'a' and 'b'"), nil
 	}
 	sum := a + b
 	return &mcp.CallToolResult{


### PR DESCRIPTION
## Summary

The everything server's `echo` and `add` tool handlers return `(nil, fmt.Errorf(...))` for input validation failures (wrong type, missing argument). In the SDK, this produces `-32603` (InternalError), which agents cannot distinguish from a server crash.

Changed to `mcp.NewToolResultError(...), nil` which returns `isError: true` with a descriptive message the agent can act on.

## Before / After

| Input | Before | After |
|-------|--------|-------|
| `echo` with `{"message": 42}` | `-32603` "invalid message argument" | `isError: true` "invalid message argument: expected string" |
| `echo` with `{}` | `-32603` "invalid message argument" | `isError: true` "invalid message argument: expected string" |
| `add` with `{"a": "x", "b": 2}` | `-32603` "invalid number arguments" | `isError: true` "invalid number arguments: expected numeric values" |

## Why this matters

The everything server is the reference example. Developers learning from it copy the `return nil, fmt.Errorf(...)` pattern. The SDK's own `NewTypedToolHandler` (typed_tools.go:19) and `NewStructuredToolHandler` (typed_tools.go:32) already use `NewToolResultError` for argument binding failures, but the untyped example teaches the opposite.

Internal errors (notification send failures at lines 408, 446) are unchanged since those represent actual server-side failures.

## Test plan

- [x] `go build ./examples/everything/` passes
- [x] `go test ./... -short` passes (all packages)
- [x] Verified via raw JSON-RPC: wrong types now return `isError: true` instead of `-32603`

Fixes #837

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for tool input validation to provide structured error messages instead of generic errors. When tools receive invalid inputs such as incorrect data types, users now get clear, consistent error feedback that better describes the validation issues encountered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->