### PR TITLE
fix(transport): stop retrying on session terminated in listenForever

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -914,6 +914,13 @@ func (c *StreamableHTTP) listenForever(ctx context.Context) {
 			c.logger.Errorf("server does not support listening")
 			return
 		}
+		if errors.Is(err, ErrSessionTerminated) {
+			// Server returned 404: the session no longer exists (server restarted
+			// or session expired). Retrying is pointless because the server won't
+			// recognize this session. The caller must re-initialize.
+			c.logger.Errorf("session terminated, stopping listener: %v", err)
+			return
+		}
 
 		select {
 		case <-ctx.Done():

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -893,6 +893,73 @@ func TestContinuousListeningMethodNotAllowed(t *testing.T) {
 	}
 }
 
+func TestContinuousListeningSessionTerminated(t *testing.T) {
+	// Start a server that returns 200 on POST (initialize) but 404 on GET
+	// (simulating a server restart where the session no longer exists).
+	sessionID := "test-session-123"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost {
+			// Handle initialize
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set(HeaderKeySessionID, sessionID)
+			resp := JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      mcp.NewRequestId(int64(0)),
+				Result:  json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"test"}}`),
+			}
+			json.NewEncoder(w).Encode(resp)
+			return
+		}
+		if r.Method == http.MethodGet {
+			// Simulate session terminated: server restarted, session gone
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+	}))
+	defer server.Close()
+
+	// Setup logger to capture log messages
+	logChan := make(chan string, 10)
+	testLogger := &testLogger{logChan: logChan}
+
+	// Create transport with continuous listening enabled
+	trans, err := NewStreamableHTTP(server.URL, WithContinuousListening(), WithLogger(testLogger))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer trans.Close()
+
+	// Start the transport
+	if err := trans.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initialize
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	initRequest := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(0)),
+		Method:  "initialize",
+	}
+	_, err = trans.SendRequest(ctx, initRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the error log message that session was terminated.
+	// Before the fix, this would retry forever and never produce this message.
+	select {
+	case logMsg := <-logChan:
+		if !strings.Contains(logMsg, "session terminated") {
+			t.Errorf("Expected error log about session terminated, got: %s", logMsg)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Timeout waiting for session terminated log; listenForever did not stop retrying")
+	}
+}
+
 // testLogger is a simple logger for testing
 type testLogger struct {
 	logChan chan string

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -894,9 +895,15 @@ func TestContinuousListeningMethodNotAllowed(t *testing.T) {
 }
 
 func TestContinuousListeningSessionTerminated(t *testing.T) {
+	// Use a short retry interval so we can verify no retries happen quickly.
+	origRetryInterval := retryInterval
+	retryInterval = 20 * time.Millisecond
+	t.Cleanup(func() { retryInterval = origRetryInterval })
+
 	// Start a server that returns 200 on POST (initialize) but 404 on GET
 	// (simulating a server restart where the session no longer exists).
 	sessionID := "test-session-123"
+	var getCalls int64
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method == http.MethodPost {
 			// Handle initialize
@@ -911,6 +918,7 @@ func TestContinuousListeningSessionTerminated(t *testing.T) {
 			return
 		}
 		if r.Method == http.MethodGet {
+			atomic.AddInt64(&getCalls, 1)
 			// Simulate session terminated: server restarted, session gone
 			w.WriteHeader(http.StatusNotFound)
 			return
@@ -949,7 +957,6 @@ func TestContinuousListeningSessionTerminated(t *testing.T) {
 	}
 
 	// Wait for the error log message that session was terminated.
-	// Before the fix, this would retry forever and never produce this message.
 	select {
 	case logMsg := <-logChan:
 		if !strings.Contains(logMsg, "session terminated") {
@@ -957,6 +964,13 @@ func TestContinuousListeningSessionTerminated(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("Timeout waiting for session terminated log; listenForever did not stop retrying")
+	}
+
+	// Verify no further retries: wait several retry intervals and check GET count.
+	time.Sleep(5 * retryInterval)
+	calls := atomic.LoadInt64(&getCalls)
+	if calls != 1 {
+		t.Errorf("Expected exactly 1 GET attempt, got %d (listener retried after session termination)", calls)
 	}
 }
 

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -907,7 +907,7 @@ func TestContinuousListeningSessionTerminated(t *testing.T) {
 				ID:      mcp.NewRequestId(int64(0)),
 				Result:  json.RawMessage(`{"protocolVersion":"2025-03-26","capabilities":{},"serverInfo":{"name":"test"}}`),
 			}
-			json.NewEncoder(w).Encode(resp)
+			_ = json.NewEncoder(w).Encode(resp)
 			return
 		}
 		if r.Method == http.MethodGet {


### PR DESCRIPTION
## Summary

- `listenForever()` now stops retrying when the server returns 404 (session terminated)
- Adds `errors.Is(err, ErrSessionTerminated)` check, matching the existing `ErrGetMethodNotAllowed` pattern
- Adds `TestContinuousListeningSessionTerminated` test

## Problem

`StreamableHTTP` clients using `WithContinuousListening()` cannot recover when the backend server restarts. The GET listener retries every 1 second indefinitely because `listenForever()` only breaks on `ErrGetMethodNotAllowed`, not `ErrSessionTerminated`.

When the server restarts with a new session, 404 means "this session doesn't exist anymore." Retrying is pointless; the caller must re-initialize.

## Test plan

- [x] New test: `TestContinuousListeningSessionTerminated` (mock server returns 404 on GET)
- [x] Existing test suite passes (`go test ./client/transport/` all green)

Fixes #836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Detects server-side session termination and immediately stops continuous retry attempts, preventing endless retry loops and reducing spurious logs and network traffic.
* **Tests**
  * Added a regression test that verifies the listener stops and logs a session-terminated event when the server signals session expiry, ensuring future changes don't reintroduce retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->