### PR TITLE
feat(transport): add CommandTransport for subprocess MCP servers

### DIFF
--- a/client/stdio.go
+++ b/client/stdio.go
@@ -46,13 +46,17 @@ func NewStdioMCPClientWithOptions(
 
 // GetStderr returns a reader for the stderr output of the subprocess.
 // This can be used to capture error messages or logs from the subprocess.
+//
+// It works with any transport that exposes a Stderr() io.Reader method,
+// including *transport.Stdio and *transport.CommandTransport.
 func GetStderr(c *Client) (io.Reader, bool) {
 	t := c.GetTransport()
 
-	stdio, ok := t.(*transport.Stdio)
-	if !ok {
-		return nil, false
+	type stderrer interface {
+		Stderr() io.Reader
 	}
-
-	return stdio.Stderr(), true
+	if s, ok := t.(stderrer); ok {
+		return s.Stderr(), true
+	}
+	return nil, false
 }

--- a/client/transport/command.go
+++ b/client/transport/command.go
@@ -1,0 +1,44 @@
+package transport
+
+// CommandTransport spawns a subprocess and communicates with it over its
+// stdin/stdout streams using JSON-RPC messages.
+//
+// CommandTransport is a thin, convenience wrapper around the Stdio transport
+// that makes the subprocess use case explicit and self-documenting. The
+// underlying behavior is identical to NewStdio: any options, methods, or
+// guarantees provided by Stdio are available here via embedding.
+//
+// Use CommandTransport when you want to launch an MCP server as a child
+// process. Use Stdio (e.g. via NewIO) when you want to attach to existing
+// streams.
+type CommandTransport struct {
+	*Stdio
+}
+
+// NewCommand creates a transport that spawns the given command as a subprocess
+// and communicates with it over stdin/stdout. The current process's
+// environment is inherited by the child.
+//
+// This is equivalent to calling NewStdio(command, nil, args...) but expresses
+// the subprocess intent more clearly.
+func NewCommand(command string, args ...string) *CommandTransport {
+	return &CommandTransport{Stdio: NewStdio(command, nil, args...)}
+}
+
+// NewCommandWithEnv creates a transport that spawns the given command as a
+// subprocess with additional environment variables appended to the parent
+// process's environment. Each entry in env must be of the form "KEY=VALUE".
+//
+// This is equivalent to calling NewStdio(command, env, args...).
+func NewCommandWithEnv(command string, env []string, args ...string) *CommandTransport {
+	return &CommandTransport{Stdio: NewStdio(command, env, args...)}
+}
+
+// NewCommandWithOptions creates a transport that spawns the given command as a
+// subprocess and applies the provided StdioOptions (for example
+// WithCommandFunc or WithCommandLogger) before the subprocess is started.
+//
+// This is equivalent to calling NewStdioWithOptions(command, env, args, opts...).
+func NewCommandWithOptions(command string, env []string, args []string, opts ...StdioOption) *CommandTransport {
+	return &CommandTransport{Stdio: NewStdioWithOptions(command, env, args, opts...)}
+}

--- a/client/transport/command_test.go
+++ b/client/transport/command_test.go
@@ -1,0 +1,139 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommandTransport_Constructors verifies that CommandTransport constructors
+// produce a transport with the expected wrapped Stdio configuration without
+// actually spawning the subprocess.
+func TestCommandTransport_Constructors(t *testing.T) {
+	t.Run("NewCommand_NoEnv", func(t *testing.T) {
+		ct := NewCommand("my-server", "--flag", "value")
+		require.NotNil(t, ct)
+		require.NotNil(t, ct.Stdio)
+		assert.Equal(t, "my-server", ct.command)
+		assert.Equal(t, []string{"--flag", "value"}, ct.args)
+		assert.Nil(t, ct.env)
+	})
+
+	t.Run("NewCommand_NoArgs", func(t *testing.T) {
+		ct := NewCommand("my-server")
+		require.NotNil(t, ct)
+		assert.Equal(t, "my-server", ct.command)
+		assert.Empty(t, ct.args)
+	})
+
+	t.Run("NewCommandWithEnv", func(t *testing.T) {
+		env := []string{"API_KEY=secret", "DEBUG=1"}
+		ct := NewCommandWithEnv("my-server", env, "--port", "8080")
+		require.NotNil(t, ct)
+		assert.Equal(t, "my-server", ct.command)
+		assert.Equal(t, []string{"--port", "8080"}, ct.args)
+		assert.Equal(t, env, ct.env)
+	})
+
+	t.Run("NewCommandWithOptions_AppliesOptions", func(t *testing.T) {
+		var optApplied bool
+		opt := func(s *Stdio) {
+			optApplied = true
+		}
+		ct := NewCommandWithOptions("echo", nil, []string{"hi"}, opt)
+		require.NotNil(t, ct)
+		assert.True(t, optApplied)
+	})
+}
+
+// TestCommandTransport_ImplementsInterface verifies that *CommandTransport
+// satisfies the transport Interface used by the client.
+func TestCommandTransport_ImplementsInterface(t *testing.T) {
+	var _ Interface = (*CommandTransport)(nil)
+}
+
+// TestCommandTransport_StderrAccessor verifies that Stderr() is reachable
+// via the embedded Stdio after the subprocess has been spawned.
+func TestCommandTransport_StderrAccessor(t *testing.T) {
+	ctx := t.Context()
+
+	ct := NewCommand("echo", "hello")
+	require.NotNil(t, ct)
+
+	require.NoError(t, ct.spawnCommand(ctx))
+	t.Cleanup(func() {
+		_ = ct.cmd.Process.Kill()
+	})
+
+	require.Equal(t, "echo", filepath.Base(ct.cmd.Path))
+	require.Contains(t, ct.cmd.Args, "hello")
+	require.NotNil(t, ct.Stderr())
+}
+
+// TestCommandTransport_EndToEnd exercises the full request/response loop
+// against the mock stdio server, ensuring the wrapper integrates correctly
+// with the underlying Stdio implementation.
+func TestCommandTransport_EndToEnd(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
+	require.NoError(t, err)
+	tempFile.Close()
+	mockServerPath := tempFile.Name() + ".exe"
+
+	require.NoError(t, compileTestServer(mockServerPath))
+
+	ct := NewCommand(mockServerPath)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, ct.Start(ctx))
+	defer ct.Close()
+
+	request := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "debug/echo",
+		Params: map[string]any{
+			"string": "hello world",
+		},
+	}
+
+	response, err := ct.SendRequest(ctx, request)
+	require.NoError(t, err)
+
+	var result struct {
+		JSONRPC string         `json:"jsonrpc"`
+		ID      mcp.RequestId  `json:"id"`
+		Method  string         `json:"method"`
+		Params  map[string]any `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal(response.Result, &result))
+
+	assert.Equal(t, "2.0", result.JSONRPC)
+	assert.Equal(t, "debug/echo", result.Method)
+	assert.Equal(t, "hello world", result.Params["string"])
+}
+
+// TestCommandTransport_WithEnv verifies that NewCommandWithEnv propagates the
+// provided environment variables to the spawned subprocess in addition to the
+// inherited parent environment.
+func TestCommandTransport_WithEnv(t *testing.T) {
+	ctx := t.Context()
+	t.Setenv("PARENT_ENV_VAR", "parent")
+
+	ct := NewCommandWithEnv("echo", []string{"CHILD_ENV_VAR=child"}, "hi")
+	require.NoError(t, ct.spawnCommand(ctx))
+	t.Cleanup(func() {
+		_ = ct.cmd.Process.Kill()
+	})
+
+	assert.Contains(t, ct.cmd.Env, "PARENT_ENV_VAR=parent")
+	assert.Contains(t, ct.cmd.Env, "CHILD_ENV_VAR=child")
+}


### PR DESCRIPTION
## Description

Adds a first-class `CommandTransport` to `client/transport/` that wraps the existing `Stdio` transport with a clearer, self-documenting API for spawning MCP servers as subprocesses. The intent — "spawn this command and talk to it over stdin/stdout" — is now expressed directly in the type name, instead of being hidden behind `NewStdio` (whose name suggests attaching to existing streams) or `WithCommandFunc`.

`CommandTransport` embeds `*Stdio`, so all existing options, methods, and behavior (including `WithCommandFunc`, `WithCommandLogger`, `Stderr()`, etc.) continue to work unchanged. The existing `Stdio` API is fully preserved — this is purely additive.

```go
// Before
t := transport.NewStdio("my-mcp-server", nil, "--flag")

// After (same behavior, clearer intent)
t := transport.NewCommand("my-mcp-server", "--flag")

// With env vars
t := transport.NewCommandWithEnv("my-mcp-server",
    []string{"API_KEY=secret"},
    "--port", "8080",
)

// With Stdio options (e.g. custom CommandFunc / logger)
t := transport.NewCommandWithOptions("my-mcp-server", nil, []string{"--flag"},
    transport.WithCommandLogger(myLogger),
)
```

As a small follow-on, `client.GetStderr` was generalized from a hard `*transport.Stdio` type assertion to a tiny `Stderr() io.Reader` interface check, so it transparently supports `*CommandTransport` (and any future transport that exposes stderr) without further changes.

Fixes #816

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

Notes:

- All exported types/functions have godoc comments per project conventions.
- `go test ./... -race` passes locally.
- `golangci-lint run ./client/...` reports 0 issues.
- Documentation here means godoc on the new public API; no separate docs site changes are needed.

## Additional Information

**What's added**

- `client/transport/command.go`
  - `CommandTransport` struct embedding `*Stdio`
  - `NewCommand(command string, args ...string) *CommandTransport`
  - `NewCommandWithEnv(command string, env []string, args ...string) *CommandTransport`
  - `NewCommandWithOptions(command string, env []string, args []string, opts ...StdioOption) *CommandTransport`
- `client/transport/command_test.go`
  - Constructor field-propagation tests
  - Compile-time `Interface` conformance check
  - `Stderr()` accessor test
  - End-to-end request/response test against the existing mock stdio server
  - Env-merging test (parent env + extra env vars)

**What's modified**

- `client/stdio.go` — `GetStderr` now uses a structural `Stderr() io.Reader` interface check instead of asserting `*transport.Stdio`, so it works for any subprocess-based transport (including the new `CommandTransport`). Behavior is unchanged for existing callers.

**Backward compatibility**

- No existing API is changed or removed.
- `Stdio`, `NewStdio`, `NewStdioWithOptions`, `WithCommandFunc`, and `WithCommandLogger` are all untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added command-based transport support with enhanced constructor options for subprocess execution, including environment variable configuration and customizable startup options.
* **Tests**
  * Added comprehensive test coverage for command transport functionality, including constructor validation and end-to-end request/response flow verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->