### PR TITLE
feat(server): add OAuth Protected Resource Metadata endpoint (RFC 9728)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ MCP Go handles all the complex protocol details and server management, so you ca
 - [Examples](#examples)
 - [Extras](#extras)
   - [Transports](#transports)
+  - [OAuth Protected Resource Metadata](#oauth-protected-resource-metadata)
   - [Session Management](#session-management)
     - [Basic Session Handling](#basic-session-handling)
     - [Per-Session Tools](#per-session-tools)
@@ -655,6 +656,27 @@ Key examples include:
 ### Transports
 
 MCP-Go supports stdio, SSE and streamable-HTTP transport layers. For SSE transport, you can use `SetConnectionLostHandler()` to detect and handle disconnections for implementing reconnection logic.
+
+### OAuth Protected Resource Metadata
+
+Servers that require OAuth can advertise their authorization requirements
+via the [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)
+`/.well-known/oauth-protected-resource` endpoint referenced by the
+[MCP authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization).
+Use `server.WithProtectedResourceMetadata` (or
+`server.WithSSEProtectedResourceMetadata`) to auto-mount the endpoint, or
+`server.NewProtectedResourceMetadataHandler` to wire it into a custom router.
+See the [HTTP transport docs](https://mcp-go.dev/transports/http#oauth-protected-resource-metadata-rfc-9728) for examples.
+
+```go
+httpServer := server.NewStreamableHTTPServer(mcpServer,
+    server.WithProtectedResourceMetadata(server.ProtectedResourceMetadataConfig{
+        Resource:             "https://my-mcp-server.com",
+        AuthorizationServers: []string{"https://auth.example.com"},
+        ScopesSupported:      []string{"mcp:read", "mcp:write"},
+    }),
+)
+```
 
 ### Session Management
 

--- a/server/protected_resource.go
+++ b/server/protected_resource.go
@@ -1,0 +1,173 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+)
+
+// WellKnownProtectedResourcePath is the base well-known URL path for
+// OAuth 2.0 Protected Resource Metadata as defined in RFC 9728.
+const WellKnownProtectedResourcePath = "/.well-known/oauth-protected-resource"
+
+// ProtectedResourceMetadataConfig holds OAuth 2.0 Protected Resource Metadata
+// as defined in RFC 9728 (https://datatracker.ietf.org/doc/html/rfc9728).
+//
+// The MCP authorization spec
+// (https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+// references this metadata for server discovery: clients fetch it from
+// /.well-known/oauth-protected-resource to learn which authorization servers,
+// scopes, and bearer methods the resource supports.
+//
+// Resource is REQUIRED. AuthorizationServers is RECOMMENDED. All other fields
+// are optional and will be omitted from the JSON response when empty.
+type ProtectedResourceMetadataConfig struct {
+	// Resource is the protected resource's identifier URI. Required.
+	Resource string `json:"resource"`
+
+	// AuthorizationServers lists the OAuth authorization server issuer
+	// identifiers that may be used to obtain access tokens for this resource.
+	AuthorizationServers []string `json:"authorization_servers,omitempty"`
+
+	// ScopesSupported lists OAuth scope values used in authorization requests
+	// to access this resource.
+	ScopesSupported []string `json:"scopes_supported,omitempty"`
+
+	// BearerMethodsSupported lists supported methods for presenting an OAuth
+	// 2.0 bearer token to the resource (e.g. "header", "body", "query").
+	BearerMethodsSupported []string `json:"bearer_methods_supported,omitempty"`
+
+	// ResourceName is a human-readable name for the protected resource.
+	ResourceName string `json:"resource_name,omitempty"`
+
+	// ResourceDocumentation is a URL of human-readable documentation for
+	// developers using this resource.
+	ResourceDocumentation string `json:"resource_documentation,omitempty"`
+
+	// ResourcePolicyURI is a URL of the resource's privacy policy.
+	ResourcePolicyURI string `json:"resource_policy_uri,omitempty"`
+
+	// ResourceTosURI is a URL of the resource's terms of service.
+	ResourceTosURI string `json:"resource_tos_uri,omitempty"`
+
+	// JWKSURI is the URL of the resource's JWK Set document used to validate
+	// signed responses from the resource.
+	JWKSURI string `json:"jwks_uri,omitempty"`
+
+	// ResourceSigningAlgValuesSupported lists JWS algorithms supported for
+	// signing resource responses.
+	ResourceSigningAlgValuesSupported []string `json:"resource_signing_alg_values_supported,omitempty"`
+
+	// TLSClientCertificateBoundAccessTokens indicates support for mTLS-bound
+	// access tokens (RFC 8705). Pointer so that "false" can be expressed
+	// explicitly and "unset" omits the field.
+	TLSClientCertificateBoundAccessTokens *bool `json:"tls_client_certificate_bound_access_tokens,omitempty"`
+
+	// AuthorizationDetailsTypesSupported lists supported authorization_details
+	// type values (RFC 9396).
+	AuthorizationDetailsTypesSupported []string `json:"authorization_details_types_supported,omitempty"`
+
+	// DPoPSigningAlgValuesSupported lists JWS algorithms supported for DPoP
+	// proof JWTs.
+	DPoPSigningAlgValuesSupported []string `json:"dpop_signing_alg_values_supported,omitempty"`
+
+	// DPoPBoundAccessTokensRequired indicates whether DPoP-bound tokens are
+	// required by this resource. Pointer so "false" can be encoded explicitly.
+	DPoPBoundAccessTokensRequired *bool `json:"dpop_bound_access_tokens_required,omitempty"`
+}
+
+// ProtectedResourceMetadataPath returns the well-known URL path that should
+// serve Protected Resource Metadata for the given resource identifier per
+// RFC 9728 §3.1.
+//
+// For a resource with no path component (e.g. "https://mcp.example.com" or
+// "https://mcp.example.com/") this returns "/.well-known/oauth-protected-resource".
+//
+// For a path-qualified resource (e.g. "https://mcp.example.com/mcp") the
+// resource path is appended after the well-known segment, producing
+// "/.well-known/oauth-protected-resource/mcp".
+//
+// If resource cannot be parsed as a URL, the bare well-known path is returned.
+func ProtectedResourceMetadataPath(resource string) string {
+	if resource == "" {
+		return WellKnownProtectedResourcePath
+	}
+	u, err := url.Parse(resource)
+	if err != nil {
+		return WellKnownProtectedResourcePath
+	}
+	p := strings.Trim(u.Path, "/")
+	if p == "" {
+		return WellKnownProtectedResourcePath
+	}
+	return path.Join(WellKnownProtectedResourcePath, p)
+}
+
+// NewProtectedResourceMetadataHandler returns an http.Handler that serves
+// the given OAuth 2.0 Protected Resource Metadata as JSON.
+//
+// The handler responds with:
+//   - 200 OK and the metadata JSON for GET requests.
+//   - 204 No Content for OPTIONS (CORS preflight).
+//   - 405 Method Not Allowed (with Allow header) for any other method.
+//
+// Permissive CORS headers (Access-Control-Allow-Origin: *) are included so
+// browser-based MCP clients can discover the resource cross-origin, and
+// Cache-Control: no-store is set per the MCP authorization spec guidance to
+// avoid stale metadata during rotation.
+//
+// Use this handler directly for custom routing setups:
+//
+//	mux := http.NewServeMux()
+//	mux.Handle("/mcp", mcpHandler)
+//	mux.Handle("/.well-known/oauth-protected-resource",
+//	    server.NewProtectedResourceMetadataHandler(server.ProtectedResourceMetadataConfig{
+//	        Resource:             "https://my-server.com",
+//	        AuthorizationServers: []string{"https://auth.example.com"},
+//	        ScopesSupported:      []string{"mcp:read", "mcp:write"},
+//	    }))
+//
+// For path-qualified resources prefer using ProtectedResourceMetadataPath to
+// derive the correct mount path:
+//
+//	mux.Handle(server.ProtectedResourceMetadataPath(cfg.Resource),
+//	    server.NewProtectedResourceMetadataHandler(cfg))
+func NewProtectedResourceMetadataHandler(config ProtectedResourceMetadataConfig) http.Handler {
+	// Pre-marshal at construction time so each request is just a copy.
+	// This struct only contains JSON-friendly types so Marshal cannot fail
+	// in practice; the lazy fallback below preserves correctness regardless.
+	body, marshalErr := json.Marshal(config)
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
+
+		switch r.Method {
+		case http.MethodOptions:
+			w.WriteHeader(http.StatusNoContent)
+			return
+		case http.MethodGet, http.MethodHead:
+			// proceed below
+		default:
+			w.Header().Set("Allow", "GET, HEAD, OPTIONS")
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		if marshalErr != nil {
+			http.Error(w, "failed to marshal protected resource metadata", http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "no-store")
+		w.WriteHeader(http.StatusOK)
+		if r.Method == http.MethodHead {
+			return
+		}
+		_, _ = w.Write(body)
+	})
+}

--- a/server/protected_resource.go
+++ b/server/protected_resource.go
@@ -89,13 +89,17 @@ type ProtectedResourceMetadataConfig struct {
 // resource path is appended after the well-known segment, producing
 // "/.well-known/oauth-protected-resource/mcp".
 //
-// If resource cannot be parsed as a URL, the bare well-known path is returned.
+// If resource is empty, cannot be parsed as a URL, or is not an absolute URI
+// (i.e. lacks a scheme and host), the bare well-known path is returned. RFC
+// 9728 resource identifiers are absolute URIs, so a bare host like
+// "mcp.example.com" or a path-only value like "/mcp" is not a valid resource
+// and must not contribute a path suffix.
 func ProtectedResourceMetadataPath(resource string) string {
 	if resource == "" {
 		return WellKnownProtectedResourcePath
 	}
 	u, err := url.Parse(resource)
-	if err != nil {
+	if err != nil || !u.IsAbs() || u.Host == "" {
 		return WellKnownProtectedResourcePath
 	}
 	p := strings.Trim(u.Path, "/")

--- a/server/protected_resource.go
+++ b/server/protected_resource.go
@@ -146,7 +146,7 @@ func NewProtectedResourceMetadataHandler(config ProtectedResourceMetadataConfig)
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "*")
-		w.Header().Set("Access-Control-Allow-Methods", "GET, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Methods", "GET, HEAD, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
 		switch r.Method {

--- a/server/protected_resource_test.go
+++ b/server/protected_resource_test.go
@@ -1,0 +1,336 @@
+package server_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func TestProtectedResourceMetadataPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource string
+		want     string
+	}{
+		{
+			name:     "empty resource",
+			resource: "",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "host only",
+			resource: "https://mcp.example.com",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "host with trailing slash",
+			resource: "https://mcp.example.com/",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "single path segment",
+			resource: "https://mcp.example.com/mcp",
+			want:     "/.well-known/oauth-protected-resource/mcp",
+		},
+		{
+			name:     "multi-segment path",
+			resource: "https://mcp.example.com/api/v1/mcp",
+			want:     "/.well-known/oauth-protected-resource/api/v1/mcp",
+		},
+		{
+			name:     "trailing slash on path",
+			resource: "https://mcp.example.com/mcp/",
+			want:     "/.well-known/oauth-protected-resource/mcp",
+		},
+		{
+			name:     "unparseable resource falls back to base path",
+			resource: "://broken",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, server.ProtectedResourceMetadataPath(tt.resource))
+		})
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_GET(t *testing.T) {
+	cfg := server.ProtectedResourceMetadataConfig{
+		Resource:               "https://my-server.example.com",
+		AuthorizationServers:   []string{"https://auth.example.com"},
+		ScopesSupported:        []string{"mcp:read", "mcp:write"},
+		BearerMethodsSupported: []string{"header"},
+		ResourceName:           "My MCP Server",
+		ResourceDocumentation:  "https://docs.example.com",
+		JWKSURI:                "https://my-server.example.com/.well-known/jwks.json",
+	}
+
+	h := server.NewProtectedResourceMetadataHandler(cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
+	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+
+	var got server.ProtectedResourceMetadataConfig
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
+	assert.Equal(t, cfg.Resource, got.Resource)
+	assert.Equal(t, cfg.AuthorizationServers, got.AuthorizationServers)
+	assert.Equal(t, cfg.ScopesSupported, got.ScopesSupported)
+	assert.Equal(t, cfg.BearerMethodsSupported, got.BearerMethodsSupported)
+	assert.Equal(t, cfg.ResourceName, got.ResourceName)
+	assert.Equal(t, cfg.ResourceDocumentation, got.ResourceDocumentation)
+	assert.Equal(t, cfg.JWKSURI, got.JWKSURI)
+}
+
+func TestNewProtectedResourceMetadataHandler_HEAD(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.ProtectedResourceMetadataConfig{
+		Resource: "https://my-server.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodHead, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+	body, _ := io.ReadAll(rec.Body)
+	assert.Empty(t, body, "HEAD response must have no body")
+}
+
+func TestNewProtectedResourceMetadataHandler_OPTIONS(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.ProtectedResourceMetadataConfig{
+		Resource: "https://my-server.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodOptions, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	assert.Equal(t, http.StatusNoContent, rec.Code)
+	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "GET, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+}
+
+func TestNewProtectedResourceMetadataHandler_MethodNotAllowed(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.ProtectedResourceMetadataConfig{
+		Resource: "https://my-server.example.com",
+	})
+
+	for _, method := range []string{http.MethodPost, http.MethodPut, http.MethodDelete, http.MethodPatch} {
+		t.Run(method, func(t *testing.T) {
+			req := httptest.NewRequest(method, "/.well-known/oauth-protected-resource", nil)
+			rec := httptest.NewRecorder()
+			h.ServeHTTP(rec, req)
+
+			assert.Equal(t, http.StatusMethodNotAllowed, rec.Code)
+			assert.NotEmpty(t, rec.Header().Get("Allow"), "Allow header must be set on 405")
+		})
+	}
+}
+
+func TestNewProtectedResourceMetadataHandler_OmitsEmptyFields(t *testing.T) {
+	h := server.NewProtectedResourceMetadataHandler(server.ProtectedResourceMetadataConfig{
+		Resource: "https://minimal.example.com",
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusOK, rec.Code)
+
+	var raw map[string]any
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&raw))
+
+	// resource is required and always present, even when emitted alone.
+	assert.Equal(t, "https://minimal.example.com", raw["resource"])
+
+	// All other fields use omitempty and must be absent.
+	for _, key := range []string{
+		"authorization_servers",
+		"scopes_supported",
+		"bearer_methods_supported",
+		"resource_name",
+		"resource_documentation",
+		"resource_policy_uri",
+		"resource_tos_uri",
+		"jwks_uri",
+		"resource_signing_alg_values_supported",
+		"tls_client_certificate_bound_access_tokens",
+		"authorization_details_types_supported",
+		"dpop_signing_alg_values_supported",
+		"dpop_bound_access_tokens_required",
+	} {
+		_, present := raw[key]
+		assert.False(t, present, "expected field %q to be omitted", key)
+	}
+}
+
+func TestStreamableHTTPServer_WithProtectedResourceMetadata_ServeHTTP(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	cfg := server.ProtectedResourceMetadataConfig{
+		Resource:             "https://mcp.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+		ScopesSupported:      []string{"mcp:read"},
+	}
+
+	httpSrv := server.NewStreamableHTTPServer(mcpSrv,
+		server.WithProtectedResourceMetadata(cfg),
+	)
+
+	ts := httptest.NewServer(httpSrv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var got server.ProtectedResourceMetadataConfig
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, cfg.Resource, got.Resource)
+	assert.Equal(t, cfg.AuthorizationServers, got.AuthorizationServers)
+	assert.Equal(t, cfg.ScopesSupported, got.ScopesSupported)
+}
+
+func TestStreamableHTTPServer_WithProtectedResourceMetadata_PathQualifiedResource(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	cfg := server.ProtectedResourceMetadataConfig{
+		Resource:             "https://mcp.example.com/mcp",
+		AuthorizationServers: []string{"https://auth.example.com"},
+	}
+
+	httpSrv := server.NewStreamableHTTPServer(mcpSrv,
+		server.WithProtectedResourceMetadata(cfg),
+	)
+	ts := httptest.NewServer(httpSrv)
+	defer ts.Close()
+
+	// Path-qualified well-known path per RFC 9728 §3.1.
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource/mcp")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var got server.ProtectedResourceMetadataConfig
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, "https://mcp.example.com/mcp", got.Resource)
+
+	// Bare well-known path must NOT serve PRM JSON for path-qualified resources.
+	resp2, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	assert.NotEqual(t, "application/json", resp2.Header.Get("Content-Type"),
+		"bare well-known path must not serve PRM when resource is path-qualified")
+}
+
+func TestStreamableHTTPServer_WithProtectedResourceMetadata_DoesNotInterfereWithMCP(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	httpSrv := server.NewStreamableHTTPServer(mcpSrv,
+		server.WithProtectedResourceMetadata(server.ProtectedResourceMetadataConfig{
+			Resource: "https://mcp.example.com",
+		}),
+	)
+	ts := httptest.NewServer(httpSrv)
+	defer ts.Close()
+
+	// Initialize MCP request must still be served at the default /mcp endpoint.
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"t","version":"0"}}}`)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL+"/mcp", body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.NotEqual(t, http.StatusNotFound, resp.StatusCode, "MCP endpoint should still be reachable")
+}
+
+func TestStreamableHTTPServer_WithoutProtectedResourceMetadata_NoMetadataServed(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	httpSrv := server.NewStreamableHTTPServer(mcpSrv)
+	ts := httptest.NewServer(httpSrv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// We just need to ensure we are NOT serving PRM JSON when not configured.
+	assert.NotEqual(t, "application/json", resp.Header.Get("Content-Type"),
+		"well-known endpoint must not return PRM JSON when not configured")
+}
+
+func TestSSEServer_WithSSEProtectedResourceMetadata(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	cfg := server.ProtectedResourceMetadataConfig{
+		Resource:             "https://sse.example.com",
+		AuthorizationServers: []string{"https://auth.example.com"},
+	}
+
+	ts := server.NewTestServer(mcpSrv,
+		server.WithSSEProtectedResourceMetadata(cfg),
+	)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var got server.ProtectedResourceMetadataConfig
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&got))
+	assert.Equal(t, cfg.Resource, got.Resource)
+	assert.Equal(t, cfg.AuthorizationServers, got.AuthorizationServers)
+}
+
+func TestSSEServer_WithSSEProtectedResourceMetadata_PathQualifiedResource(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	cfg := server.ProtectedResourceMetadataConfig{
+		Resource: "https://sse.example.com/mcp",
+	}
+
+	ts := server.NewTestServer(mcpSrv,
+		server.WithSSEProtectedResourceMetadata(cfg),
+	)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource/mcp")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestSSEServer_WithoutProtectedResourceMetadata_WellKnown404(t *testing.T) {
+	mcpSrv := server.NewMCPServer("test", "1.0.0")
+	ts := server.NewTestServer(mcpSrv)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/.well-known/oauth-protected-resource")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/server/protected_resource_test.go
+++ b/server/protected_resource_test.go
@@ -55,6 +55,21 @@ func TestProtectedResourceMetadataPath(t *testing.T) {
 			resource: "://broken",
 			want:     "/.well-known/oauth-protected-resource",
 		},
+		{
+			name:     "bare host without scheme falls back to base path",
+			resource: "mcp.example.com",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "bare host with path but no scheme falls back to base path",
+			resource: "mcp.example.com/mcp",
+			want:     "/.well-known/oauth-protected-resource",
+		},
+		{
+			name:     "path-only resource falls back to base path",
+			resource: "/mcp",
+			want:     "/.well-known/oauth-protected-resource",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/protected_resource_test.go
+++ b/server/protected_resource_test.go
@@ -100,7 +100,7 @@ func TestNewProtectedResourceMetadataHandler_GET(t *testing.T) {
 	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
 	assert.Equal(t, "no-store", rec.Header().Get("Cache-Control"))
 	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "GET, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "GET, HEAD, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
 
 	var got server.ProtectedResourceMetadataConfig
 	require.NoError(t, json.NewDecoder(rec.Body).Decode(&got))
@@ -139,7 +139,7 @@ func TestNewProtectedResourceMetadataHandler_OPTIONS(t *testing.T) {
 
 	assert.Equal(t, http.StatusNoContent, rec.Code)
 	assert.Equal(t, "*", rec.Header().Get("Access-Control-Allow-Origin"))
-	assert.Equal(t, "GET, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
+	assert.Equal(t, "GET, HEAD, OPTIONS", rec.Header().Get("Access-Control-Allow-Methods"))
 }
 
 func TestNewProtectedResourceMetadataHandler_MethodNotAllowed(t *testing.T) {

--- a/server/sse.go
+++ b/server/sse.go
@@ -199,6 +199,13 @@ type SSEServer struct {
 	keepAlive         bool
 	keepAliveInterval time.Duration
 
+	// protectedResourceMetadata, when non-nil, is served as RFC 9728 OAuth
+	// 2.0 Protected Resource Metadata. The well-known path is derived from
+	// the configured Resource via ProtectedResourceMetadataPath.
+	protectedResourceMetadata        *ProtectedResourceMetadataConfig
+	protectedResourceMetadataPath    string
+	protectedResourceMetadataHandler http.Handler
+
 	mu sync.RWMutex
 }
 
@@ -312,6 +319,24 @@ func WithKeepAliveInterval(keepAliveInterval time.Duration) SSEOption {
 func WithKeepAlive(keepAlive bool) SSEOption {
 	return func(s *SSEServer) {
 		s.keepAlive = keepAlive
+	}
+}
+
+// WithSSEProtectedResourceMetadata configures the SSEServer to serve OAuth
+// 2.0 Protected Resource Metadata (RFC 9728) at the well-known endpoint
+// derived from the configured Resource (see ProtectedResourceMetadataPath).
+//
+// The metadata is served both when the server is started via Start (the
+// well-known path is dispatched from ServeHTTP) and when the server is used
+// directly as an http.Handler. When using WithHTTPServer with a custom
+// http.Server whose Handler is not the SSEServer itself, mount the metadata
+// endpoint manually via NewProtectedResourceMetadataHandler.
+func WithSSEProtectedResourceMetadata(config ProtectedResourceMetadataConfig) SSEOption {
+	return func(s *SSEServer) {
+		cfg := config
+		s.protectedResourceMetadata = &cfg
+		s.protectedResourceMetadataPath = ProtectedResourceMetadataPath(cfg.Resource)
+		s.protectedResourceMetadataHandler = NewProtectedResourceMetadataHandler(cfg)
 	}
 }
 
@@ -790,6 +815,10 @@ func (s *SSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	path := r.URL.Path
+	if s.protectedResourceMetadataHandler != nil && path == s.protectedResourceMetadataPath {
+		s.protectedResourceMetadataHandler.ServeHTTP(w, r)
+		return
+	}
 	// Use exact path matching rather than Contains
 	ssePath := s.CompleteSsePath()
 	if ssePath != "" && path == ssePath {

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -145,6 +145,23 @@ func WithTLSCert(certFile, keyFile string) StreamableHTTPOption {
 	}
 }
 
+// WithProtectedResourceMetadata configures the StreamableHTTPServer to serve
+// OAuth 2.0 Protected Resource Metadata (RFC 9728) at the well-known endpoint
+// derived from the configured Resource (see ProtectedResourceMetadataPath).
+//
+// The metadata is served both when the server is started via Start (registered
+// on the internal mux) and when the server is used directly as an
+// http.Handler via ServeHTTP. To mount the metadata endpoint manually on a
+// custom router, use NewProtectedResourceMetadataHandler instead.
+func WithProtectedResourceMetadata(config ProtectedResourceMetadataConfig) StreamableHTTPOption {
+	return func(s *StreamableHTTPServer) {
+		cfg := config
+		s.protectedResourceMetadata = &cfg
+		s.protectedResourceMetadataPath = ProtectedResourceMetadataPath(cfg.Resource)
+		s.protectedResourceMetadataHandler = NewProtectedResourceMetadataHandler(cfg)
+	}
+}
+
 // WithSessionIdleTTL sets the idle TTL for per-session transport state.
 // When enabled, a background sweeper periodically removes entries from
 // per-session stores (tools, resources, resource templates, log levels,
@@ -207,6 +224,13 @@ type StreamableHTTPServer struct {
 	sessionIdleTTL    time.Duration
 	sessionLastActive sync.Map // sessionID → *atomic.Int64 (unix nanos)
 	sweeperCancel     context.CancelFunc
+
+	// protectedResourceMetadata, when non-nil, is served as RFC 9728 OAuth
+	// 2.0 Protected Resource Metadata. The well-known path is derived from
+	// the configured Resource via ProtectedResourceMetadataPath.
+	protectedResourceMetadata        *ProtectedResourceMetadataConfig
+	protectedResourceMetadataPath    string
+	protectedResourceMetadataHandler http.Handler
 }
 
 // NewStreamableHTTPServer creates a new streamable-http server instance
@@ -244,7 +268,17 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 }
 
 // ServeHTTP implements the http.Handler interface.
+//
+// When WithProtectedResourceMetadata has been configured, requests to the
+// derived /.well-known/oauth-protected-resource path are dispatched to the
+// metadata handler so that the same StreamableHTTPServer can be mounted as a
+// single http.Handler while still exposing OAuth discovery metadata.
 func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.protectedResourceMetadataHandler != nil && r.URL.Path == s.protectedResourceMetadataPath {
+		s.protectedResourceMetadataHandler.ServeHTTP(w, r)
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPost:
 		s.handlePost(w, r)
@@ -266,6 +300,9 @@ func (s *StreamableHTTPServer) Start(addr string) error {
 	if s.httpServer == nil {
 		mux := http.NewServeMux()
 		mux.Handle(s.endpointPath, s)
+		if s.protectedResourceMetadataHandler != nil && s.protectedResourceMetadataPath != s.endpointPath {
+			mux.Handle(s.protectedResourceMetadataPath, s.protectedResourceMetadataHandler)
+		}
 		s.httpServer = &http.Server{
 			Addr:    addr,
 			Handler: mux,

--- a/www/docs/pages/transports/http.mdx
+++ b/www/docs/pages/transports/http.mdx
@@ -665,6 +665,100 @@ type Claims struct {
 }
 ```
 
+### OAuth Protected Resource Metadata (RFC 9728)
+
+When your MCP server requires OAuth, clients need a way to discover which
+authorization servers, scopes, and bearer methods are supported. The MCP
+[authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
+points clients at a [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728)
+`/.well-known/oauth-protected-resource` endpoint to do exactly that.
+
+`mcp-go` provides two ways to serve this metadata.
+
+#### Option A: Auto-mounted via a server option
+
+The simplest approach — the well-known endpoint is registered automatically
+by `Start()` and is also dispatched when the server is mounted as an
+`http.Handler` via `ServeHTTP`.
+
+```go
+mcpServer := server.NewMCPServer("my-server", "1.0.0")
+
+httpServer := server.NewStreamableHTTPServer(mcpServer,
+    server.WithProtectedResourceMetadata(server.ProtectedResourceMetadataConfig{
+        Resource:               "https://my-mcp-server.com",
+        AuthorizationServers:   []string{"https://auth.example.com"},
+        ScopesSupported:        []string{"mcp:read", "mcp:write"},
+        BearerMethodsSupported: []string{"header"},
+        ResourceName:           "My MCP Server",
+    }),
+)
+
+httpServer.Start(":8080")
+// GET http://localhost:8080/.well-known/oauth-protected-resource
+//   -> 200 application/json with the metadata above
+```
+
+For SSE servers, use the equivalent `WithSSEProtectedResourceMetadata`:
+
+```go
+sseServer := server.NewSSEServer(mcpServer,
+    server.WithSSEProtectedResourceMetadata(server.ProtectedResourceMetadataConfig{
+        Resource:             "https://my-mcp-server.com",
+        AuthorizationServers: []string{"https://auth.example.com"},
+    }),
+)
+```
+
+#### Option B: Standalone handler for custom routing
+
+If you build your own `http.ServeMux` (or use a router like `chi` / `gin`),
+use `NewProtectedResourceMetadataHandler` directly:
+
+```go
+mux := http.NewServeMux()
+mux.Handle("/mcp", mcpHandler)
+mux.Handle("/.well-known/oauth-protected-resource",
+    server.NewProtectedResourceMetadataHandler(server.ProtectedResourceMetadataConfig{
+        Resource:             "https://my-mcp-server.com",
+        AuthorizationServers: []string{"https://auth.example.com"},
+        ScopesSupported:      []string{"mcp:read", "mcp:write"},
+    }))
+http.ListenAndServe(":8080", mux)
+```
+
+#### Path-qualified resources (RFC 9728 §3.1)
+
+When your resource identifier has a path (e.g. `https://example.com/mcp`),
+the well-known URL must include that path suffix:
+`/.well-known/oauth-protected-resource/mcp`. Use
+`server.ProtectedResourceMetadataPath` to derive the correct path:
+
+```go
+cfg := server.ProtectedResourceMetadataConfig{
+    Resource:             "https://example.com/mcp",
+    AuthorizationServers: []string{"https://auth.example.com"},
+}
+mux.Handle(server.ProtectedResourceMetadataPath(cfg.Resource),
+    server.NewProtectedResourceMetadataHandler(cfg))
+// -> mounts at /.well-known/oauth-protected-resource/mcp
+```
+
+The auto-mount options (`WithProtectedResourceMetadata` /
+`WithSSEProtectedResourceMetadata`) apply this rule automatically.
+
+#### Handler behavior
+
+| Method  | Response                                                                |
+|---------|-------------------------------------------------------------------------|
+| `GET`   | `200` with `application/json` body, `Cache-Control: no-store`           |
+| `HEAD`  | `200` headers, no body                                                  |
+| `OPTIONS` | `204` (CORS preflight), permissive `Access-Control-Allow-*` headers   |
+| other   | `405` with `Allow: GET, HEAD, OPTIONS`                                  |
+
+CORS is enabled with `Access-Control-Allow-Origin: *` so browser-based MCP
+clients can perform discovery cross-origin.
+
 ### Request Headers
 
 The StreamableHTTP transport now passes HTTP request headers to MCP handlers. This allows you to access the original HTTP headers that were sent with the request in your tool and resource handlers.


### PR DESCRIPTION
## Description

Adds server-side support for advertising OAuth requirements via the
`/.well-known/oauth-protected-resource` metadata endpoint defined in
[RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728) and referenced by
the [MCP authorization spec](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization).

Until now, mcp-go had client-side OAuth (`WithHTTPOAuth()`) but no way for a
server to advertise its authorization requirements, forcing every server author
to either hand-roll an RFC 9728 endpoint or rely on clients with pre-configured
auth-server knowledge.

This PR provides both shapes proposed in the issue:

**Option A — standalone handler (custom routing):**

```go
mux := http.NewServeMux()
mux.Handle("/mcp", mcpHandler)
mux.Handle(server.ProtectedResourceMetadataPath(cfg.Resource),
    server.NewProtectedResourceMetadataHandler(server.ProtectedResourceMetadataConfig{
        Resource:             "https://my-server.com",
        AuthorizationServers: []string{"https://auth.example.com"},
        ScopesSupported:      []string{"mcp:read", "mcp:write"},
    }))
```

**Option B — server option (auto-mounted):**

```go
server.NewStreamableHTTPServer(mcpServer,
    server.WithProtectedResourceMetadata(server.ProtectedResourceMetadataConfig{
        Resource:             "https://my-mcp-server.com",
        AuthorizationServers: []string{"https://auth.example.com"},
    }),
)
```

When configured via Option B the well-known endpoint is served both when the
server is started via `Start()` (registered on its internal mux) and when the
server is mounted directly as an `http.Handler` (dispatched from `ServeHTTP`),
so both deployment styles work without extra wiring.

Behavior of the handler:

- `GET` → `200` with `application/json` body and `Cache-Control: no-store`
- `HEAD` → `200` headers, no body
- `OPTIONS` → `204` (CORS preflight)
- Any other method → `405` with an `Allow` header
- Permissive `Access-Control-Allow-*` headers for browser-based discovery

The path helper `ProtectedResourceMetadataPath` implements RFC 9728 §3.1
path insertion: a bare resource URL maps to `/.well-known/oauth-protected-resource`,
while a path-qualified resource like `https://mcp.example.com/mcp` maps to
`/.well-known/oauth-protected-resource/mcp`.

Fixes #814

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Authorization (2025-06-18)](https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization)
- [x] Implementation follows the specification exactly

## Additional Information

### Files

- **`server/protected_resource.go`** (new) — `ProtectedResourceMetadataConfig`,
  `NewProtectedResourceMetadataHandler`, and `ProtectedResourceMetadataPath`.
- **`server/protected_resource_test.go`** (new) — covers path derivation
  (host-only / trailing slash / single & multi-segment / unparseable),
  `GET`/`HEAD`/`OPTIONS`/`405` semantics, CORS and `Cache-Control` headers,
  `omitempty` on every optional field, integration with both
  `StreamableHTTPServer` and `SSEServer` including the path-qualified
  variant, and verification that the well-known endpoint does not interfere
  with the regular `/mcp` endpoint.
- **`server/streamable_http.go`** — adds `WithProtectedResourceMetadata`,
  dispatches the well-known path from `ServeHTTP`, and registers it on the
  internal mux in `Start()`.
- **`server/sse.go`** — adds `WithSSEProtectedResourceMetadata` and
  dispatches the well-known path from `ServeHTTP`.

### Backward compatibility

Fully backward compatible: all new fields/methods are additive and the new
dispatch in `ServeHTTP` only fires when the option is configured. No
existing exported APIs are changed.

### Relationship to existing PRs

There are two other open PRs targeting this same issue. This one was opened
as a third take because each of the existing ones has gaps worth combining
and correcting in a single coherent change — noting the differences here
for reference:

- **#820** (everfid-ever) — clean handler with the rich RFC 9728 field set
  (DPoP / mTLS / JWKS / signing algs) plus `Cache-Control: no-store` and an
  `Allow` header on 405. Auto-mounting is layered through a thin mux
  wrapper accessed via a new `HTTPHandler()` method, so the well-known
  path is **not** reachable when the server is used directly as an
  `http.Handler` via `ServeHTTP`. It also does not implement RFC 9728
  §3.1 path-qualified well-known suffixes.
- **#824** (MariaChrysafis) — implements RFC 9728 §3.1 path insertion via
  a `ProtectedResourceMetadataPath` helper and dispatches from `ServeHTTP`,
  so both deployment styles work. However it ships a smaller field set
  (no DPoP/mTLS bindings), is missing `Cache-Control: no-store` and the
  `Allow` header on 405, and bundles an unrelated breaking client-side
  rename (`JwksURI` → `JWKSURI` in `client/transport/oauth.go`).

This PR takes the union of the good parts:

- API shape from the issue (`ProtectedResourceMetadataConfig`,
  `NewProtectedResourceMetadataHandler`, `WithProtectedResourceMetadata`,
  `WithSSEProtectedResourceMetadata`)
- Full RFC 9728 field set incl. DPoP / mTLS / JWKS / signing algs (#820)
- `Cache-Control: no-store`, `Allow` header on 405, `HEAD` support (#820 + new)
- `ProtectedResourceMetadataPath` helper for RFC 9728 §3.1 path insertion (#824)
- Dispatch from `ServeHTTP` *and* registration on the internal mux in
  `Start()`, so both deployment styles work uniformly
- No unrelated changes outside the protected-resource feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RFC 9728 OAuth 2.0 Protected Resource Metadata discovery: servers can now expose protected-resource metadata at the well-known endpoint (supports path-qualified resources). Handlers respond to GET/HEAD/OPTIONS, include CORS and no-store cache headers, and return JSON metadata.
* **Tests**
  * Added comprehensive unit and integration tests covering endpoint routing, responses, headers, and serialization behavior.
* **Documentation**
  * Added README and docs page describing usage and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->