### PR TITLE
feat: add opt-in CORS support to HTTP transports (#810)

### DIFF
--- a/README.md
+++ b/README.md
@@ -678,6 +678,34 @@ httpServer := server.NewStreamableHTTPServer(mcpServer,
 )
 ```
 
+### CORS for browser-based clients
+
+Servers exposed to browser-based MCP clients can opt into Cross-Origin
+Resource Sharing handling on either HTTP transport. CORS is disabled by
+default; configure it explicitly via `server.WithStreamableHTTPCORS` or
+`server.WithSSECORS`:
+
+```go
+httpServer := server.NewStreamableHTTPServer(mcpServer,
+    server.WithEndpointPath("/mcp"),
+    server.WithStreamableHTTPCORS(
+        server.WithCORSAllowedOrigins("https://my-ai-app.com", "http://localhost:3000"),
+        server.WithCORSAllowCredentials(),
+        server.WithCORSMaxAge(300),
+    ),
+)
+```
+
+The transport answers preflight (`OPTIONS`) requests directly and decorates
+simple responses with the appropriate `Access-Control-Allow-Origin`,
+`Access-Control-Allow-Credentials`, `Access-Control-Expose-Headers` and
+`Vary` headers. Sensible defaults are used when the corresponding option is
+omitted (`GET, POST, DELETE, OPTIONS` for methods; `Content-Type,
+Mcp-Session-Id, Last-Event-ID, Authorization` for request headers;
+`Mcp-Session-Id` for exposed headers). Combining `WithCORSAllowedOrigins("*")`
+with `WithCORSAllowCredentials()` echoes the request `Origin` to remain
+spec-compliant.
+
 ### Session Management
 
 MCP-Go provides a robust session management system that allows you to:

--- a/server/http_cors.go
+++ b/server/http_cors.go
@@ -1,0 +1,222 @@
+package server
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// CORSConfig holds the Cross-Origin Resource Sharing configuration shared by
+// the SSE and Streamable HTTP transports. The zero value disables CORS
+// handling entirely; set at least one allowed origin via AllowedOrigins (or
+// the WithCORSAllowedOrigins helper) to enable it.
+//
+// CORS handling is opt-in: when no origins are configured, the transports do
+// not emit any Access-Control-* response headers and preflight (OPTIONS)
+// requests are passed through to the underlying handlers unchanged.
+type CORSConfig struct {
+	// AllowedOrigins is the list of origins permitted to access the server.
+	// The literal value "*" allows any origin, but is incompatible with
+	// AllowCredentials per the CORS specification — when both are set, the
+	// server echoes the request's Origin header instead of "*".
+	AllowedOrigins []string
+
+	// AllowedMethods is the list of HTTP methods allowed for cross-origin
+	// requests. When empty, GET, POST, DELETE and OPTIONS are advertised.
+	AllowedMethods []string
+
+	// AllowedHeaders is the list of headers a client may send with the
+	// actual request. When empty, a sensible MCP-aware default of
+	// Content-Type, Mcp-Session-Id, Last-Event-ID and Authorization is
+	// advertised.
+	AllowedHeaders []string
+
+	// ExposedHeaders is the list of response headers the browser is
+	// permitted to access from JavaScript. When empty, Mcp-Session-Id is
+	// exposed by default so clients can read newly-issued session IDs.
+	ExposedHeaders []string
+
+	// AllowCredentials, when true, causes the server to send
+	// Access-Control-Allow-Credentials: true on cross-origin responses.
+	AllowCredentials bool
+
+	// MaxAge is the number of seconds browsers may cache the preflight
+	// response. Zero (or negative) omits the header.
+	MaxAge int
+}
+
+// CORSOption configures a CORSConfig. It is consumed by the per-transport
+// options WithSSECORS and WithStreamableHTTPCORS.
+type CORSOption func(*CORSConfig)
+
+// WithCORSAllowedOrigins sets the list of origins allowed to access the
+// server. Passing "*" allows any origin. Calling this multiple times within a
+// single WithSSECORS / WithStreamableHTTPCORS invocation replaces the previous
+// value.
+func WithCORSAllowedOrigins(origins ...string) CORSOption {
+	return func(c *CORSConfig) {
+		c.AllowedOrigins = append(c.AllowedOrigins[:0:0], origins...)
+	}
+}
+
+// WithCORSAllowedMethods sets the list of HTTP methods advertised in
+// preflight responses via Access-Control-Allow-Methods.
+func WithCORSAllowedMethods(methods ...string) CORSOption {
+	return func(c *CORSConfig) {
+		c.AllowedMethods = append(c.AllowedMethods[:0:0], methods...)
+	}
+}
+
+// WithCORSAllowedHeaders sets the list of headers advertised in preflight
+// responses via Access-Control-Allow-Headers.
+func WithCORSAllowedHeaders(headers ...string) CORSOption {
+	return func(c *CORSConfig) {
+		c.AllowedHeaders = append(c.AllowedHeaders[:0:0], headers...)
+	}
+}
+
+// WithCORSExposedHeaders sets the list of headers exposed to the browser
+// client via Access-Control-Expose-Headers.
+func WithCORSExposedHeaders(headers ...string) CORSOption {
+	return func(c *CORSConfig) {
+		c.ExposedHeaders = append(c.ExposedHeaders[:0:0], headers...)
+	}
+}
+
+// WithCORSAllowCredentials enables Access-Control-Allow-Credentials: true on
+// cross-origin responses. When combined with an AllowedOrigins value of "*",
+// the server echoes the request's Origin header to remain spec-compliant.
+func WithCORSAllowCredentials() CORSOption {
+	return func(c *CORSConfig) {
+		c.AllowCredentials = true
+	}
+}
+
+// WithCORSMaxAge sets the Access-Control-Max-Age header (in seconds)
+// emitted on preflight responses. Zero or negative values omit the header.
+func WithCORSMaxAge(seconds int) CORSOption {
+	return func(c *CORSConfig) {
+		c.MaxAge = seconds
+	}
+}
+
+// enabled reports whether CORS handling should be performed for this
+// configuration. A nil receiver or empty AllowedOrigins disables CORS.
+func (c *CORSConfig) enabled() bool {
+	return c != nil && len(c.AllowedOrigins) > 0
+}
+
+// resolveOrigin returns the value to set on Access-Control-Allow-Origin for
+// the given request Origin, or the empty string if the origin is not allowed.
+func (c *CORSConfig) resolveOrigin(origin string) string {
+	for _, allowed := range c.AllowedOrigins {
+		if allowed == "*" {
+			// Per the CORS spec, "*" cannot be combined with credentials.
+			// When credentials are required, echo the request origin
+			// instead so the browser still accepts the response.
+			if c.AllowCredentials {
+				if origin == "" {
+					return ""
+				}
+				return origin
+			}
+			return "*"
+		}
+		if origin != "" && allowed == origin {
+			return origin
+		}
+	}
+	return ""
+}
+
+// applyCommonHeaders writes the response headers shared between simple and
+// preflight responses (Allow-Origin, Allow-Credentials, Expose-Headers, Vary).
+// It returns true if the request's origin was permitted by the configuration.
+func (c *CORSConfig) applyCommonHeaders(w http.ResponseWriter, r *http.Request) bool {
+	h := w.Header()
+	// Always advertise Vary: Origin so caches do not serve a response with
+	// CORS headers from one origin to a request from a different one.
+	h.Add("Vary", "Origin")
+
+	origin := r.Header.Get("Origin")
+	allowOrigin := c.resolveOrigin(origin)
+	if allowOrigin == "" {
+		return false
+	}
+	h.Set("Access-Control-Allow-Origin", allowOrigin)
+	if c.AllowCredentials {
+		h.Set("Access-Control-Allow-Credentials", "true")
+	}
+
+	exposed := c.ExposedHeaders
+	if len(exposed) == 0 {
+		exposed = []string{HeaderKeySessionID}
+	}
+	h.Set("Access-Control-Expose-Headers", strings.Join(exposed, ", "))
+	return true
+}
+
+// handlePreflight writes a complete preflight (CORS OPTIONS) response and
+// returns true. The caller must skip its normal request handling when this
+// returns true. It returns false when the request is not a CORS preflight.
+func (c *CORSConfig) handlePreflight(w http.ResponseWriter, r *http.Request) bool {
+	if !c.enabled() {
+		return false
+	}
+	if r.Method != http.MethodOptions || r.Header.Get("Access-Control-Request-Method") == "" {
+		return false
+	}
+
+	c.applyCommonHeaders(w, r)
+
+	h := w.Header()
+	methods := c.AllowedMethods
+	if len(methods) == 0 {
+		methods = []string{http.MethodGet, http.MethodPost, http.MethodDelete, http.MethodOptions}
+	}
+	h.Set("Access-Control-Allow-Methods", strings.Join(methods, ", "))
+
+	headers := c.AllowedHeaders
+	if len(headers) == 0 {
+		headers = []string{"Content-Type", HeaderKeySessionID, "Last-Event-ID", "Authorization"}
+	}
+	h.Set("Access-Control-Allow-Headers", strings.Join(headers, ", "))
+
+	if c.MaxAge > 0 {
+		h.Set("Access-Control-Max-Age", strconv.Itoa(c.MaxAge))
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+	return true
+}
+
+// applySimple writes the headers for a non-preflight (simple) cross-origin
+// response. It is a no-op when CORS is not enabled.
+func (c *CORSConfig) applySimple(w http.ResponseWriter, r *http.Request) {
+	if !c.enabled() {
+		return
+	}
+	c.applyCommonHeaders(w, r)
+}
+
+// clone returns a deep copy of the configuration so callers cannot mutate
+// internal state after construction.
+func (c *CORSConfig) clone() *CORSConfig {
+	if c == nil {
+		return nil
+	}
+	cp := *c
+	if c.AllowedOrigins != nil {
+		cp.AllowedOrigins = append([]string(nil), c.AllowedOrigins...)
+	}
+	if c.AllowedMethods != nil {
+		cp.AllowedMethods = append([]string(nil), c.AllowedMethods...)
+	}
+	if c.AllowedHeaders != nil {
+		cp.AllowedHeaders = append([]string(nil), c.AllowedHeaders...)
+	}
+	if c.ExposedHeaders != nil {
+		cp.ExposedHeaders = append([]string(nil), c.ExposedHeaders...)
+	}
+	return &cp
+}

--- a/server/http_cors_test.go
+++ b/server/http_cors_test.go
@@ -1,0 +1,373 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORSConfig_DisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	var c *CORSConfig
+	assert.False(t, c.enabled(), "nil config must be disabled")
+
+	c = &CORSConfig{}
+	assert.False(t, c.enabled(), "config without origins must be disabled")
+
+	c = &CORSConfig{AllowedOrigins: []string{"https://example.com"}}
+	assert.True(t, c.enabled(), "config with origins must be enabled")
+}
+
+func TestCORSConfig_ResolveOrigin(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		cfg         CORSConfig
+		origin      string
+		wantAllowed string
+	}{
+		{
+			name:        "exact match",
+			cfg:         CORSConfig{AllowedOrigins: []string{"https://example.com"}},
+			origin:      "https://example.com",
+			wantAllowed: "https://example.com",
+		},
+		{
+			name:        "no match returns empty",
+			cfg:         CORSConfig{AllowedOrigins: []string{"https://example.com"}},
+			origin:      "https://attacker.com",
+			wantAllowed: "",
+		},
+		{
+			name:        "wildcard without credentials returns *",
+			cfg:         CORSConfig{AllowedOrigins: []string{"*"}},
+			origin:      "https://anywhere.com",
+			wantAllowed: "*",
+		},
+		{
+			name:        "wildcard with credentials echoes origin",
+			cfg:         CORSConfig{AllowedOrigins: []string{"*"}, AllowCredentials: true},
+			origin:      "https://anywhere.com",
+			wantAllowed: "https://anywhere.com",
+		},
+		{
+			name:        "wildcard with credentials but no origin returns empty",
+			cfg:         CORSConfig{AllowedOrigins: []string{"*"}, AllowCredentials: true},
+			origin:      "",
+			wantAllowed: "",
+		},
+		{
+			name:        "multiple origins picks the matching one",
+			cfg:         CORSConfig{AllowedOrigins: []string{"https://a.com", "https://b.com"}},
+			origin:      "https://b.com",
+			wantAllowed: "https://b.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.cfg.resolveOrigin(tt.origin)
+			assert.Equal(t, tt.wantAllowed, got)
+		})
+	}
+}
+
+func TestCORSOptionHelpers(t *testing.T) {
+	t.Parallel()
+
+	cfg := &CORSConfig{}
+	for _, opt := range []CORSOption{
+		WithCORSAllowedOrigins("https://example.com", "https://other.com"),
+		WithCORSAllowedMethods(http.MethodGet, http.MethodPost),
+		WithCORSAllowedHeaders("X-Custom", "Authorization"),
+		WithCORSExposedHeaders("X-Trace"),
+		WithCORSAllowCredentials(),
+		WithCORSMaxAge(600),
+	} {
+		opt(cfg)
+	}
+
+	assert.Equal(t, []string{"https://example.com", "https://other.com"}, cfg.AllowedOrigins)
+	assert.Equal(t, []string{http.MethodGet, http.MethodPost}, cfg.AllowedMethods)
+	assert.Equal(t, []string{"X-Custom", "Authorization"}, cfg.AllowedHeaders)
+	assert.Equal(t, []string{"X-Trace"}, cfg.ExposedHeaders)
+	assert.True(t, cfg.AllowCredentials)
+	assert.Equal(t, 600, cfg.MaxAge)
+}
+
+func TestCORSOptionHelpers_ReplaceOnRepeatedCall(t *testing.T) {
+	t.Parallel()
+
+	cfg := &CORSConfig{AllowedOrigins: []string{"https://stale.com"}}
+	WithCORSAllowedOrigins("https://fresh.com")(cfg)
+	assert.Equal(t, []string{"https://fresh.com"}, cfg.AllowedOrigins)
+}
+
+func TestStreamableHTTP_CORS_Preflight(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewStreamableHTTPServer(mcp,
+		WithStreamableHTTPCORS(
+			WithCORSAllowedOrigins("https://example.com"),
+			WithCORSAllowedMethods(http.MethodPost, http.MethodGet, http.MethodDelete, http.MethodOptions),
+			WithCORSAllowedHeaders("Content-Type", "Mcp-Session-Id"),
+			WithCORSAllowCredentials(),
+			WithCORSMaxAge(120),
+		),
+	)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+	req.Header.Set("Access-Control-Request-Headers", "Content-Type")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+	assert.Equal(t, "120", resp.Header.Get("Access-Control-Max-Age"))
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Methods"), http.MethodPost)
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Headers"), "Mcp-Session-Id")
+	assert.Equal(t, "Origin", resp.Header.Get("Vary"))
+}
+
+func TestStreamableHTTP_CORS_PreflightDisallowedOrigin(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewStreamableHTTPServer(mcp,
+		WithStreamableHTTPCORS(WithCORSAllowedOrigins("https://example.com")),
+	)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://attacker.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	// Preflight is still answered (browser will block), but no Allow-Origin
+	// header is emitted because the origin is not in the allow list.
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestStreamableHTTP_CORS_SimpleRequest(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewStreamableHTTPServer(mcp,
+		WithStreamableHTTPCORS(
+			WithCORSAllowedOrigins("https://example.com"),
+			WithCORSExposedHeaders("Mcp-Session-Id", "X-Trace"),
+		),
+	)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	body := strings.NewReader(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}`)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, ts.URL, body)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+	exposed := resp.Header.Get("Access-Control-Expose-Headers")
+	assert.Contains(t, exposed, "Mcp-Session-Id")
+	assert.Contains(t, exposed, "X-Trace")
+	assert.Equal(t, "Origin", resp.Header.Get("Vary"))
+}
+
+func TestStreamableHTTP_CORS_NoConfigPassesPreflightThrough(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewStreamableHTTPServer(mcp)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	// With CORS disabled, OPTIONS is not handled specially and falls
+	// through to ServeHTTP's default branch (404).
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestStreamableHTTP_CORS_WildcardWithCredentialsEchoesOrigin(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewStreamableHTTPServer(mcp,
+		WithStreamableHTTPCORS(
+			WithCORSAllowedOrigins("*"),
+			WithCORSAllowCredentials(),
+		),
+	)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://anywhere.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, "https://anywhere.com", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+}
+
+func TestSSE_CORS_Preflight(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewSSEServer(mcp,
+		WithSSECORS(
+			WithCORSAllowedOrigins("https://example.com"),
+		),
+	)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, ts.URL+"/sse", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Methods"), http.MethodGet)
+}
+
+func TestSSE_CORS_DefaultWildcardPreservedWhenDisabled(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	ts := NewTestServer(mcp)
+	t.Cleanup(ts.Close)
+
+	// Issue a GET to the SSE endpoint and look for the default behavior.
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/sse", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	// Without an explicit CORS config, handleSSE preserves the historical
+	// "*" default to avoid breaking existing browser-based clients.
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestSSE_CORS_OverridesDefaultWildcard(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewSSEServer(mcp,
+		WithSSECORS(WithCORSAllowedOrigins("https://example.com")),
+	)
+	ts := httptest.NewServer(srv)
+	t.Cleanup(ts.Close)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/sse", nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set("Origin", "https://example.com")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestSSE_CORS_HandlersHonorConfig(t *testing.T) {
+	t.Parallel()
+
+	mcp := NewMCPServer("test", "1.0.0")
+	srv := NewSSEServer(mcp,
+		WithSSECORS(WithCORSAllowedOrigins("https://example.com")),
+	)
+
+	mux := http.NewServeMux()
+	mux.Handle("/custom/sse", srv.SSEHandler())
+	mux.Handle("/custom/message", srv.MessageHandler())
+	ts := httptest.NewServer(mux)
+	t.Cleanup(ts.Close)
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodOptions, ts.URL+"/custom/message", nil)
+	require.NoError(t, err)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", http.MethodPost)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "https://example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORSConfig_Clone(t *testing.T) {
+	t.Parallel()
+
+	orig := &CORSConfig{
+		AllowedOrigins:   []string{"a"},
+		AllowedMethods:   []string{"GET"},
+		AllowedHeaders:   []string{"X-A"},
+		ExposedHeaders:   []string{"X-B"},
+		AllowCredentials: true,
+		MaxAge:           5,
+	}
+	cp := orig.clone()
+	cp.AllowedOrigins[0] = "mutated"
+	assert.Equal(t, "a", orig.AllowedOrigins[0], "clone must not share slice with original")
+
+	var nilCfg *CORSConfig
+	assert.Nil(t, nilCfg.clone())
+}

--- a/server/sse.go
+++ b/server/sse.go
@@ -206,6 +206,11 @@ type SSEServer struct {
 	protectedResourceMetadataPath    string
 	protectedResourceMetadataHandler http.Handler
 
+	// corsConfig, when non-nil and with at least one allowed origin, makes
+	// the SSE server emit CORS headers and handle preflight requests. See
+	// WithSSECORS.
+	corsConfig *CORSConfig
+
 	mu sync.RWMutex
 }
 
@@ -340,6 +345,35 @@ func WithSSEProtectedResourceMetadata(config ProtectedResourceMetadataConfig) SS
 	}
 }
 
+// WithSSECORS configures Cross-Origin Resource Sharing for the SSE server.
+//
+// CORS handling is opt-in: callers must specify at least one allowed origin
+// via WithCORSAllowedOrigins for any Access-Control-* headers to be emitted.
+// When enabled, preflight (OPTIONS) requests are handled directly by the
+// server and simple cross-origin responses get the appropriate Allow-Origin,
+// Allow-Credentials, Expose-Headers and Vary headers attached.
+//
+// Example:
+//
+//	srv := server.NewSSEServer(mcpServer,
+//	    server.WithSSECORS(
+//	        server.WithCORSAllowedOrigins("https://example.com"),
+//	        server.WithCORSAllowCredentials(),
+//	    ),
+//	)
+func WithSSECORS(opts ...CORSOption) SSEOption {
+	return func(s *SSEServer) {
+		if s.corsConfig == nil {
+			s.corsConfig = &CORSConfig{}
+		}
+		for _, opt := range opts {
+			if opt != nil {
+				opt(s.corsConfig)
+			}
+		}
+	}
+}
+
 // WithSSEContextFunc sets a function that will be called to customise the context
 // to the server using the incoming request.
 func WithSSEContextFunc(fn SSEContextFunc) SSEOption {
@@ -442,7 +476,13 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
+	// Preserve historical default of allowing any origin for browser-based
+	// EventSource clients, unless the caller has opted into an explicit
+	// CORS configuration via WithSSECORS (which has already populated the
+	// Access-Control-* headers on the response).
+	if !s.corsConfig.enabled() {
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+	}
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -748,6 +788,10 @@ func (s *SSEServer) CompleteMessagePath() string {
 
 // SSEHandler returns an http.Handler for the SSE endpoint.
 //
+// When CORS has been configured via WithSSECORS, the returned handler
+// transparently handles preflight requests and applies the appropriate
+// Access-Control-* headers to simple responses.
+//
 // This method allows you to mount the SSE handler at any arbitrary path
 // using your own router (e.g. net/http, gorilla/mux, chi, etc.). It is
 // intended for advanced scenarios where you want to control the routing or
@@ -772,7 +816,7 @@ func (s *SSEServer) CompleteMessagePath() string {
 //
 // For non-dynamic cases, use ServeHTTP method instead.
 func (s *SSEServer) SSEHandler() http.Handler {
-	return http.HandlerFunc(s.handleSSE)
+	return s.withCORS(http.HandlerFunc(s.handleSSE))
 }
 
 // MessageHandler returns an http.Handler for the message endpoint.
@@ -801,11 +845,36 @@ func (s *SSEServer) SSEHandler() http.Handler {
 //
 // For non-dynamic cases, use ServeHTTP method instead.
 func (s *SSEServer) MessageHandler() http.Handler {
-	return http.HandlerFunc(s.handleMessage)
+	return s.withCORS(http.HandlerFunc(s.handleMessage))
+}
+
+// withCORS wraps next with CORS preflight and header handling using the
+// SSE server's configured CORSConfig. It is a no-op when CORS is disabled.
+func (s *SSEServer) withCORS(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.corsConfig.enabled() {
+			if s.corsConfig.handlePreflight(w, r) {
+				return
+			}
+			s.corsConfig.applySimple(w, r)
+		}
+		next.ServeHTTP(w, r)
+	})
 }
 
 // ServeHTTP implements the http.Handler interface.
+//
+// When CORS is configured via WithSSECORS, preflight (OPTIONS) requests are
+// answered directly and simple cross-origin responses are decorated with the
+// configured Access-Control-* headers before being dispatched to the SSE or
+// message handlers.
 func (s *SSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.corsConfig.enabled() {
+		if s.corsConfig.handlePreflight(w, r) {
+			return
+		}
+		s.corsConfig.applySimple(w, r)
+	}
 	if s.dynamicBasePathFunc != nil {
 		http.Error(
 			w,

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -175,6 +175,37 @@ func WithSessionIdleTTL(ttl time.Duration) StreamableHTTPOption {
 	}
 }
 
+// WithStreamableHTTPCORS configures Cross-Origin Resource Sharing for the
+// Streamable HTTP server.
+//
+// CORS handling is opt-in: callers must specify at least one allowed origin
+// via WithCORSAllowedOrigins for any Access-Control-* headers to be emitted.
+// When enabled, preflight (OPTIONS) requests are answered directly by the
+// server and simple cross-origin responses are decorated with the configured
+// Allow-Origin, Allow-Credentials, Expose-Headers and Vary headers.
+//
+// Example:
+//
+//	srv := server.NewStreamableHTTPServer(mcpServer,
+//	    server.WithEndpointPath("/mcp"),
+//	    server.WithStreamableHTTPCORS(
+//	        server.WithCORSAllowedOrigins("https://my-ai-app.com"),
+//	        server.WithCORSAllowCredentials(),
+//	    ),
+//	)
+func WithStreamableHTTPCORS(opts ...CORSOption) StreamableHTTPOption {
+	return func(s *StreamableHTTPServer) {
+		if s.corsConfig == nil {
+			s.corsConfig = &CORSConfig{}
+		}
+		for _, opt := range opts {
+			if opt != nil {
+				opt(s.corsConfig)
+			}
+		}
+	}
+}
+
 // StreamableHTTPServer implements a Streamable-http based MCP server.
 // It communicates with clients over HTTP protocol, supporting both direct HTTP responses, and SSE streams.
 // https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http
@@ -231,6 +262,11 @@ type StreamableHTTPServer struct {
 	protectedResourceMetadata        *ProtectedResourceMetadataConfig
 	protectedResourceMetadataPath    string
 	protectedResourceMetadataHandler http.Handler
+
+	// corsConfig, when non-nil and with at least one allowed origin, makes
+	// the server emit CORS headers and answer preflight requests. See
+	// WithStreamableHTTPCORS.
+	corsConfig *CORSConfig
 }
 
 // NewStreamableHTTPServer creates a new streamable-http server instance
@@ -273,7 +309,17 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 // derived /.well-known/oauth-protected-resource path are dispatched to the
 // metadata handler so that the same StreamableHTTPServer can be mounted as a
 // single http.Handler while still exposing OAuth discovery metadata.
+//
+// When WithStreamableHTTPCORS has been configured, CORS preflight (OPTIONS)
+// requests are answered directly and simple cross-origin responses are
+// decorated with the configured Access-Control-* headers before dispatch.
 func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if s.corsConfig.enabled() {
+		if s.corsConfig.handlePreflight(w, r) {
+			return
+		}
+		s.corsConfig.applySimple(w, r)
+	}
 	if s.protectedResourceMetadataHandler != nil && r.URL.Path == s.protectedResourceMetadataPath {
 		s.protectedResourceMetadataHandler.ServeHTTP(w, r)
 		return

--- a/www/docs/pages/transports/http.mdx
+++ b/www/docs/pages/transports/http.mdx
@@ -759,6 +759,46 @@ The auto-mount options (`WithProtectedResourceMetadata` /
 CORS is enabled with `Access-Control-Allow-Origin: *` so browser-based MCP
 clients can perform discovery cross-origin.
 
+### Cross-Origin Resource Sharing (CORS)
+
+The MCP endpoints themselves are **not** CORS-enabled by default — every
+deployment has different origin requirements, and emitting permissive
+headers unconditionally would be a security regression. Browser-based MCP
+clients hosted on a different origin than the server will be blocked unless
+you opt in.
+
+Use `server.WithStreamableHTTPCORS` (or `server.WithSSECORS` for the SSE
+transport) to enable CORS handling. The transport then answers preflight
+(`OPTIONS`) requests directly and decorates simple cross-origin responses
+with the appropriate `Access-Control-*` headers, including a `Vary: Origin`
+so downstream caches behave correctly.
+
+```go
+httpServer := server.NewStreamableHTTPServer(mcpServer,
+    server.WithEndpointPath("/mcp"),
+    server.WithStreamableHTTPCORS(
+        server.WithCORSAllowedOrigins("https://my-ai-app.com", "http://localhost:3000"),
+        server.WithCORSAllowCredentials(),
+        server.WithCORSMaxAge(300),
+    ),
+)
+```
+
+Available `CORSOption` helpers:
+
+| Option                          | Purpose                                                                |
+|---------------------------------|------------------------------------------------------------------------|
+| `WithCORSAllowedOrigins(...)`   | Origins permitted to access the server. `"*"` allows any origin.       |
+| `WithCORSAllowedMethods(...)`   | Methods advertised in preflight (defaults to `GET, POST, DELETE, OPTIONS`). |
+| `WithCORSAllowedHeaders(...)`   | Request headers advertised in preflight (defaults to `Content-Type, Mcp-Session-Id, Last-Event-ID, Authorization`). |
+| `WithCORSExposedHeaders(...)`   | Response headers exposed to JavaScript (defaults to `Mcp-Session-Id`). |
+| `WithCORSAllowCredentials()`    | Sends `Access-Control-Allow-Credentials: true`.                        |
+| `WithCORSMaxAge(seconds)`       | Sets `Access-Control-Max-Age` for preflight caching.                   |
+
+When `WithCORSAllowedOrigins("*")` is combined with `WithCORSAllowCredentials()`,
+the server echoes the request's `Origin` header instead of `*` to remain
+compliant with the CORS specification.
+
 ### Request Headers
 
 The StreamableHTTP transport now passes HTTP request headers to MCP handlers. This allows you to access the original HTTP headers that were sent with the request in your tool and resource handlers.

--- a/www/docs/pages/transports/sse.mdx
+++ b/www/docs/pages/transports/sse.mdx
@@ -289,8 +289,20 @@ sseServer := server.NewSSEServer(s,
         // Add custom context values from headers
         return ctx
     }),
+
+    // Enable Cross-Origin Resource Sharing for browser-based clients
+    server.WithSSECORS(
+        server.WithCORSAllowedOrigins("https://my-ai-app.com"),
+        server.WithCORSAllowCredentials(),
+    ),
 )
 ```
+
+CORS handling is opt-in. Without `WithSSECORS`, the SSE stream falls back to
+the historical default of `Access-Control-Allow-Origin: *` for backwards
+compatibility, while the message endpoint emits no CORS headers.
+See the [Streamable HTTP CORS docs](/transports/http#cross-origin-resource-sharing-cors)
+for the full list of `CORSOption` helpers shared between both transports.
 
 **Resulting endpoints:**
 - SSE stream: `http://localhost:8080/api/mcp/sse`


### PR DESCRIPTION
## Description

Adds opt-in Cross-Origin Resource Sharing (CORS) support to both the SSE and Streamable HTTP transports. Browser-based MCP clients (web AI assistants, in-page tooling, etc.) hosted on a different origin than the server were previously blocked unless users wrapped the transport in third-party CORS middleware — error-prone enough that the official `go-sdk` ships a built-in `CrossOriginProtection` for the same reason.

A shared `CORSConfig` struct and a family of `CORSOption` helpers (`WithCORSAllowedOrigins`, `WithCORSAllowedMethods`, `WithCORSAllowedHeaders`, `WithCORSExposedHeaders`, `WithCORSAllowCredentials`, `WithCORSMaxAge`) are exposed from `package server` and consumed by two transport-specific options: `WithStreamableHTTPCORS` and `WithSSECORS`. When at least one origin is configured the transports answer preflight (`OPTIONS`) requests directly with `204 No Content`, decorate simple cross-origin responses with the appropriate `Access-Control-*` headers plus `Vary: Origin`, fall back to MCP-aware defaults for methods/headers/exposed-headers, and echo the request `Origin` instead of `*` when wildcard origins are combined with credentials.

```go
httpServer := server.NewStreamableHTTPServer(mcpServer,
    server.WithEndpointPath("/mcp"),
    server.WithStreamableHTTPCORS(
        server.WithCORSAllowedOrigins("https://my-ai-app.com", "http://localhost:3000"),
        server.WithCORSAllowCredentials(),
        server.WithCORSMaxAge(300),
    ),
)
```

CORS is strictly opt-in. With no `WithStreamableHTTPCORS` / `WithSSECORS` configured, the transports behave exactly as before — including the SSE handler's historical `Access-Control-Allow-Origin: *` default for browser `EventSource` clients.

Fixes #810

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

**Files added**

- `server/http_cors.go` — `CORSConfig`, `CORSOption`, helper constructors, and the preflight/simple-request middleware logic.
- `server/http_cors_test.go` — covers the `CORSOption` helpers, `resolveOrigin` decision matrix, Streamable HTTP preflight (allowed/disallowed origin), simple cross-origin responses, the wildcard-with-credentials echo, the disabled-by-default behaviour, SSE preflight on `ServeHTTP`, the dedicated `SSEHandler`/`MessageHandler` entry points, and `CORSConfig.clone` semantics.

**Files modified**

- `server/sse.go` — adds `WithSSECORS`, wires CORS into `ServeHTTP`, `SSEHandler` and `MessageHandler`, and gates the historical `Access-Control-Allow-Origin: *` default in `handleSSE` on the absence of an explicit CORS config.
- `server/streamable_http.go` — adds `WithStreamableHTTPCORS` and the CORS preflight/simple-request hooks at the top of `ServeHTTP`.
- `README.md`, `www/docs/pages/transports/http.mdx`, `www/docs/pages/transports/sse.mdx` — new CORS sections, an option-reference table, and a cross-link between transports.

**Backwards compatibility**

Fully backwards-compatible. Without an explicit `WithStreamableHTTPCORS` / `WithSSECORS` option the transports emit the same headers (or lack thereof) as previous releases.

**Verification**

- `go test ./... -race` — all packages pass
- `golangci-lint run` — 0 issues
- `npx vocs build` in `www/` — succeeds with no MDX errors
- `go doc ./server <Symbol>` — godoc renders cleanly on every new exported name