### PR TITLE
feat: validate tool output against declared output schemas (#811)

### DIFF
--- a/server/input_validation.go
+++ b/server/input_validation.go
@@ -16,9 +16,9 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// inputSchemaValidator compiles and caches JSON Schema validators for tool
-// input schemas. Compilation is performed lazily on first use and the
-// resulting schema is cached for the lifetime of the server.
+// compiledSchemaCache compiles and caches JSON Schema validators keyed by
+// tool name. Compilation is performed lazily on first use and the resulting
+// schema is cached for the lifetime of the cache.
 //
 // The cache is two-level: tool name -> schema digest -> compiled entry. Two
 // sessions can expose the same tool name with different schemas (via
@@ -26,7 +26,11 @@ import (
 // schema; each distinct schema is compiled once. Name-level invalidation
 // drops every entry registered for that name in a single map delete, which
 // keeps DeleteTools / SetTools cleanup cheap.
-type inputSchemaValidator struct {
+//
+// The same cache type backs both input and output schema validation; each
+// validator owns its own cache instance so input and output schemas with
+// the same digest do not collide.
+type compiledSchemaCache struct {
 	mu     sync.RWMutex
 	cached map[string]map[string]*cachedToolSchema
 }
@@ -39,11 +43,100 @@ type cachedToolSchema struct {
 	compileErr error
 }
 
-// newInputSchemaValidator returns a fresh validator with an empty cache.
-func newInputSchemaValidator() *inputSchemaValidator {
-	return &inputSchemaValidator{
+// newCompiledSchemaCache returns a fresh empty schema cache.
+func newCompiledSchemaCache() *compiledSchemaCache {
+	return &compiledSchemaCache{
 		cached: make(map[string]map[string]*cachedToolSchema),
 	}
+}
+
+// invalidate drops cached compilations for the given tool names. Used when
+// tools are re-registered or removed so that stale schemas are not reused.
+func (c *compiledSchemaCache) invalidate(names ...string) {
+	if c == nil || len(names) == 0 {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, name := range names {
+		delete(c.cached, name)
+	}
+}
+
+// invalidateAll drops the entire cache.
+func (c *compiledSchemaCache) invalidateAll() {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.cached = make(map[string]map[string]*cachedToolSchema)
+}
+
+// lookupOrCompile returns the compiled schema for the given (toolName,
+// schemaJSON) pair, compiling and caching it on first access. Compilation
+// errors are cached too so that a malformed schema is not recompiled on
+// every call.
+func (c *compiledSchemaCache) lookupOrCompile(toolName string, schemaJSON []byte) (*jsonschema.Schema, error) {
+	digest := schemaDigest(schemaJSON)
+
+	c.mu.RLock()
+	if perName, ok := c.cached[toolName]; ok {
+		if entry, ok := perName[digest]; ok {
+			c.mu.RUnlock()
+			return entry.compiled, entry.compileErr
+		}
+	}
+	c.mu.RUnlock()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Re-check under the write lock in case another goroutine compiled it.
+	perName, ok := c.cached[toolName]
+	if !ok {
+		perName = make(map[string]*cachedToolSchema)
+		c.cached[toolName] = perName
+	}
+	if entry, ok := perName[digest]; ok {
+		return entry.compiled, entry.compileErr
+	}
+
+	compiled, compileErr := compileSchema(toolName, schemaJSON)
+	perName[digest] = &cachedToolSchema{
+		compiled:   compiled,
+		compileErr: compileErr,
+	}
+	return compiled, compileErr
+}
+
+// inputSchemaValidator validates tool call arguments against the tool's
+// declared input schema, reusing a compiledSchemaCache to amortize the
+// cost of JSON Schema compilation across calls.
+type inputSchemaValidator struct {
+	*compiledSchemaCache
+}
+
+// newInputSchemaValidator returns a fresh validator with an empty cache.
+func newInputSchemaValidator() *inputSchemaValidator {
+	return &inputSchemaValidator{compiledSchemaCache: newCompiledSchemaCache()}
+}
+
+// invalidate drops cached compilations for the given tool names. The
+// receiver-level method preserves the historical nil-safety guarantee: a
+// nil *inputSchemaValidator is a valid no-op.
+func (v *inputSchemaValidator) invalidate(names ...string) {
+	if v == nil {
+		return
+	}
+	v.compiledSchemaCache.invalidate(names...)
+}
+
+// invalidateAll drops the entire cache. Safe to call on a nil receiver.
+func (v *inputSchemaValidator) invalidateAll() {
+	if v == nil {
+		return
+	}
+	v.compiledSchemaCache.invalidateAll()
 }
 
 // validate validates raw arguments against the tool's input schema. If the
@@ -71,61 +164,6 @@ func (v *inputSchemaValidator) validate(tool mcp.Tool, rawArgs any) (bool, error
 		return true, formatValidationError(err)
 	}
 	return true, nil
-}
-
-// invalidate drops cached compilations for the given tool names. Used when
-// tools are re-registered or removed so that stale schemas are not reused.
-func (v *inputSchemaValidator) invalidate(names ...string) {
-	if v == nil || len(names) == 0 {
-		return
-	}
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	for _, name := range names {
-		delete(v.cached, name)
-	}
-}
-
-// invalidateAll drops the entire cache.
-func (v *inputSchemaValidator) invalidateAll() {
-	if v == nil {
-		return
-	}
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	v.cached = make(map[string]map[string]*cachedToolSchema)
-}
-
-func (v *inputSchemaValidator) lookupOrCompile(toolName string, schemaJSON []byte) (*jsonschema.Schema, error) {
-	digest := schemaDigest(schemaJSON)
-
-	v.mu.RLock()
-	if perName, ok := v.cached[toolName]; ok {
-		if entry, ok := perName[digest]; ok {
-			v.mu.RUnlock()
-			return entry.compiled, entry.compileErr
-		}
-	}
-	v.mu.RUnlock()
-
-	v.mu.Lock()
-	defer v.mu.Unlock()
-	// Re-check under the write lock in case another goroutine compiled it.
-	perName, ok := v.cached[toolName]
-	if !ok {
-		perName = make(map[string]*cachedToolSchema)
-		v.cached[toolName] = perName
-	}
-	if entry, ok := perName[digest]; ok {
-		return entry.compiled, entry.compileErr
-	}
-
-	compiled, compileErr := compileSchema(toolName, schemaJSON)
-	perName[digest] = &cachedToolSchema{
-		compiled:   compiled,
-		compileErr: compileErr,
-	}
-	return compiled, compileErr
 }
 
 // schemaDigest returns a stable hex-encoded SHA-256 of the canonical schema

--- a/server/output_validation.go
+++ b/server/output_validation.go
@@ -62,12 +62,33 @@ func (v *outputSchemaValidator) validate(tool mcp.Tool, result *mcp.CallToolResu
 	if v == nil || result == nil {
 		return false, nil
 	}
-	// Error results carry diagnostic content that need not match the
-	// declared output schema.
-	if result.IsError {
+	return v.validateStructured(tool, result.StructuredContent, result.IsError)
+}
+
+// validateCreateTaskResult is the *mcp.CreateTaskResult counterpart to
+// validate. Task-augmented tool calls produce a CreateTaskResult whose
+// StructuredContent carries the structured payload that will eventually be
+// surfaced to the client via tasks/result; validating it before the result
+// is persisted to the task entry keeps the task path consistent with the
+// synchronous path's WithOutputSchemaValidation contract.
+func (v *outputSchemaValidator) validateCreateTaskResult(tool mcp.Tool, result *mcp.CreateTaskResult) (bool, error) {
+	if v == nil || result == nil {
 		return false, nil
 	}
-	if result.StructuredContent == nil {
+	return v.validateStructured(tool, result.StructuredContent, result.IsError)
+}
+
+// validateStructured runs the actual schema check against the structured
+// content and IsError flag extracted from a tool result. Both *CallToolResult
+// and *CreateTaskResult delegate here so the skip rules and error formatting
+// stay in one place.
+func (v *outputSchemaValidator) validateStructured(tool mcp.Tool, structured any, isError bool) (bool, error) {
+	// Error results carry diagnostic content that need not match the
+	// declared output schema.
+	if isError {
+		return false, nil
+	}
+	if structured == nil {
 		return false, nil
 	}
 	schemaJSON, ok := outputSchemaJSONFor(tool)
@@ -80,7 +101,7 @@ func (v *outputSchemaValidator) validate(tool mcp.Tool, result *mcp.CallToolResu
 		return false, nil
 	}
 
-	value, err := normalizeStructuredContentForValidation(result.StructuredContent)
+	value, err := normalizeStructuredContentForValidation(structured)
 	if err != nil {
 		return true, fmt.Errorf("invalid structured content: %w", err)
 	}

--- a/server/output_validation.go
+++ b/server/output_validation.go
@@ -1,0 +1,149 @@
+// Package server provides MCP (Model Context Protocol) server implementations.
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// outputSchemaValidator validates a tool's StructuredContent return value
+// against the tool's declared output schema. It reuses a compiledSchemaCache
+// to amortize the cost of JSON Schema compilation across calls.
+//
+// The cache is independent from the input schema cache so that input and
+// output schemas registered for the same tool name do not collide on lookup.
+type outputSchemaValidator struct {
+	*compiledSchemaCache
+}
+
+// newOutputSchemaValidator returns a fresh validator with an empty cache.
+func newOutputSchemaValidator() *outputSchemaValidator {
+	return &outputSchemaValidator{compiledSchemaCache: newCompiledSchemaCache()}
+}
+
+// invalidate drops cached compilations for the given tool names. Safe to
+// call on a nil receiver so callers do not need a separate guard when
+// validation is disabled.
+func (v *outputSchemaValidator) invalidate(names ...string) {
+	if v == nil {
+		return
+	}
+	v.compiledSchemaCache.invalidate(names...)
+}
+
+// invalidateAll drops the entire cache. Safe to call on a nil receiver.
+func (v *outputSchemaValidator) invalidateAll() {
+	if v == nil {
+		return
+	}
+	v.compiledSchemaCache.invalidateAll()
+}
+
+// validate checks the tool result against the tool's declared output schema.
+// The boolean return reports whether validation actually ran; the error is
+// set only when validation ran and the structured content did not satisfy
+// the schema.
+//
+// Validation is skipped (and reported as not-run) when:
+//   - the tool declares no output schema
+//   - the result is nil or carries IsError = true (error results are not
+//     required to conform to the success-shape schema)
+//   - the result has no StructuredContent (mcp-go does not synthesise
+//     structured output from text content; tools without structured output
+//     are passed through to preserve back-compat)
+//   - the schema fails to compile (matches input validator behaviour: a
+//     broken schema must not make tool calls unexpectedly fail)
+func (v *outputSchemaValidator) validate(tool mcp.Tool, result *mcp.CallToolResult) (bool, error) {
+	if v == nil || result == nil {
+		return false, nil
+	}
+	// Error results carry diagnostic content that need not match the
+	// declared output schema.
+	if result.IsError {
+		return false, nil
+	}
+	if result.StructuredContent == nil {
+		return false, nil
+	}
+	schemaJSON, ok := outputSchemaJSONFor(tool)
+	if !ok {
+		return false, nil
+	}
+
+	compiled, err := v.lookupOrCompile(tool.Name, schemaJSON)
+	if err != nil {
+		return false, nil
+	}
+
+	value, err := normalizeStructuredContentForValidation(result.StructuredContent)
+	if err != nil {
+		return true, fmt.Errorf("invalid structured content: %w", err)
+	}
+
+	if err := compiled.Validate(value); err != nil {
+		return true, formatOutputValidationError(err)
+	}
+	return true, nil
+}
+
+// outputSchemaJSONFor returns the JSON representation of the tool's output
+// schema. It prefers RawOutputSchema when set, otherwise marshals the
+// structured OutputSchema. The boolean return is false when the tool
+// declares no usable output schema.
+func outputSchemaJSONFor(tool mcp.Tool) ([]byte, bool) {
+	if len(tool.RawOutputSchema) > 0 {
+		return tool.RawOutputSchema, true
+	}
+	if tool.OutputSchema.Type == "" && len(tool.OutputSchema.Properties) == 0 && len(tool.OutputSchema.Required) == 0 {
+		return nil, false
+	}
+	data, err := json.Marshal(tool.OutputSchema)
+	if err != nil {
+		return nil, false
+	}
+	return data, true
+}
+
+// normalizeStructuredContentForValidation converts the structured content
+// (which may already be a decoded map/slice/scalar or a typed Go struct)
+// into the loosely-typed representation that the JSON Schema validator
+// expects. We round-trip through JSON so that struct field tags and custom
+// MarshalJSON implementations are honoured during validation.
+func normalizeStructuredContentForValidation(structured any) (any, error) {
+	if structured == nil {
+		return nil, nil
+	}
+	if raw, ok := structured.(json.RawMessage); ok {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			return nil, nil
+		}
+		return jsonschema.UnmarshalJSON(bytes.NewReader(raw))
+	}
+	encoded, err := json.Marshal(structured)
+	if err != nil {
+		return nil, err
+	}
+	return jsonschema.UnmarshalJSON(bytes.NewReader(encoded))
+}
+
+// formatOutputValidationError shapes a validator error as a single flat
+// message suitable for surfacing to the client. The message is prefixed
+// with "output schema validation failed" so callers can distinguish it
+// from input validation failures.
+func formatOutputValidationError(err error) error {
+	formatted := formatValidationError(err)
+	// formatValidationError wraps with "input schema validation failed:";
+	// rewrite the prefix so output errors are identifiable.
+	msg := formatted.Error()
+	const inputPrefix = "input schema validation failed: "
+	const outputPrefix = "output schema validation failed: "
+	if len(msg) >= len(inputPrefix) && msg[:len(inputPrefix)] == inputPrefix {
+		return fmt.Errorf("%s%s", outputPrefix, msg[len(inputPrefix):])
+	}
+	return fmt.Errorf("output schema validation failed: %w", err)
+}

--- a/server/output_validation_test.go
+++ b/server/output_validation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -259,4 +260,193 @@ func TestOutputSchemaValidation_TypedHandler(t *testing.T) {
 	})
 	resp = callTool(t, srv, "get_weather", map[string]any{"city": "London"})
 	requireToolErrorContaining(t, resp, "temperature")
+}
+
+// waitForTaskTerminal polls the server until the named task reaches a
+// terminal status or the deadline elapses, returning the latest observed
+// status. It exists to keep the task-validation tests focused on the
+// validation behaviour rather than retry plumbing.
+func waitForTaskTerminal(t *testing.T, srv *MCPServer, ctx context.Context, taskID string) mcp.TaskStatus {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var status mcp.TaskStatus
+	for time.Now().Before(deadline) {
+		task, _, err := srv.getTask(ctx, taskID)
+		require.NoError(t, err)
+		status = task.Status
+		if status.IsTerminal() {
+			return status
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("task %s did not reach terminal status (last: %s)", taskID, status)
+	return status
+}
+
+// TestOutputSchemaValidation_TaskAugmented_RegularTool exercises the
+// hybrid-mode path: a regular tool with TaskSupportOptional invoked with a
+// task param, whose handler returns non-conforming StructuredContent. The
+// validator must intercept the bad result before it is persisted to the
+// task entry, so that tasks/result surfaces a validation error instead of
+// the original payload.
+func TestOutputSchemaValidation_TaskAugmented_RegularTool(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0",
+		WithTaskCapabilities(true, true, true),
+		WithOutputSchemaValidation(),
+	)
+
+	tool := mcp.NewTool("get_weather",
+		mcp.WithDescription("Get the current weather"),
+		mcp.WithString("city", mcp.Required()),
+		mcp.WithOutputSchema[weatherOutput](),
+		mcp.WithTaskSupport(mcp.TaskSupportOptional),
+	)
+	srv.AddTool(tool, func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultStructuredOnly(map[string]any{
+			"temperature": "not-a-number",
+			"unit":        "C",
+		}), nil
+	})
+
+	ctx := t.Context()
+	createRes, reqErr := srv.handleToolCall(ctx, 1, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "get_weather",
+			Arguments: map[string]any{"city": "London"},
+			Task:      &mcp.TaskParams{},
+		},
+	})
+	require.Nil(t, reqErr)
+	created, ok := createRes.(*mcp.CreateTaskResult)
+	require.True(t, ok, "task-augmented call must return CreateTaskResult")
+	taskID := created.Task.TaskId
+	require.NotEmpty(t, taskID)
+
+	status := waitForTaskTerminal(t, srv, ctx, taskID)
+	assert.Equal(t, mcp.TaskStatusCompleted, status,
+		"task should complete (the validation error is recorded as a successful tool error result, not a task failure)")
+
+	taskResult, resErr := srv.handleTaskResult(ctx, 2, mcp.TaskResultRequest{
+		Params: mcp.TaskResultParams{TaskId: taskID},
+	})
+	require.Nil(t, resErr)
+	require.NotNil(t, taskResult)
+
+	assert.True(t, taskResult.IsError, "validation failure must surface as a tool execution error")
+	require.NotEmpty(t, taskResult.Content)
+	tc, ok := taskResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "output schema validation failed")
+	assert.Contains(t, tc.Text, "temperature")
+	assert.Nil(t, taskResult.StructuredContent,
+		"the bad structured content must not survive to the client")
+}
+
+// TestOutputSchemaValidation_TaskTool exercises the task-only path: a tool
+// registered via AddTaskTool whose handler returns a *CreateTaskResult
+// carrying non-conforming StructuredContent. Validation must run on the
+// CreateTaskResult before the task is completed.
+func TestOutputSchemaValidation_TaskTool(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0",
+		WithTaskCapabilities(true, true, true),
+		WithOutputSchemaValidation(),
+	)
+
+	tool := mcp.Tool{
+		Name:        "compute_weather",
+		Description: "Compute weather asynchronously",
+		Execution:   &mcp.ToolExecution{TaskSupport: mcp.TaskSupportRequired},
+	}
+	// Reuse the WithOutputSchema helper by piggy-backing on a NewTool call,
+	// then merge its OutputSchema onto the task tool definition above so the
+	// task tool path validates the same shape.
+	template := mcp.NewTool("compute_weather",
+		mcp.WithDescription("Compute weather asynchronously"),
+		mcp.WithOutputSchema[weatherOutput](),
+		mcp.WithTaskSupport(mcp.TaskSupportRequired),
+	)
+	tool.OutputSchema = template.OutputSchema
+	tool.RawOutputSchema = template.RawOutputSchema
+
+	srv.AddTaskTool(tool, func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CreateTaskResult, error) {
+		return &mcp.CreateTaskResult{
+			StructuredContent: map[string]any{
+				"temperature": "definitely-not-a-number",
+				"unit":        "C",
+			},
+		}, nil
+	})
+
+	ctx := t.Context()
+	createRes, reqErr := srv.handleToolCall(ctx, 1, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name: "compute_weather",
+			Task: &mcp.TaskParams{},
+		},
+	})
+	require.Nil(t, reqErr)
+	created, ok := createRes.(*mcp.CreateTaskResult)
+	require.True(t, ok)
+	taskID := created.Task.TaskId
+	require.NotEmpty(t, taskID)
+
+	status := waitForTaskTerminal(t, srv, ctx, taskID)
+	assert.Equal(t, mcp.TaskStatusCompleted, status)
+
+	taskResult, resErr := srv.handleTaskResult(ctx, 2, mcp.TaskResultRequest{
+		Params: mcp.TaskResultParams{TaskId: taskID},
+	})
+	require.Nil(t, resErr)
+	require.NotNil(t, taskResult)
+
+	assert.True(t, taskResult.IsError, "validation failure must surface as a tool execution error")
+	require.NotEmpty(t, taskResult.Content)
+	tc, ok := taskResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Contains(t, tc.Text, "output schema validation failed")
+	assert.Contains(t, tc.Text, "temperature")
+	assert.Nil(t, taskResult.StructuredContent)
+}
+
+// TestOutputSchemaValidation_TaskAugmented_HappyPath confirms a conforming
+// task result is left untouched: the structured payload reaches the client
+// through tasks/result and IsError remains false.
+func TestOutputSchemaValidation_TaskAugmented_HappyPath(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0",
+		WithTaskCapabilities(true, true, true),
+		WithOutputSchemaValidation(),
+	)
+
+	tool := mcp.NewTool("get_weather",
+		mcp.WithDescription("Get the current weather"),
+		mcp.WithString("city", mcp.Required()),
+		mcp.WithOutputSchema[weatherOutput](),
+		mcp.WithTaskSupport(mcp.TaskSupportOptional),
+	)
+	srv.AddTool(tool, func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultStructuredOnly(weatherOutput{Temperature: 21.5, Unit: "C"}), nil
+	})
+
+	ctx := t.Context()
+	createRes, reqErr := srv.handleToolCall(ctx, 1, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "get_weather",
+			Arguments: map[string]any{"city": "London"},
+			Task:      &mcp.TaskParams{},
+		},
+	})
+	require.Nil(t, reqErr)
+	created := createRes.(*mcp.CreateTaskResult)
+	taskID := created.Task.TaskId
+
+	status := waitForTaskTerminal(t, srv, ctx, taskID)
+	assert.Equal(t, mcp.TaskStatusCompleted, status)
+
+	taskResult, resErr := srv.handleTaskResult(ctx, 2, mcp.TaskResultRequest{
+		Params: mcp.TaskResultParams{TaskId: taskID},
+	})
+	require.Nil(t, resErr)
+	require.NotNil(t, taskResult)
+	assert.False(t, taskResult.IsError)
+	require.NotNil(t, taskResult.StructuredContent)
 }

--- a/server/output_validation_test.go
+++ b/server/output_validation_test.go
@@ -1,0 +1,262 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// weatherOutput mirrors the example in the issue: a structured result
+// describing a temperature reading with required fields.
+type weatherOutput struct {
+	Temperature float64 `json:"temperature"`
+	Unit        string  `json:"unit"`
+}
+
+// fakeWeatherTool returns a tool that declares an output schema for the
+// weatherOutput shape via WithOutputSchema, matching the canonical usage
+// pattern from the issue.
+func fakeWeatherTool() mcp.Tool {
+	return mcp.NewTool("get_weather",
+		mcp.WithDescription("Get the current weather"),
+		mcp.WithString("city", mcp.Required()),
+		mcp.WithOutputSchema[weatherOutput](),
+	)
+}
+
+// rawOutputSchemaTool returns a tool whose output schema is supplied via
+// WithRawOutputSchema rather than the typed helper, so we can confirm the
+// raw path participates in validation.
+func rawOutputSchemaTool() mcp.Tool {
+	return mcp.NewTool("raw_output",
+		mcp.WithDescription("Tool with raw output schema"),
+		mcp.WithRawOutputSchema(json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"value": {"type": "string"}
+			},
+			"required": ["value"],
+			"additionalProperties": false
+		}`)),
+	)
+}
+
+// TestOutputSchemaValidation covers the matrix of validation outcomes for a
+// tool whose handler returns structured content. Each row exercises a
+// single server lifecycle, registers the tool, makes one call, and asserts
+// on either success or a tool execution error.
+func TestOutputSchemaValidation(t *testing.T) {
+	noOutputSchemaTool := mcp.NewTool("no_schema",
+		mcp.WithDescription("Tool without an output schema"),
+	)
+	brokenOutputSchemaTool := mcp.Tool{
+		Name:            "broken_output",
+		Description:     "Tool with malformed output schema",
+		RawOutputSchema: json.RawMessage(`{"type": "object", "properties": {`),
+	}
+
+	tests := []struct {
+		name            string
+		options         []ServerOption
+		tool            mcp.Tool
+		handlerResult   *mcp.CallToolResult
+		wantSuccess     bool
+		wantErrContains string
+	}{
+		{
+			// Regression guard: with validation off, a non-conforming
+			// structured result silently passes through to the client. Pinned
+			// so we never flip the default to strict and break existing
+			// servers that declare schemas but return loose output.
+			name:    "disabled by default accepts non-conforming output",
+			options: nil,
+			tool:    fakeWeatherTool(),
+			handlerResult: mcp.NewToolResultStructuredOnly(map[string]any{
+				"temperature": "not-a-number",
+			}),
+			wantSuccess: true,
+		},
+		{
+			// The motivating fix: with validation on, a structured result
+			// that does not conform to the declared output schema must
+			// surface as a tool execution error instead of being shipped to
+			// the client.
+			name:    "wrong type rejected",
+			options: []ServerOption{WithOutputSchemaValidation()},
+			tool:    fakeWeatherTool(),
+			handlerResult: mcp.NewToolResultStructuredOnly(map[string]any{
+				"temperature": "not-a-number",
+				"unit":        "C",
+			}),
+			wantErrContains: "temperature",
+		},
+		{
+			name:    "missing required field rejected",
+			options: []ServerOption{WithOutputSchemaValidation()},
+			tool:    fakeWeatherTool(),
+			handlerResult: mcp.NewToolResultStructuredOnly(map[string]any{
+				"temperature": 21.5,
+			}),
+			wantErrContains: "unit",
+		},
+		{
+			name:    "valid structured content passes through",
+			options: []ServerOption{WithOutputSchemaValidation()},
+			tool:    fakeWeatherTool(),
+			handlerResult: mcp.NewToolResultStructuredOnly(weatherOutput{
+				Temperature: 21.5,
+				Unit:        "C",
+			}),
+			wantSuccess: true,
+		},
+		{
+			// Tools whose handlers return only text content (no
+			// StructuredContent) are unaffected, even when the tool declares
+			// an output schema. Validating absent structured content would
+			// break a common pattern where the schema is documentation only.
+			name:          "missing structured content is unaffected",
+			options:       []ServerOption{WithOutputSchemaValidation()},
+			tool:          fakeWeatherTool(),
+			handlerResult: mcp.NewToolResultText("21.5C"),
+			wantSuccess:   true,
+		},
+		{
+			// Error results are diagnostic and need not match the success
+			// shape declared by the output schema.
+			name:          "error result skips validation",
+			options:       []ServerOption{WithOutputSchemaValidation()},
+			tool:          fakeWeatherTool(),
+			handlerResult: mcp.NewToolResultError("upstream weather API unavailable"),
+			wantSuccess:   false, // the result is itself an IsError result
+		},
+		{
+			// A tool that does not declare an output schema is unaffected
+			// regardless of what it returns.
+			name:    "tool without output schema is unaffected",
+			options: []ServerOption{WithOutputSchemaValidation()},
+			tool:    noOutputSchemaTool,
+			handlerResult: mcp.NewToolResultStructuredOnly(map[string]any{
+				"anything": "goes",
+			}),
+			wantSuccess: true,
+		},
+		{
+			// A schema that fails to compile must not block calls to the
+			// tool. The validator silently degrades and the handler result
+			// is returned as-is.
+			name:    "malformed schema is silently skipped",
+			options: []ServerOption{WithOutputSchemaValidation()},
+			tool:    brokenOutputSchemaTool,
+			handlerResult: mcp.NewToolResultStructuredOnly(map[string]any{
+				"anything": true,
+			}),
+			wantSuccess: true,
+		},
+		{
+			name:    "raw output schema participates in validation",
+			options: []ServerOption{WithOutputSchemaValidation()},
+			tool:    rawOutputSchemaTool(),
+			handlerResult: mcp.NewToolResultStructuredOnly(map[string]any{
+				"value": "ok",
+				"extra": "rejected",
+			}),
+			wantErrContains: "extra",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewMCPServer("test", "1.0.0", tt.options...)
+			srv.AddTool(tt.tool, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return tt.handlerResult, nil
+			})
+
+			args := map[string]any{}
+			if tt.tool.Name == "get_weather" {
+				args["city"] = "London"
+			}
+			resp := callTool(t, srv, tt.tool.Name, args)
+
+			switch {
+			case tt.wantErrContains != "":
+				requireToolErrorContaining(t, resp, tt.wantErrContains)
+				// Output-validation failures are tagged with the
+				// "output schema validation failed" prefix to distinguish
+				// them from input validation errors. Verify the tag is
+				// present so callers can disambiguate.
+				jr := resp.(mcp.JSONRPCResponse)
+				result := jr.Result.(*mcp.CallToolResult)
+				tc := result.Content[0].(mcp.TextContent)
+				assert.Contains(t, tc.Text, "output schema validation failed")
+			case tt.wantSuccess:
+				requireToolSuccess(t, resp)
+			default:
+				// Tests that explicitly want an error result without a
+				// validation failure (handler returned an error result).
+				jr, ok := resp.(mcp.JSONRPCResponse)
+				require.True(t, ok)
+				result, ok := jr.Result.(*mcp.CallToolResult)
+				require.True(t, ok)
+				require.True(t, result.IsError)
+			}
+		})
+	}
+}
+
+// TestOutputSchemaValidation_DeleteToolInvalidatesCache makes a validated
+// call to populate the output schema cache, deletes the tool, and asserts
+// the cache entry is cleaned up so a tool re-added under the same name
+// does not reuse a stale compilation.
+func TestOutputSchemaValidation_DeleteToolInvalidatesCache(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithOutputSchemaValidation())
+	srv.AddTool(fakeWeatherTool(), func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultStructuredOnly(weatherOutput{Temperature: 1, Unit: "C"}), nil
+	})
+
+	resp := callTool(t, srv, "get_weather", map[string]any{"city": "London"})
+	requireToolSuccess(t, resp)
+	require.Len(t, srv.outputValidator.cached, 1, "cache should be populated after a validated call")
+
+	srv.DeleteTools("get_weather")
+	require.Len(t, srv.outputValidator.cached, 0, "cache should be empty after DeleteTools")
+}
+
+// TestOutputSchemaValidation_TypedHandler exercises the canonical end-to-end
+// path from the issue: a tool declared with WithOutputSchema[T] whose
+// handler is wired up via NewStructuredToolHandler returning a Go struct.
+// Because the handler returns a typed value, the only way it can produce a
+// non-conforming result is by returning a different type — which we
+// simulate by registering the typed schema against a handler that returns
+// a deliberately-wrong map.
+func TestOutputSchemaValidation_TypedHandler(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithOutputSchemaValidation())
+
+	// Happy path: a properly-typed result passes through.
+	srv.AddTool(fakeWeatherTool(), mcp.NewStructuredToolHandler(
+		func(_ context.Context, _ mcp.CallToolRequest, _ struct {
+			City string `json:"city"`
+		}) (weatherOutput, error) {
+			return weatherOutput{Temperature: 21.5, Unit: "C"}, nil
+		},
+	))
+	resp := callTool(t, srv, "get_weather", map[string]any{"city": "London"})
+	result := requireToolSuccess(t, resp)
+	require.NotNil(t, result.StructuredContent)
+
+	// Re-register the tool with a handler that returns a non-conforming
+	// shape. The validator should reject it before it reaches the client.
+	srv.DeleteTools("get_weather")
+	srv.AddTool(fakeWeatherTool(), func(_ context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultStructuredOnly(map[string]any{
+			"temperature": "string-not-number",
+			"unit":        "C",
+		}), nil
+	})
+	resp = callTool(t, srv, "get_weather", map[string]any{"city": "London"})
+	requireToolErrorContaining(t, resp, "temperature")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -215,6 +215,7 @@ type MCPServer struct {
 	activeTasks                int                  // Current count of running (non-terminal) tasks
 	inflightCancels            sync.Map             // Maps request ID -> context.CancelFunc for in-flight requests
 	inputValidator             *inputSchemaValidator
+	outputValidator            *outputSchemaValidator
 }
 
 // WithPaginationLimit sets the pagination limit for the server.
@@ -408,6 +409,35 @@ func WithInputSchemaValidation() ServerOption {
 	return func(s *MCPServer) {
 		if s.inputValidator == nil {
 			s.inputValidator = newInputSchemaValidator()
+		}
+	}
+}
+
+// WithOutputSchemaValidation enables server-side validation of tool call
+// results against each tool's declared outputSchema. When a tool returns a
+// CallToolResult whose StructuredContent does not conform to the schema, the
+// server replaces the result with a tool execution error (CallToolResult with
+// IsError: true) so the client never sees a result that violates the
+// declared contract.
+//
+// The MCP tools specification states that when an outputSchema is provided,
+// the tool result MUST include structuredContent conforming to that schema.
+// Enabling this option enforces that contract at runtime.
+//
+// Validation is skipped for results whose StructuredContent is nil and for
+// error results (IsError: true). Tools whose output schemas cannot be
+// compiled (malformed JSON Schema) are silently skipped, matching the
+// behaviour of WithInputSchemaValidation, so a single broken schema cannot
+// block tool calls.
+//
+// This option is opt-in to preserve backwards compatibility with servers
+// whose hand-written output schemas may not perfectly describe the values
+// their handlers actually return. Enabling it is recommended for any server
+// whose schemas are accurate.
+func WithOutputSchemaValidation() ServerOption {
+	return func(s *MCPServer) {
+		if s.outputValidator == nil {
+			s.outputValidator = newOutputSchemaValidator()
 		}
 	}
 }
@@ -909,6 +939,7 @@ func (s *MCPServer) SetTools(tools ...ServerTool) {
 	s.tools = newTools
 	s.toolsMu.Unlock()
 	s.inputValidator.invalidateAll()
+	s.outputValidator.invalidateAll()
 
 	// When the list of available tools changes, servers that declared the listChanged capability SHOULD send a notification.
 	if s.capabilities.tools.listChanged {
@@ -953,9 +984,11 @@ func (s *MCPServer) DeleteTools(names ...string) {
 	}
 	s.toolsMu.Unlock()
 
-	// Drop any cached compiled input schemas for the removed tools so a tool
-	// re-added later under the same name does not reuse a stale compilation.
+	// Drop any cached compiled input/output schemas for the removed tools so
+	// a tool re-added later under the same name does not reuse a stale
+	// compilation.
 	s.inputValidator.invalidate(names...)
+	s.outputValidator.invalidate(names...)
 
 	// When the list of available tools changes, servers that declared the listChanged capability SHOULD send a notification.
 	if exists && s.capabilities.tools != nil && s.capabilities.tools.listChanged {
@@ -1743,6 +1776,17 @@ func (s *MCPServer) handleToolCall(
 			id:   id,
 			code: mcp.INTERNAL_ERROR,
 			err:  err,
+		}
+	}
+
+	// Validate the tool's StructuredContent against its declared output
+	// schema when output schema validation has been enabled via
+	// WithOutputSchemaValidation. A validation failure is surfaced as a
+	// tool execution error so the client cannot silently receive a result
+	// that violates the declared contract.
+	if s.outputValidator != nil {
+		if _, vErr := s.outputValidator.validate(tool.Tool, result); vErr != nil {
+			return validationToolResult(vErr), nil
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -1958,6 +1958,19 @@ func (s *MCPServer) executeTaskTool(
 
 	// Task succeeded - store the CreateTaskResult
 	// Note: The actual result will be retrieved later via tasks/result
+	//
+	// Validate the StructuredContent against the tool's declared output
+	// schema when WithOutputSchemaValidation is enabled. If validation fails,
+	// persist a tool execution error in place of the bad result so the
+	// client cannot retrieve a result that violates the schema via
+	// tasks/result. handleTaskResult accepts both *CallToolResult and
+	// *CreateTaskResult, so storing a *CallToolResult here is safe.
+	if s.outputValidator != nil {
+		if _, vErr := s.outputValidator.validateCreateTaskResult(taskTool.Tool, result); vErr != nil {
+			s.completeTask(entry, validationToolResult(vErr), nil)
+			return
+		}
+	}
 	s.completeTask(entry, result, nil)
 }
 
@@ -2046,6 +2059,18 @@ func (s *MCPServer) executeRegularToolAsTask(
 
 	// Task succeeded - store the CallToolResult directly
 	// When retrieved via tasks/result, this will be returned to the client
+	//
+	// Mirror the synchronous path: validate the result's StructuredContent
+	// against the tool's declared output schema when
+	// WithOutputSchemaValidation is enabled. A validation failure replaces
+	// the result with a tool execution error so the bad payload never
+	// reaches the client via tasks/result.
+	if s.outputValidator != nil {
+		if _, vErr := s.outputValidator.validate(regularTool.Tool, result); vErr != nil {
+			s.completeTask(entry, validationToolResult(vErr), nil)
+			return
+		}
+	}
 	s.completeTask(entry, result, nil)
 }
 

--- a/www/docs/pages/servers/tools.mdx
+++ b/www/docs/pages/servers/tools.mdx
@@ -215,6 +215,27 @@ func searchProductsHandler(ctx context.Context, req mcp.CallToolRequest, args Se
 }
 ```
 
+### Validating Output Against the Schema
+
+Declaring an output schema is a contract: clients can rely on the shape of
+`structuredContent` matching the schema you advertised. To enforce that
+contract at runtime, opt in to output schema validation when constructing
+the server:
+
+```go
+s := server.NewMCPServer("Product Search", "1.0.0",
+    server.WithToolCapabilities(false),
+    server.WithOutputSchemaValidation(), // reject results that don't match outputSchema
+)
+```
+
+When enabled, every tool result whose `StructuredContent` does not conform
+to the declared `outputSchema` is replaced with a tool execution error
+(`IsError: true`). This catches handler bugs server-side instead of letting
+them reach the client as a silent protocol violation. Tools without an
+output schema, results without `StructuredContent`, and error results are
+all passed through unchanged.
+
 ### Array Output Schema
 
 Tools can return arrays of structured data:


### PR DESCRIPTION
## Description

Adds `server.WithOutputSchemaValidation()`, an opt-in MCP server option that validates each tool result's `StructuredContent` against the tool's declared `outputSchema` (set via `WithOutputSchema[T]()` or `WithRawOutputSchema`). When validation fails the server replaces the result with a tool execution error (`IsError: true`) so the client never receives structured content that violates the schema the server advertised.

Today a tool can declare an `outputSchema` and then silently return non-conforming `StructuredContent` — a protocol violation that only the client (if any) would catch. The MCP tools spec requires that, when an `outputSchema` is provided, the result MUST include `structuredContent` conforming to that schema; this option enforces that contract at runtime.

Example:

```go
type WeatherResult struct {
    Temperature float64 `json:"temperature"`
    Unit        string  `json:"unit"`
}

s := server.NewMCPServer("weather", "1.0.0",
    server.WithOutputSchemaValidation(),
)
s.AddTool(mcp.NewTool("get_weather",
    mcp.WithOutputSchema[WeatherResult](),
), handler)
// If handler returns StructuredContent that doesn't match WeatherResult,
// the server now returns a tool execution error instead of shipping the bad result.
```

The option is opt-in (matching `WithInputSchemaValidation`) to preserve back-compat with servers whose hand-written schemas may not perfectly describe the values their handlers actually return.

Fixes #811

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

Implementation notes for reviewers:

- Refactored `inputSchemaValidator`'s cache into a shared `compiledSchemaCache` type so input and output validation share the same SHA-256-keyed, digest-deduplicated cache plumbing without duplicating invalidation paths. Each validator owns its own cache instance so input and output schemas with the same digest do not collide.
- Validation is skipped when `StructuredContent` is `nil`, when the result is already `IsError: true`, or when the output schema fails to compile — matching the existing input-validator's degrade-gracefully policy so a single broken schema cannot block tool calls.
- `DeleteTools` / `SetTools` invalidate the output cache too, mirroring the input cache lifecycle.
- Validation errors are tagged with the prefix `output schema validation failed: ` so callers can distinguish them from input validation errors when both options are enabled.

Files:

- `server/output_validation.go` (new) — `outputSchemaValidator` + helpers
- `server/output_validation_test.go` (new) — matrix of validation outcomes plus cache-invalidation and typed-handler end-to-end tests
- `server/input_validation.go` — extracted shared `compiledSchemaCache`; `inputSchemaValidator` now embeds it (no behaviour change)
- `server/server.go` — added `WithOutputSchemaValidation` option, validation call site after the tool handler runs, and cache-invalidation hooks
- `www/docs/pages/servers/tools.mdx` — documented the new option in the existing output-schema section

Backward compatibility: validation is strictly opt-in. Existing servers see no change unless they pass `WithOutputSchemaValidation()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Optional runtime validation of tool results against declared output schemas; non-conforming results are returned as execution errors.
* **Bug Fixes**
  * Cache invalidation improved so removing/re-registering tools no longer reuses stale compiled schema state.
* **Tests**
  * Added comprehensive tests covering output-schema validation, cached compilation behavior, typed handlers, and task/result flows.
* **Documentation**
  * New docs describing how to enable and use output schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->