### PR TITLE
feat(transport): add LoggingTransport wrapper for JSON-RPC tracing

### DIFF
--- a/client/transport/logging.go
+++ b/client/transport/logging.go
@@ -1,0 +1,291 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// LoggingOption configures a LoggingTransport.
+type LoggingOption func(*loggingConfig)
+
+type loggingConfig struct {
+	level    slog.Level
+	payloads bool
+}
+
+// WithLoggingLevel sets the slog level used for the log records emitted by
+// the LoggingTransport. The default is slog.LevelDebug.
+func WithLoggingLevel(level slog.Level) LoggingOption {
+	return func(c *loggingConfig) {
+		c.level = level
+	}
+}
+
+// WithLoggingPayloads controls whether full JSON-RPC payloads (params,
+// result, error) are included in the structured log records. When disabled,
+// only message metadata (direction, method, id, duration) is logged. The
+// default is true.
+func WithLoggingPayloads(enabled bool) LoggingOption {
+	return func(c *loggingConfig) {
+		c.payloads = enabled
+	}
+}
+
+// LoggingTransport wraps a transport.Interface and logs every JSON-RPC
+// message that flows through it using a slog.Logger. It is a transparent
+// decorator: NewLogging returns a wrapper whose interface set mirrors the
+// inner transport, so type assertions against BidirectionalInterface or
+// HTTPConnection continue to behave as expected.
+type LoggingTransport struct {
+	inner  Interface
+	logger *slog.Logger
+	level  slog.Level
+	logRaw bool
+
+	notifyMu       sync.RWMutex
+	onNotification func(notification mcp.JSONRPCNotification)
+}
+
+// NewLogging returns an Interface that logs all JSON-RPC traffic passing
+// through inner using the provided logger. When logger is nil, slog.Default
+// is used. If inner additionally implements BidirectionalInterface and/or
+// HTTPConnection, the returned wrapper also implements those interfaces, so
+// it can be used as a drop-in replacement.
+func NewLogging(inner Interface, logger *slog.Logger, opts ...LoggingOption) Interface {
+	base := newLoggingTransport(inner, logger, opts...)
+
+	bidir, isBidir := inner.(BidirectionalInterface)
+	httpConn, isHTTP := inner.(HTTPConnection)
+
+	switch {
+	case isBidir && isHTTP:
+		return &loggingBidirHTTPTransport{
+			loggingBidirTransport: loggingBidirTransport{LoggingTransport: base, bidir: bidir},
+			http:                  httpConn,
+		}
+	case isBidir:
+		return &loggingBidirTransport{LoggingTransport: base, bidir: bidir}
+	case isHTTP:
+		return &loggingHTTPTransport{LoggingTransport: base, http: httpConn}
+	default:
+		return base
+	}
+}
+
+func newLoggingTransport(inner Interface, logger *slog.Logger, opts ...LoggingOption) *LoggingTransport {
+	cfg := loggingConfig{level: slog.LevelDebug, payloads: true}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	lt := &LoggingTransport{
+		inner:  inner,
+		logger: logger,
+		level:  cfg.level,
+		logRaw: cfg.payloads,
+	}
+	// Pre-register a notification handler on the inner transport so that
+	// notifications are still logged even when the user never registers one
+	// on the wrapper.
+	inner.SetNotificationHandler(lt.handleNotification)
+	return lt
+}
+
+// Start delegates to the wrapped transport.
+func (l *LoggingTransport) Start(ctx context.Context) error {
+	return l.inner.Start(ctx)
+}
+
+// SendRequest forwards the request to the wrapped transport while logging
+// both the outgoing request and the incoming response (or error).
+func (l *LoggingTransport) SendRequest(ctx context.Context, request JSONRPCRequest) (*JSONRPCResponse, error) {
+	attrs := []slog.Attr{
+		slog.String("method", request.Method),
+		slog.Any("id", request.ID),
+	}
+	if l.logRaw && request.Params != nil {
+		attrs = append(attrs, slog.Any("params", request.Params))
+	}
+	l.log(ctx, "→ request", attrs...)
+
+	start := time.Now()
+	resp, err := l.inner.SendRequest(ctx, request)
+	duration := time.Since(start)
+
+	respAttrs := []slog.Attr{
+		slog.Any("id", request.ID),
+		slog.String("method", request.Method),
+		slog.Duration("duration", duration),
+	}
+	if err != nil {
+		respAttrs = append(respAttrs, slog.String("error", err.Error()))
+		l.log(ctx, "← response error", respAttrs...)
+		return nil, err
+	}
+	if resp != nil && resp.Error != nil {
+		respAttrs = append(respAttrs,
+			slog.Int("code", resp.Error.Code),
+			slog.String("error", resp.Error.Message),
+		)
+		l.log(ctx, "← response error", respAttrs...)
+		return resp, nil
+	}
+	if l.logRaw && resp != nil && len(resp.Result) > 0 {
+		respAttrs = append(respAttrs, slog.String("result", string(resp.Result)))
+	}
+	l.log(ctx, "← response", respAttrs...)
+	return resp, nil
+}
+
+// SendNotification forwards a notification to the wrapped transport and logs
+// the outgoing message.
+func (l *LoggingTransport) SendNotification(ctx context.Context, notification mcp.JSONRPCNotification) error {
+	attrs := []slog.Attr{slog.String("method", notification.Method)}
+	if l.logRaw {
+		if data, err := json.Marshal(notification.Params); err == nil && len(data) > 0 && string(data) != "null" {
+			attrs = append(attrs, slog.String("params", string(data)))
+		}
+	}
+	l.log(ctx, "→ notification", attrs...)
+
+	if err := l.inner.SendNotification(ctx, notification); err != nil {
+		l.log(ctx, "→ notification error",
+			slog.String("method", notification.Method),
+			slog.String("error", err.Error()),
+		)
+		return err
+	}
+	return nil
+}
+
+// SetNotificationHandler registers handler to receive notifications from the
+// server. The wrapper logs every incoming notification before forwarding it
+// to handler.
+func (l *LoggingTransport) SetNotificationHandler(handler func(notification mcp.JSONRPCNotification)) {
+	l.notifyMu.Lock()
+	defer l.notifyMu.Unlock()
+	l.onNotification = handler
+}
+
+// Close shuts down the wrapped transport.
+func (l *LoggingTransport) Close() error {
+	return l.inner.Close()
+}
+
+// GetSessionId returns the session id reported by the wrapped transport.
+func (l *LoggingTransport) GetSessionId() string {
+	return l.inner.GetSessionId()
+}
+
+func (l *LoggingTransport) handleNotification(notification mcp.JSONRPCNotification) {
+	attrs := []slog.Attr{slog.String("method", notification.Method)}
+	if l.logRaw {
+		if data, err := json.Marshal(notification.Params); err == nil && len(data) > 0 && string(data) != "null" {
+			attrs = append(attrs, slog.String("params", string(data)))
+		}
+	}
+	l.log(context.Background(), "← notification", attrs...)
+
+	l.notifyMu.RLock()
+	h := l.onNotification
+	l.notifyMu.RUnlock()
+	if h != nil {
+		h(notification)
+	}
+}
+
+func (l *LoggingTransport) log(ctx context.Context, msg string, attrs ...slog.Attr) {
+	if !l.logger.Enabled(ctx, l.level) {
+		return
+	}
+	l.logger.LogAttrs(ctx, l.level, msg, attrs...)
+}
+
+// loggingBidirTransport adds BidirectionalInterface support when the inner
+// transport implements it.
+type loggingBidirTransport struct {
+	*LoggingTransport
+	bidir BidirectionalInterface
+}
+
+// SetRequestHandler registers a handler for incoming server-to-client
+// requests. The wrapper logs each incoming request and the corresponding
+// outgoing response before delegating to handler.
+func (l *loggingBidirTransport) SetRequestHandler(handler RequestHandler) {
+	if handler == nil {
+		l.bidir.SetRequestHandler(nil)
+		return
+	}
+	wrapped := func(ctx context.Context, req JSONRPCRequest) (*JSONRPCResponse, error) {
+		attrs := []slog.Attr{
+			slog.String("method", req.Method),
+			slog.Any("id", req.ID),
+		}
+		if l.logRaw && req.Params != nil {
+			attrs = append(attrs, slog.Any("params", req.Params))
+		}
+		l.log(ctx, "← request", attrs...)
+
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		duration := time.Since(start)
+
+		respAttrs := []slog.Attr{
+			slog.Any("id", req.ID),
+			slog.String("method", req.Method),
+			slog.Duration("duration", duration),
+		}
+		if err != nil {
+			respAttrs = append(respAttrs, slog.String("error", err.Error()))
+			l.log(ctx, "→ response error", respAttrs...)
+			return nil, err
+		}
+		if resp != nil && resp.Error != nil {
+			respAttrs = append(respAttrs,
+				slog.Int("code", resp.Error.Code),
+				slog.String("error", resp.Error.Message),
+			)
+			l.log(ctx, "→ response error", respAttrs...)
+			return resp, nil
+		}
+		if l.logRaw && resp != nil && len(resp.Result) > 0 {
+			respAttrs = append(respAttrs, slog.String("result", string(resp.Result)))
+		}
+		l.log(ctx, "→ response", respAttrs...)
+		return resp, nil
+	}
+	l.bidir.SetRequestHandler(wrapped)
+}
+
+// loggingHTTPTransport adds HTTPConnection support when the inner transport
+// implements it.
+type loggingHTTPTransport struct {
+	*LoggingTransport
+	http HTTPConnection
+}
+
+// SetProtocolVersion forwards the negotiated protocol version to the wrapped
+// HTTP transport.
+func (l *loggingHTTPTransport) SetProtocolVersion(version string) {
+	l.http.SetProtocolVersion(version)
+}
+
+// loggingBidirHTTPTransport supports both BidirectionalInterface and
+// HTTPConnection.
+type loggingBidirHTTPTransport struct {
+	loggingBidirTransport
+	http HTTPConnection
+}
+
+// SetProtocolVersion forwards the negotiated protocol version to the wrapped
+// HTTP transport.
+func (l *loggingBidirHTTPTransport) SetProtocolVersion(version string) {
+	l.http.SetProtocolVersion(version)
+}

--- a/client/transport/logging.go
+++ b/client/transport/logging.go
@@ -27,9 +27,10 @@ func WithLoggingLevel(level slog.Level) LoggingOption {
 }
 
 // WithLoggingPayloads controls whether full JSON-RPC payloads (params,
-// result, error) are included in the structured log records. When disabled,
-// only message metadata (direction, method, id, duration) is logged. The
-// default is true.
+// result and JSON-RPC error code/message) are included in the structured
+// log records. When disabled, only message metadata (direction, method,
+// id, duration and the bare "← response error" / "→ response error"
+// marker for failed calls) is logged. The default is true.
 func WithLoggingPayloads(enabled bool) LoggingOption {
 	return func(c *loggingConfig) {
 		c.payloads = enabled
@@ -56,6 +57,14 @@ type LoggingTransport struct {
 // is used. If inner additionally implements BidirectionalInterface and/or
 // HTTPConnection, the returned wrapper also implements those interfaces, so
 // it can be used as a drop-in replacement.
+//
+// NewLogging installs its own notification handler on the inner transport
+// so that incoming notifications can be logged. Because [Interface] does
+// not expose a way to read the previously-registered handler, NewLogging
+// must be applied before any handler is registered on the inner transport;
+// otherwise the previously-registered handler will be displaced. Callers
+// that need to receive notifications should register their handler on the
+// returned wrapper, which will both log the notification and forward it.
 func NewLogging(inner Interface, logger *slog.Logger, opts ...LoggingOption) Interface {
 	base := newLoggingTransport(inner, logger, opts...)
 
@@ -130,10 +139,12 @@ func (l *LoggingTransport) SendRequest(ctx context.Context, request JSONRPCReque
 		return nil, err
 	}
 	if resp != nil && resp.Error != nil {
-		respAttrs = append(respAttrs,
-			slog.Int("code", resp.Error.Code),
-			slog.String("error", resp.Error.Message),
-		)
+		if l.logRaw {
+			respAttrs = append(respAttrs,
+				slog.Int("code", resp.Error.Code),
+				slog.String("error", resp.Error.Message),
+			)
+		}
 		l.log(ctx, "← response error", respAttrs...)
 		return resp, nil
 	}
@@ -248,10 +259,12 @@ func (l *loggingBidirTransport) SetRequestHandler(handler RequestHandler) {
 			return nil, err
 		}
 		if resp != nil && resp.Error != nil {
-			respAttrs = append(respAttrs,
-				slog.Int("code", resp.Error.Code),
-				slog.String("error", resp.Error.Message),
-			)
+			if l.logRaw {
+				respAttrs = append(respAttrs,
+					slog.Int("code", resp.Error.Code),
+					slog.String("error", resp.Error.Message),
+				)
+			}
 			l.log(ctx, "→ response error", respAttrs...)
 			return resp, nil
 		}

--- a/client/transport/logging_test.go
+++ b/client/transport/logging_test.go
@@ -467,6 +467,76 @@ func TestLoggingTransport_DisablePayloads(t *testing.T) {
 	assert.False(t, hasResult, "result must be omitted when payloads are disabled")
 }
 
+func TestLoggingTransport_DisablePayloadsHidesJSONRPCError(t *testing.T) {
+	inner := &fakeTransport{
+		requestResp: &JSONRPCResponse{
+			JSONRPC: mcp.JSONRPC_VERSION,
+			ID:      mcp.NewRequestId(int64(1)),
+			Error: &mcp.JSONRPCErrorDetails{
+				Code:    mcp.METHOD_NOT_FOUND,
+				Message: "sensitive: user 'alice@example.com' not found",
+			},
+		},
+	}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger, WithLoggingPayloads(false))
+
+	resp, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "tools/missing",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error, "error must still be returned to the caller")
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	assert.Equal(t, "← response error", records[1].Message,
+		"the error marker should still be emitted so the failure is visible")
+	respAttrs := attrsOf(records[1])
+	_, hasCode := respAttrs["code"]
+	assert.False(t, hasCode, "JSON-RPC error code must be omitted when payloads are disabled")
+	_, hasErr := respAttrs["error"]
+	assert.False(t, hasErr, "JSON-RPC error message must be omitted when payloads are disabled")
+}
+
+func TestLoggingTransport_DisablePayloadsBidirectionalError(t *testing.T) {
+	inner := &fakeBidirTransport{}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger, WithLoggingPayloads(false)).(BidirectionalInterface)
+
+	transport.SetRequestHandler(func(_ context.Context, req JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{
+			JSONRPC: mcp.JSONRPC_VERSION,
+			ID:      req.ID,
+			Error: &mcp.JSONRPCErrorDetails{
+				Code:    mcp.INVALID_PARAMS,
+				Message: "sensitive bidirectional error message",
+			},
+		}, nil
+	})
+	require.NotNil(t, inner.requestHandler)
+
+	_, err := inner.requestHandler(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "sampling/createMessage",
+	})
+	require.NoError(t, err)
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	assert.Equal(t, "→ response error", records[1].Message)
+	respAttrs := attrsOf(records[1])
+	_, hasCode := respAttrs["code"]
+	assert.False(t, hasCode)
+	_, hasErr := respAttrs["error"]
+	assert.False(t, hasErr)
+}
+
 func TestLoggingTransport_LevelFilteredEarly(t *testing.T) {
 	// When the logger has a higher minimum level than the transport's level,
 	// no records should be emitted.

--- a/client/transport/logging_test.go
+++ b/client/transport/logging_test.go
@@ -1,0 +1,494 @@
+package transport
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// captureHandler is a slog.Handler that records every emitted record so
+// tests can assert on the structured output of the LoggingTransport.
+type captureHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+	level   slog.Level
+}
+
+func newCaptureHandler() *captureHandler {
+	return &captureHandler{level: slog.LevelDebug}
+}
+
+func (h *captureHandler) Enabled(_ context.Context, level slog.Level) bool {
+	return level >= h.level
+}
+
+func (h *captureHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r.Clone())
+	return nil
+}
+
+func (h *captureHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h *captureHandler) WithGroup(string) slog.Handler      { return h }
+
+func (h *captureHandler) snapshot() []slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	out := make([]slog.Record, len(h.records))
+	copy(out, h.records)
+	return out
+}
+
+func (h *captureHandler) reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = nil
+}
+
+func attrsOf(r slog.Record) map[string]slog.Value {
+	m := make(map[string]slog.Value)
+	r.Attrs(func(a slog.Attr) bool {
+		m[a.Key] = a.Value
+		return true
+	})
+	return m
+}
+
+// fakeTransport is a minimal Interface implementation used to drive the
+// LoggingTransport in tests.
+type fakeTransport struct {
+	startErr        error
+	requestResp     *JSONRPCResponse
+	requestErr      error
+	notificationErr error
+	notifyHandler   func(notification mcp.JSONRPCNotification)
+	sentRequests    []JSONRPCRequest
+	sentNotifs      []mcp.JSONRPCNotification
+	sessionID       string
+	closed          bool
+}
+
+func (f *fakeTransport) Start(_ context.Context) error { return f.startErr }
+
+func (f *fakeTransport) SendRequest(_ context.Context, req JSONRPCRequest) (*JSONRPCResponse, error) {
+	f.sentRequests = append(f.sentRequests, req)
+	if f.requestErr != nil {
+		return nil, f.requestErr
+	}
+	return f.requestResp, nil
+}
+
+func (f *fakeTransport) SendNotification(_ context.Context, n mcp.JSONRPCNotification) error {
+	f.sentNotifs = append(f.sentNotifs, n)
+	return f.notificationErr
+}
+
+func (f *fakeTransport) SetNotificationHandler(handler func(notification mcp.JSONRPCNotification)) {
+	f.notifyHandler = handler
+}
+
+func (f *fakeTransport) Close() error {
+	f.closed = true
+	return nil
+}
+
+func (f *fakeTransport) GetSessionId() string { return f.sessionID }
+
+// fakeBidirTransport additionally implements BidirectionalInterface.
+type fakeBidirTransport struct {
+	fakeTransport
+	requestHandler RequestHandler
+}
+
+func (f *fakeBidirTransport) SetRequestHandler(handler RequestHandler) {
+	f.requestHandler = handler
+}
+
+// fakeHTTPTransport additionally implements HTTPConnection.
+type fakeHTTPTransport struct {
+	fakeTransport
+	protocolVersion string
+}
+
+func (f *fakeHTTPTransport) SetProtocolVersion(version string) {
+	f.protocolVersion = version
+}
+
+// fakeBidirHTTPTransport implements both optional interfaces.
+type fakeBidirHTTPTransport struct {
+	fakeBidirTransport
+	protocolVersion string
+}
+
+func (f *fakeBidirHTTPTransport) SetProtocolVersion(version string) {
+	f.protocolVersion = version
+}
+
+func TestLoggingTransport_BasicInterface(t *testing.T) {
+	inner := &fakeTransport{
+		requestResp: &JSONRPCResponse{
+			JSONRPC: mcp.JSONRPC_VERSION,
+			ID:      mcp.NewRequestId(int64(1)),
+			Result:  json.RawMessage(`{"ok":true}`),
+		},
+		sessionID: "session-1",
+	}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+
+	transport := NewLogging(inner, logger)
+
+	// Should not satisfy optional interfaces.
+	_, isBidir := transport.(BidirectionalInterface)
+	assert.False(t, isBidir, "plain transport should not implement BidirectionalInterface")
+	_, isHTTP := transport.(HTTPConnection)
+	assert.False(t, isHTTP, "plain transport should not implement HTTPConnection")
+
+	require.NoError(t, transport.Start(t.Context()))
+
+	resp, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "tools/list",
+		Params:  map[string]any{"cursor": "abc"},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	require.NoError(t, transport.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		Notification: mcp.Notification{
+			Method: "notifications/initialized",
+		},
+	}))
+
+	assert.Equal(t, "session-1", transport.GetSessionId())
+	require.NoError(t, transport.Close())
+	assert.True(t, inner.closed)
+
+	records := handler.snapshot()
+	require.Len(t, records, 3)
+
+	// Outgoing request
+	assert.Equal(t, "→ request", records[0].Message)
+	reqAttrs := attrsOf(records[0])
+	assert.Equal(t, "tools/list", reqAttrs["method"].String())
+	require.Contains(t, reqAttrs, "id")
+	require.Contains(t, reqAttrs, "params")
+
+	// Incoming response
+	assert.Equal(t, "← response", records[1].Message)
+	respAttrs := attrsOf(records[1])
+	assert.Equal(t, "tools/list", respAttrs["method"].String())
+	require.Contains(t, respAttrs, "duration")
+	require.Contains(t, respAttrs, "result")
+	assert.Equal(t, `{"ok":true}`, respAttrs["result"].String())
+
+	// Outgoing notification
+	assert.Equal(t, "→ notification", records[2].Message)
+	notifAttrs := attrsOf(records[2])
+	assert.Equal(t, "notifications/initialized", notifAttrs["method"].String())
+}
+
+func TestLoggingTransport_LogsRequestErrors(t *testing.T) {
+	inner := &fakeTransport{
+		requestErr: errors.New("boom"),
+	}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+
+	transport := NewLogging(inner, logger)
+	_, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(7)),
+		Method:  "tools/call",
+	})
+	require.Error(t, err)
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	assert.Equal(t, "→ request", records[0].Message)
+	assert.Equal(t, "← response error", records[1].Message)
+	errAttrs := attrsOf(records[1])
+	assert.Equal(t, "boom", errAttrs["error"].String())
+}
+
+func TestLoggingTransport_LogsJSONRPCError(t *testing.T) {
+	inner := &fakeTransport{
+		requestResp: &JSONRPCResponse{
+			JSONRPC: mcp.JSONRPC_VERSION,
+			ID:      mcp.NewRequestId(int64(2)),
+			Error: &mcp.JSONRPCErrorDetails{
+				Code:    mcp.METHOD_NOT_FOUND,
+				Message: "Method not found",
+			},
+		},
+	}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger)
+
+	resp, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(2)),
+		Method:  "tools/missing",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Error)
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	assert.Equal(t, "← response error", records[1].Message)
+	errAttrs := attrsOf(records[1])
+	assert.Equal(t, int64(mcp.METHOD_NOT_FOUND), errAttrs["code"].Int64())
+	assert.Equal(t, "Method not found", errAttrs["error"].String())
+}
+
+func TestLoggingTransport_LogsIncomingNotifications(t *testing.T) {
+	inner := &fakeTransport{}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger)
+
+	var received mcp.JSONRPCNotification
+	called := make(chan struct{})
+	transport.SetNotificationHandler(func(n mcp.JSONRPCNotification) {
+		received = n
+		close(called)
+	})
+
+	require.NotNil(t, inner.notifyHandler, "wrapper should register a handler on inner transport")
+	notif := mcp.JSONRPCNotification{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		Notification: mcp.Notification{
+			Method: "notifications/tools/list_changed",
+		},
+	}
+	inner.notifyHandler(notif)
+	<-called
+
+	assert.Equal(t, notif.Method, received.Method)
+
+	records := handler.snapshot()
+	require.Len(t, records, 1)
+	assert.Equal(t, "← notification", records[0].Message)
+	attrs := attrsOf(records[0])
+	assert.Equal(t, "notifications/tools/list_changed", attrs["method"].String())
+}
+
+func TestLoggingTransport_NotificationDeliveredWithoutHandler(t *testing.T) {
+	inner := &fakeTransport{}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger)
+	// Sanity: still wraps even if no user handler.
+	require.NotNil(t, transport)
+	require.NotNil(t, inner.notifyHandler)
+
+	inner.notifyHandler(mcp.JSONRPCNotification{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		Notification: mcp.Notification{
+			Method: "notifications/progress",
+		},
+	})
+
+	records := handler.snapshot()
+	require.Len(t, records, 1)
+	assert.Equal(t, "← notification", records[0].Message)
+}
+
+func TestLoggingTransport_BidirectionalPassThrough(t *testing.T) {
+	inner := &fakeBidirTransport{}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+
+	transport := NewLogging(inner, logger)
+	bidir, ok := transport.(BidirectionalInterface)
+	require.True(t, ok, "wrapper around BidirectionalInterface must implement it")
+
+	bidir.SetRequestHandler(func(_ context.Context, req JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{
+			JSONRPC: mcp.JSONRPC_VERSION,
+			ID:      req.ID,
+			Result:  json.RawMessage(`{"echo":true}`),
+		}, nil
+	})
+	require.NotNil(t, inner.requestHandler)
+
+	resp, err := inner.requestHandler(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(99)),
+		Method:  "sampling/createMessage",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	assert.Equal(t, "← request", records[0].Message)
+	assert.Equal(t, "→ response", records[1].Message)
+	respAttrs := attrsOf(records[1])
+	assert.Equal(t, `{"echo":true}`, respAttrs["result"].String())
+}
+
+func TestLoggingTransport_BidirectionalHandlerError(t *testing.T) {
+	inner := &fakeBidirTransport{}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger).(BidirectionalInterface)
+
+	transport.SetRequestHandler(func(_ context.Context, _ JSONRPCRequest) (*JSONRPCResponse, error) {
+		return nil, fmt.Errorf("nope")
+	})
+	_, err := inner.requestHandler(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "sampling/createMessage",
+	})
+	require.Error(t, err)
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	assert.Equal(t, "→ response error", records[1].Message)
+
+	// Resetting to nil should clear the handler on the inner.
+	handler.reset()
+	transport.SetRequestHandler(nil)
+	assert.Nil(t, inner.requestHandler)
+}
+
+func TestLoggingTransport_HTTPPassThrough(t *testing.T) {
+	inner := &fakeHTTPTransport{}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+
+	transport := NewLogging(inner, logger)
+	httpConn, ok := transport.(HTTPConnection)
+	require.True(t, ok, "wrapper around HTTPConnection must implement it")
+
+	httpConn.SetProtocolVersion("2025-06-18")
+	assert.Equal(t, "2025-06-18", inner.protocolVersion)
+
+	// Plain wrapper must NOT advertise BidirectionalInterface.
+	_, isBidir := transport.(BidirectionalInterface)
+	assert.False(t, isBidir)
+}
+
+func TestLoggingTransport_BidirectionalAndHTTP(t *testing.T) {
+	inner := &fakeBidirHTTPTransport{}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+
+	transport := NewLogging(inner, logger)
+	httpConn, ok := transport.(HTTPConnection)
+	require.True(t, ok)
+	bidir, ok := transport.(BidirectionalInterface)
+	require.True(t, ok)
+
+	httpConn.SetProtocolVersion("2025-06-18")
+	assert.Equal(t, "2025-06-18", inner.protocolVersion)
+
+	bidir.SetRequestHandler(func(_ context.Context, req JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{ID: req.ID, JSONRPC: mcp.JSONRPC_VERSION, Result: json.RawMessage(`null`)}, nil
+	})
+	require.NotNil(t, inner.requestHandler)
+}
+
+func TestLoggingTransport_NilLoggerUsesDefault(t *testing.T) {
+	inner := &fakeTransport{requestResp: &JSONRPCResponse{JSONRPC: mcp.JSONRPC_VERSION, ID: mcp.NewRequestId(int64(1))}}
+	transport := NewLogging(inner, nil)
+
+	_, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "ping",
+	})
+	require.NoError(t, err)
+}
+
+func TestLoggingTransport_LevelOption(t *testing.T) {
+	inner := &fakeTransport{requestResp: &JSONRPCResponse{JSONRPC: mcp.JSONRPC_VERSION, ID: mcp.NewRequestId(int64(1))}}
+	handler := newCaptureHandler()
+	handler.level = slog.LevelInfo
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger, WithLoggingLevel(slog.LevelInfo))
+
+	_, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "ping",
+	})
+	require.NoError(t, err)
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	for _, r := range records {
+		assert.Equal(t, slog.LevelInfo, r.Level)
+	}
+}
+
+func TestLoggingTransport_DisablePayloads(t *testing.T) {
+	inner := &fakeTransport{
+		requestResp: &JSONRPCResponse{
+			JSONRPC: mcp.JSONRPC_VERSION,
+			ID:      mcp.NewRequestId(int64(1)),
+			Result:  json.RawMessage(`{"ok":true}`),
+		},
+	}
+	handler := newCaptureHandler()
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger, WithLoggingPayloads(false))
+
+	_, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "ping",
+		Params:  map[string]any{"x": 1},
+	})
+	require.NoError(t, err)
+
+	records := handler.snapshot()
+	require.Len(t, records, 2)
+	reqAttrs := attrsOf(records[0])
+	_, hasParams := reqAttrs["params"]
+	assert.False(t, hasParams, "params must be omitted when payloads are disabled")
+	respAttrs := attrsOf(records[1])
+	_, hasResult := respAttrs["result"]
+	assert.False(t, hasResult, "result must be omitted when payloads are disabled")
+}
+
+func TestLoggingTransport_LevelFilteredEarly(t *testing.T) {
+	// When the logger has a higher minimum level than the transport's level,
+	// no records should be emitted.
+	inner := &fakeTransport{requestResp: &JSONRPCResponse{JSONRPC: mcp.JSONRPC_VERSION, ID: mcp.NewRequestId(int64(1))}}
+	handler := newCaptureHandler()
+	handler.level = slog.LevelWarn
+	logger := slog.New(handler)
+	transport := NewLogging(inner, logger) // default debug level
+
+	_, err := transport.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "ping",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, handler.snapshot())
+}
+
+func TestLoggingTransport_StartError(t *testing.T) {
+	inner := &fakeTransport{startErr: errors.New("cannot start")}
+	transport := NewLogging(inner, slog.New(newCaptureHandler()))
+	err := transport.Start(t.Context())
+	require.Error(t, err)
+	assert.Equal(t, "cannot start", err.Error())
+}

--- a/www/docs/pages/clients/transports.mdx
+++ b/www/docs/pages/clients/transports.mdx
@@ -1122,3 +1122,55 @@ func (myCustomLogger) Errorf(format string, args ...any) {
     // TODO
 }
 ```
+
+### JSON-RPC Tracing with `LoggingTransport`
+
+For debugging the wire protocol itself, wrap any transport with
+`transport.NewLogging`. The wrapper is a transparent decorator: it implements
+`transport.Interface` and additionally `BidirectionalInterface` /
+`HTTPConnection` whenever the inner transport does, so type assertions in the
+client continue to behave as expected.
+
+```go
+import (
+    "log/slog"
+    "os"
+
+    "github.com/mark3labs/mcp-go/client"
+    "github.com/mark3labs/mcp-go/client/transport"
+)
+
+func tracedClient() (*client.Client, error) {
+    inner, err := transport.NewStdio("my-server", nil)
+    if err != nil {
+        return nil, err
+    }
+
+    logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+        Level: slog.LevelDebug,
+    }))
+
+    // Wrap the transport so every JSON-RPC message is logged.
+    logged := transport.NewLogging(inner, logger,
+        transport.WithLoggingLevel(slog.LevelDebug),
+        transport.WithLoggingPayloads(true), // include params/result bodies
+    )
+
+    return client.NewClient(logged), nil
+}
+```
+
+Each record carries the message direction, method name, request id and (for
+responses) the duration of the round-trip:
+
+```text
+level=DEBUG msg="→ request"  method=initialize id=1
+level=DEBUG msg="← response" method=initialize id=1 duration=12ms
+level=DEBUG msg="→ request"  method=tools/list id=2
+level=DEBUG msg="← response" method=tools/list id=2 duration=3ms
+level=DEBUG msg="← notification" method=notifications/tools/list_changed
+```
+
+Use `WithLoggingPayloads(false)` to suppress message bodies when only the
+method/id metadata is required, and `WithLoggingLevel` to change the slog
+level at which records are emitted.


### PR DESCRIPTION
## Description

Adds `transport.LoggingTransport`, a transparent decorator that wraps any client `transport.Interface` and emits a structured `slog` record for every JSON-RPC message that flows through it. The wrapper makes it trivial to debug MCP client/server traffic without polluting production transports or hand-rolling a full `Interface` implementation.

`NewLogging` inspects the inner transport at construction time and returns a wrapper that preserves its capability set: when the inner transport implements `BidirectionalInterface` and/or `HTTPConnection`, the returned value implements them too, so the existing type assertions in `client.Client` (sampling/elicitation/roots, HTTP protocol-version negotiation) keep working unchanged.

Each record carries the message direction, method name, request id and round-trip duration; payloads (params/result) are included by default and can be suppressed for noisier production-style logging.

Before:

```go
stdio, _ := transport.NewStdio("my-server", nil)
c := client.NewClient(stdio) // no visibility into the wire protocol
```

After:

```go
stdio, _ := transport.NewStdio("my-server", nil)
logged := transport.NewLogging(stdio, slog.Default(),
    transport.WithLoggingLevel(slog.LevelDebug),
    transport.WithLoggingPayloads(true),
)
c := client.NewClient(logged)
// level=DEBUG msg="→ request"  method=initialize id=1
// level=DEBUG msg="← response" method=initialize id=1 duration=12ms
```

Fixes #813

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

**New files**

- `client/transport/logging.go` — `LoggingTransport`, `NewLogging`, the `WithLoggingLevel` / `WithLoggingPayloads` options, and three internal wrapper types that conditionally expose `BidirectionalInterface` and/or `HTTPConnection` based on the inner transport.
- `client/transport/logging_test.go` — 14 unit tests covering plain/bidirectional/HTTP/combined wrapping, request and notification logging in both directions, JSON-RPC and transport-level error paths, payload suppression, level filtering, nil-logger fallback and `Start` error propagation.

**Modified files**

- `www/docs/pages/clients/transports.mdx` — adds a *JSON-RPC Tracing with `LoggingTransport`* subsection under *Logging Configuration* with usage example and sample log output.

**Backward compatibility**

- Purely additive: no existing exported symbols, signatures or behaviours are modified. Users who do not call `NewLogging` are unaffected.
- The wrapper preserves the inner transport's interface set, so client features that rely on `BidirectionalInterface` or `HTTPConnection` (sampling, elicitation, roots, HTTP protocol-version negotiation) continue to work when the wrapper is inserted.

**Verification**

- `go test ./... -race` passes.
- `golangci-lint run` reports 0 issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * JSON‑RPC traffic logging: trace requests, responses, and notifications with configurable log level and optional inclusion of params/results; preserves compatibility with bidirectional and HTTP transports.
* **Documentation**
  * Added guide for enabling and configuring JSON‑RPC request/response tracing.
* **Tests**
  * Added comprehensive test suite validating logging behavior, payload options, level filtering, and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->