### PR TITLE
feat(mcp): add SchemaCache for stateless/serverless deployments

### DIFF
--- a/mcp/schema_cache.go
+++ b/mcp/schema_cache.go
@@ -1,0 +1,372 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"sync"
+
+	"github.com/google/jsonschema-go/jsonschema"
+)
+
+// SchemaCache stores pre-computed JSON schemas for tool input/output types.
+//
+// SchemaCache is intended to amortise the cost of JSON-Schema reflection in
+// stateless or serverless deployments (e.g., AWS Lambda, Google Cloud
+// Functions) where servers are reconstructed on every invocation. Schemas can
+// be warmed once at build time, persisted to disk via [SchemaCache.Save], and
+// reloaded at start-up via [LoadSchemaCache]. Cached schemas are then consumed
+// by [WithCachedInputSchema] and [WithCachedOutputSchema] in lieu of the
+// reflection performed by [WithInputSchema] and [WithOutputSchema].
+//
+// SchemaCache is safe for concurrent use by multiple goroutines.
+type SchemaCache struct {
+	mu      sync.RWMutex
+	schemas map[string]json.RawMessage
+}
+
+// NewSchemaCache creates a new empty SchemaCache.
+func NewSchemaCache() *SchemaCache {
+	return &SchemaCache{schemas: make(map[string]json.RawMessage)}
+}
+
+// Warm stores the JSON schema for the given type name. Schemas are typically
+// produced by [SchemaFor]. Passing a nil schema removes any existing entry
+// for typeName.
+func (c *SchemaCache) Warm(typeName string, schema map[string]any) {
+	if c == nil {
+		return
+	}
+	if schema == nil {
+		c.mu.Lock()
+		delete(c.schemas, typeName)
+		c.mu.Unlock()
+		return
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return
+	}
+	c.WarmRaw(typeName, raw)
+}
+
+// WarmRaw stores a pre-marshaled JSON schema under the given type name.
+// This avoids an unmarshal/marshal round-trip when callers already hold the
+// schema as raw JSON. Passing a nil or empty schema removes any existing
+// entry for typeName.
+func (c *SchemaCache) WarmRaw(typeName string, schema json.RawMessage) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.schemas == nil {
+		c.schemas = make(map[string]json.RawMessage)
+	}
+	if len(schema) == 0 {
+		delete(c.schemas, typeName)
+		return
+	}
+	// Copy to avoid aliasing the caller's slice.
+	clone := make(json.RawMessage, len(schema))
+	copy(clone, schema)
+	c.schemas[typeName] = clone
+}
+
+// Get retrieves a cached schema by type name as a generic map. The second
+// return value reports whether the entry was present.
+func (c *SchemaCache) Get(typeName string) (map[string]any, bool) {
+	raw, ok := c.GetRaw(typeName)
+	if !ok {
+		return nil, false
+	}
+	out := make(map[string]any)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+// GetRaw retrieves a cached schema by type name as raw JSON. The returned
+// slice is a copy and may be safely mutated by the caller.
+func (c *SchemaCache) GetRaw(typeName string) (json.RawMessage, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	raw, ok := c.schemas[typeName]
+	if !ok {
+		return nil, false
+	}
+	clone := make(json.RawMessage, len(raw))
+	copy(clone, raw)
+	return clone, true
+}
+
+// Has reports whether a schema is cached under typeName.
+func (c *SchemaCache) Has(typeName string) bool {
+	if c == nil {
+		return false
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	_, ok := c.schemas[typeName]
+	return ok
+}
+
+// Len returns the number of cached schemas.
+func (c *SchemaCache) Len() int {
+	if c == nil {
+		return 0
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.schemas)
+}
+
+// Keys returns the cached type names in sorted order. The result is a fresh
+// slice and may be modified by the caller.
+func (c *SchemaCache) Keys() []string {
+	if c == nil {
+		return nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	keys := make([]string, 0, len(c.schemas))
+	for k := range c.schemas {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// MarshalJSON serialises the cache as a JSON object whose keys are type
+// names and whose values are the cached JSON schemas. Keys are emitted in
+// sorted order so that the encoded form is deterministic and diff-friendly.
+func (c *SchemaCache) MarshalJSON() ([]byte, error) {
+	if c == nil {
+		return []byte("{}"), nil
+	}
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	keys := make([]string, 0, len(c.schemas))
+	for k := range c.schemas {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	buf := make([]byte, 0, 64+len(c.schemas)*64)
+	buf = append(buf, '{')
+	for i, k := range keys {
+		if i > 0 {
+			buf = append(buf, ',')
+		}
+		keyBytes, err := json.Marshal(k)
+		if err != nil {
+			return nil, fmt.Errorf("marshal schema cache key: %w", err)
+		}
+		buf = append(buf, keyBytes...)
+		buf = append(buf, ':')
+		buf = append(buf, c.schemas[k]...)
+	}
+	buf = append(buf, '}')
+	return buf, nil
+}
+
+// UnmarshalJSON loads a previously serialised cache, replacing any existing
+// contents. The input must be a JSON object whose values are themselves JSON
+// schemas; values are stored verbatim as raw JSON.
+func (c *SchemaCache) UnmarshalJSON(data []byte) error {
+	if c == nil {
+		return fmt.Errorf("mcp: SchemaCache.UnmarshalJSON on nil receiver")
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return fmt.Errorf("decode schema cache: %w", err)
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.schemas = make(map[string]json.RawMessage, len(raw))
+	for k, v := range raw {
+		clone := make(json.RawMessage, len(v))
+		copy(clone, v)
+		c.schemas[k] = clone
+	}
+	return nil
+}
+
+// Save writes the cache to a file as JSON. Parent directories are created if
+// needed. The file is written atomically by writing to a temporary sibling
+// and renaming it into place.
+func (c *SchemaCache) Save(path string) error {
+	if c == nil {
+		return fmt.Errorf("mcp: SchemaCache.Save on nil receiver")
+	}
+	data, err := c.MarshalJSON()
+	if err != nil {
+		return err
+	}
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create schema cache directory: %w", err)
+		}
+	}
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".schema-cache-*.json")
+	if err != nil {
+		return fmt.Errorf("create temp schema cache file: %w", err)
+	}
+	tmpName := tmp.Name()
+	cleanup := func() { _ = os.Remove(tmpName) }
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		cleanup()
+		return fmt.Errorf("write schema cache: %w", err)
+	}
+	if err := tmp.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("close schema cache: %w", err)
+	}
+	if err := os.Rename(tmpName, path); err != nil {
+		cleanup()
+		return fmt.Errorf("rename schema cache into place: %w", err)
+	}
+	return nil
+}
+
+// LoadSchemaCache reads a cache from a file produced by [SchemaCache.Save].
+func LoadSchemaCache(path string) (*SchemaCache, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read schema cache: %w", err)
+	}
+	c := NewSchemaCache()
+	if err := c.UnmarshalJSON(data); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// TypeKey returns the canonical cache key for the Go type T as derived from
+// reflection. The key is the package-qualified type name (e.g.
+// "main.WeatherInput"). Renaming or moving the type will change this key, so
+// callers that need a stable identifier across refactors should pass an
+// explicit key to [SchemaCache.Warm] and [WithCachedInputSchemaKey].
+func TypeKey[T any]() string {
+	return reflect.TypeFor[T]().String()
+}
+
+// SchemaFor returns the JSON schema generated for the Go type T, formatted as
+// a generic map suitable for [SchemaCache.Warm]. It returns nil if reflection
+// or marshalling fails. Use [SchemaForRaw] when an error is desired.
+func SchemaFor[T any]() map[string]any {
+	raw, err := SchemaForRaw[T]()
+	if err != nil {
+		return nil
+	}
+	out := make(map[string]any)
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil
+	}
+	return out
+}
+
+// SchemaForRaw returns the JSON schema generated for the Go type T as raw
+// JSON. It is the lower-level building block underlying [SchemaFor],
+// [WithInputSchema] and [WithOutputSchema].
+func SchemaForRaw[T any]() (json.RawMessage, error) {
+	schema, err := jsonschema.For[T](&jsonschema.ForOptions{IgnoreInvalidTypes: true})
+	if err != nil {
+		return nil, fmt.Errorf("generate schema: %w", err)
+	}
+	raw, err := json.Marshal(schema)
+	if err != nil {
+		return nil, fmt.Errorf("marshal schema: %w", err)
+	}
+	return raw, nil
+}
+
+// WarmFor computes the schema for T via reflection and stores it in cache.
+// If key is provided, the first non-empty entry is used as the cache key;
+// otherwise [TypeKey] is used. WarmFor is a no-op when cache is nil. It
+// returns an error only when schema generation itself fails.
+func WarmFor[T any](cache *SchemaCache, key ...string) error {
+	if cache == nil {
+		return nil
+	}
+	raw, err := SchemaForRaw[T]()
+	if err != nil {
+		return err
+	}
+	k := TypeKey[T]()
+	for _, candidate := range key {
+		if candidate != "" {
+			k = candidate
+			break
+		}
+	}
+	cache.WarmRaw(k, raw)
+	return nil
+}
+
+// WithCachedInputSchema is a cache-aware variant of [WithInputSchema]. It
+// looks up the schema for T in cache using [TypeKey]; on a miss it falls
+// back to reflection and stores the freshly computed schema back into the
+// cache so that subsequent invocations are served from memory. Passing a nil
+// cache is equivalent to [WithInputSchema].
+func WithCachedInputSchema[T any](cache *SchemaCache) ToolOption {
+	return WithCachedInputSchemaKey[T](cache, TypeKey[T]())
+}
+
+// WithCachedInputSchemaKey is a variant of [WithCachedInputSchema] that uses
+// an explicit cache key instead of one derived from T's type name. Use this
+// when stability of the key across renames or package moves matters.
+func WithCachedInputSchemaKey[T any](cache *SchemaCache, key string) ToolOption {
+	return func(t *Tool) {
+		raw, ok := cache.GetRaw(key)
+		if !ok {
+			fresh, err := SchemaForRaw[T]()
+			if err != nil {
+				return
+			}
+			raw = fresh
+			cache.WarmRaw(key, fresh)
+		}
+		t.InputSchema.Type = ""
+		t.RawInputSchema = raw
+	}
+}
+
+// WithCachedOutputSchema is a cache-aware variant of [WithOutputSchema]. It
+// looks up the schema for T in cache using [TypeKey]; on a miss it falls
+// back to reflection and stores the freshly computed schema back into the
+// cache. Passing a nil cache is equivalent to [WithOutputSchema].
+func WithCachedOutputSchema[T any](cache *SchemaCache) ToolOption {
+	return WithCachedOutputSchemaKey[T](cache, TypeKey[T]())
+}
+
+// WithCachedOutputSchemaKey is a variant of [WithCachedOutputSchema] that
+// uses an explicit cache key instead of one derived from T's type name.
+func WithCachedOutputSchemaKey[T any](cache *SchemaCache, key string) ToolOption {
+	return func(t *Tool) {
+		raw, ok := cache.GetRaw(key)
+		if !ok {
+			fresh, err := SchemaForRaw[T]()
+			if err != nil {
+				return
+			}
+			raw = fresh
+			cache.WarmRaw(key, fresh)
+		}
+		if err := json.Unmarshal(raw, &t.OutputSchema); err != nil {
+			return
+		}
+		// Always set the type to "object" as of the current MCP spec.
+		// https://modelcontextprotocol.io/specification/2025-06-18/server/tools#output-schema
+		t.OutputSchema.Type = "object"
+	}
+}

--- a/mcp/schema_cache.go
+++ b/mcp/schema_cache.go
@@ -325,16 +325,29 @@ func WithCachedInputSchema[T any](cache *SchemaCache) ToolOption {
 // WithCachedInputSchemaKey is a variant of [WithCachedInputSchema] that uses
 // an explicit cache key instead of one derived from T's type name. Use this
 // when stability of the key across renames or package moves matters.
+//
+// An empty key disables the cache entirely for this call: the schema is
+// always reflected fresh and never read from or written to cache. This
+// mirrors [WarmFor] and prevents distinct types from colliding on a shared
+// empty-string cache slot.
 func WithCachedInputSchemaKey[T any](cache *SchemaCache, key string) ToolOption {
 	return func(t *Tool) {
-		raw, ok := cache.GetRaw(key)
+		var (
+			raw json.RawMessage
+			ok  bool
+		)
+		if key != "" {
+			raw, ok = cache.GetRaw(key)
+		}
 		if !ok {
 			fresh, err := SchemaForRaw[T]()
 			if err != nil {
 				return
 			}
 			raw = fresh
-			cache.WarmRaw(key, fresh)
+			if key != "" {
+				cache.WarmRaw(key, fresh)
+			}
 		}
 		t.InputSchema.Type = ""
 		t.RawInputSchema = raw
@@ -351,16 +364,29 @@ func WithCachedOutputSchema[T any](cache *SchemaCache) ToolOption {
 
 // WithCachedOutputSchemaKey is a variant of [WithCachedOutputSchema] that
 // uses an explicit cache key instead of one derived from T's type name.
+//
+// An empty key disables the cache entirely for this call: the schema is
+// always reflected fresh and never read from or written to cache. This
+// mirrors [WarmFor] and prevents distinct types from colliding on a shared
+// empty-string cache slot.
 func WithCachedOutputSchemaKey[T any](cache *SchemaCache, key string) ToolOption {
 	return func(t *Tool) {
-		raw, ok := cache.GetRaw(key)
+		var (
+			raw json.RawMessage
+			ok  bool
+		)
+		if key != "" {
+			raw, ok = cache.GetRaw(key)
+		}
 		if !ok {
 			fresh, err := SchemaForRaw[T]()
 			if err != nil {
 				return
 			}
 			raw = fresh
-			cache.WarmRaw(key, fresh)
+			if key != "" {
+				cache.WarmRaw(key, fresh)
+			}
 		}
 		if err := json.Unmarshal(raw, &t.OutputSchema); err != nil {
 			return

--- a/mcp/schema_cache_test.go
+++ b/mcp/schema_cache_test.go
@@ -1,0 +1,323 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type schemaCacheTestInput struct {
+	Name string `json:"name" jsonschema:"Person's name"`
+	Age  int    `json:"age" jsonschema:"Person's age"`
+}
+
+type schemaCacheTestOutput struct {
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+}
+
+func TestSchemaCache_WarmAndGet(t *testing.T) {
+	c := NewSchemaCache()
+	require.Equal(t, 0, c.Len())
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+	c.Warm("Foo", schema)
+
+	assert.True(t, c.Has("Foo"))
+	assert.False(t, c.Has("Bar"))
+	assert.Equal(t, 1, c.Len())
+	assert.Equal(t, []string{"Foo"}, c.Keys())
+
+	got, ok := c.Get("Foo")
+	require.True(t, ok)
+	assert.Equal(t, "object", got["type"])
+
+	// Mutating the returned map must not affect the cached value.
+	got["type"] = "string"
+	again, _ := c.Get("Foo")
+	assert.Equal(t, "object", again["type"])
+
+	// Warming with nil removes the entry.
+	c.Warm("Foo", nil)
+	assert.False(t, c.Has("Foo"))
+	_, ok = c.Get("Foo")
+	assert.False(t, ok)
+}
+
+func TestSchemaCache_WarmRaw_CopiesInput(t *testing.T) {
+	c := NewSchemaCache()
+	src := json.RawMessage(`{"type":"object"}`)
+	c.WarmRaw("Foo", src)
+
+	// Mutating the source slice must not affect the cached entry.
+	for i := range src {
+		src[i] = 'x'
+	}
+
+	raw, ok := c.GetRaw("Foo")
+	require.True(t, ok)
+	assert.JSONEq(t, `{"type":"object"}`, string(raw))
+}
+
+func TestSchemaCache_NilSafe(t *testing.T) {
+	var c *SchemaCache
+	assert.False(t, c.Has("x"))
+	assert.Equal(t, 0, c.Len())
+	assert.Nil(t, c.Keys())
+
+	_, ok := c.Get("x")
+	assert.False(t, ok)
+	_, ok = c.GetRaw("x")
+	assert.False(t, ok)
+
+	// Warm/WarmRaw must not panic on a nil cache.
+	c.Warm("x", map[string]any{"type": "string"})
+	c.WarmRaw("x", json.RawMessage(`{"type":"string"}`))
+
+	data, err := c.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, "{}", string(data))
+
+	require.Error(t, c.UnmarshalJSON([]byte("{}")))
+	require.Error(t, c.Save("/tmp/should-not-be-written.json"))
+}
+
+func TestSchemaCache_MarshalDeterministic(t *testing.T) {
+	c := NewSchemaCache()
+	c.WarmRaw("B", json.RawMessage(`{"type":"object"}`))
+	c.WarmRaw("A", json.RawMessage(`{"type":"string"}`))
+	c.WarmRaw("C", json.RawMessage(`{"type":"number"}`))
+
+	data, err := c.MarshalJSON()
+	require.NoError(t, err)
+
+	// Verify keys appear in sorted order.
+	idxA := strings.Index(string(data), `"A"`)
+	idxB := strings.Index(string(data), `"B"`)
+	idxC := strings.Index(string(data), `"C"`)
+	require.NotEqual(t, -1, idxA)
+	require.NotEqual(t, -1, idxB)
+	require.NotEqual(t, -1, idxC)
+	assert.Less(t, idxA, idxB)
+	assert.Less(t, idxB, idxC)
+
+	// Round-trip should be stable.
+	again, err := c.MarshalJSON()
+	require.NoError(t, err)
+	assert.Equal(t, string(data), string(again))
+}
+
+func TestSchemaCache_RoundTripJSON(t *testing.T) {
+	c := NewSchemaCache()
+	c.Warm("Input", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+		"required": []any{"name"},
+	})
+	c.Warm("Output", map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"ok": map[string]any{"type": "boolean"},
+		},
+	})
+
+	data, err := json.Marshal(c)
+	require.NoError(t, err)
+
+	loaded := NewSchemaCache()
+	require.NoError(t, json.Unmarshal(data, loaded))
+	assert.Equal(t, c.Len(), loaded.Len())
+	assert.Equal(t, c.Keys(), loaded.Keys())
+
+	for _, key := range c.Keys() {
+		want, _ := c.GetRaw(key)
+		got, _ := loaded.GetRaw(key)
+		assert.JSONEq(t, string(want), string(got), "round-trip mismatch for %q", key)
+	}
+}
+
+func TestSchemaCache_UnmarshalReplaces(t *testing.T) {
+	c := NewSchemaCache()
+	c.WarmRaw("Stale", json.RawMessage(`{"type":"object"}`))
+	require.NoError(t, c.UnmarshalJSON([]byte(`{"Fresh":{"type":"string"}}`)))
+	assert.False(t, c.Has("Stale"))
+	assert.True(t, c.Has("Fresh"))
+}
+
+func TestSchemaCache_UnmarshalInvalid(t *testing.T) {
+	c := NewSchemaCache()
+	require.Error(t, c.UnmarshalJSON([]byte("not json")))
+}
+
+func TestSchemaCache_SaveLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "schemas.json")
+
+	c := NewSchemaCache()
+	require.NoError(t, WarmFor[schemaCacheTestInput](c))
+	require.NoError(t, WarmFor[schemaCacheTestOutput](c))
+	require.NoError(t, c.Save(path))
+
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Greater(t, info.Size(), int64(0))
+
+	loaded, err := LoadSchemaCache(path)
+	require.NoError(t, err)
+	assert.Equal(t, c.Keys(), loaded.Keys())
+
+	for _, key := range c.Keys() {
+		want, _ := c.GetRaw(key)
+		got, _ := loaded.GetRaw(key)
+		assert.JSONEq(t, string(want), string(got))
+	}
+}
+
+func TestLoadSchemaCache_Missing(t *testing.T) {
+	_, err := LoadSchemaCache(filepath.Join(t.TempDir(), "missing.json"))
+	require.Error(t, err)
+}
+
+func TestSchemaFor_PopulatesCache(t *testing.T) {
+	schema := SchemaFor[schemaCacheTestInput]()
+	require.NotNil(t, schema)
+	assert.Equal(t, "object", schema["type"])
+
+	props, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	assert.Contains(t, props, "name")
+	assert.Contains(t, props, "age")
+}
+
+func TestSchemaForRaw_Error(t *testing.T) {
+	// Sanity: SchemaForRaw on a well-formed type must succeed and produce
+	// non-empty JSON.
+	raw, err := SchemaForRaw[schemaCacheTestInput]()
+	require.NoError(t, err)
+	assert.NotEmpty(t, raw)
+}
+
+func TestTypeKey_Stable(t *testing.T) {
+	// TypeKey is the package-qualified type name; verify it includes both
+	// the package and type identifier.
+	k := TypeKey[schemaCacheTestInput]()
+	assert.Contains(t, k, "schemaCacheTestInput")
+	// Calling twice yields the same key.
+	assert.Equal(t, k, TypeKey[schemaCacheTestInput]())
+}
+
+func TestWithCachedInputSchema_HitAndMiss(t *testing.T) {
+	cache := NewSchemaCache()
+
+	// Cold call: cache miss, schema is generated and stored.
+	tool := NewTool("t1", WithCachedInputSchema[schemaCacheTestInput](cache))
+	assert.NotEmpty(t, tool.RawInputSchema)
+	assert.True(t, cache.Has(TypeKey[schemaCacheTestInput]()))
+
+	// Warm call: cache hit, schema served from cache.
+	cached, _ := cache.GetRaw(TypeKey[schemaCacheTestInput]())
+	tool2 := NewTool("t2", WithCachedInputSchema[schemaCacheTestInput](cache))
+	assert.JSONEq(t, string(cached), string(tool2.RawInputSchema))
+
+	// Marshalled tool exposes the schema under "inputSchema".
+	data, err := json.Marshal(tool2)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(data, &out))
+	props, ok := out["inputSchema"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "object", props["type"])
+}
+
+func TestWithCachedInputSchemaKey_UsesProvidedKey(t *testing.T) {
+	cache := NewSchemaCache()
+	const key = "stable.input.v1"
+
+	tool := NewTool("t", WithCachedInputSchemaKey[schemaCacheTestInput](cache, key))
+	assert.NotEmpty(t, tool.RawInputSchema)
+	assert.True(t, cache.Has(key))
+	assert.False(t, cache.Has(TypeKey[schemaCacheTestInput]()))
+}
+
+func TestWithCachedInputSchema_PrecomputedCacheAvoidsReflection(t *testing.T) {
+	cache := NewSchemaCache()
+	const key = "stable.input.v1"
+	cache.WarmRaw(key, json.RawMessage(`{"type":"object","properties":{"foo":{"type":"string"}}}`))
+
+	tool := NewTool("t", WithCachedInputSchemaKey[schemaCacheTestInput](cache, key))
+	assert.JSONEq(t,
+		`{"type":"object","properties":{"foo":{"type":"string"}}}`,
+		string(tool.RawInputSchema),
+	)
+}
+
+func TestWithCachedOutputSchema_HitAndMiss(t *testing.T) {
+	cache := NewSchemaCache()
+
+	tool := NewTool("t1", WithCachedOutputSchema[schemaCacheTestOutput](cache))
+	assert.Equal(t, "object", tool.OutputSchema.Type)
+	assert.NotEmpty(t, tool.OutputSchema.Properties)
+	assert.True(t, cache.Has(TypeKey[schemaCacheTestOutput]()))
+
+	// Marshalled output should have type=object.
+	data, err := json.Marshal(tool)
+	require.NoError(t, err)
+	var out map[string]any
+	require.NoError(t, json.Unmarshal(data, &out))
+	outSchema, ok := out["outputSchema"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "object", outSchema["type"])
+}
+
+func TestWithCachedSchemas_NilCacheFallsBackToReflection(t *testing.T) {
+	tool := NewTool("t",
+		WithCachedInputSchema[schemaCacheTestInput](nil),
+		WithCachedOutputSchema[schemaCacheTestOutput](nil),
+	)
+	assert.NotEmpty(t, tool.RawInputSchema)
+	assert.Equal(t, "object", tool.OutputSchema.Type)
+}
+
+func TestWarmFor_ExplicitKey(t *testing.T) {
+	cache := NewSchemaCache()
+	require.NoError(t, WarmFor[schemaCacheTestInput](cache, "custom"))
+	assert.True(t, cache.Has("custom"))
+	assert.False(t, cache.Has(TypeKey[schemaCacheTestInput]()))
+}
+
+func TestWarmFor_NilCacheNoOp(t *testing.T) {
+	require.NoError(t, WarmFor[schemaCacheTestInput](nil))
+}
+
+func TestSchemaCache_ConcurrentAccess(t *testing.T) {
+	cache := NewSchemaCache()
+	var wg sync.WaitGroup
+	const workers = 16
+	wg.Add(workers)
+	for i := range workers {
+		go func(i int) {
+			defer wg.Done()
+			cache.WarmRaw("k"+string(rune('0'+(i%10))), json.RawMessage(`{"type":"object"}`))
+			_, _ = cache.GetRaw("k0")
+			_ = cache.Has("k1")
+			_ = cache.Len()
+			_ = cache.Keys()
+			_, _ = cache.MarshalJSON()
+		}(i)
+	}
+	wg.Wait()
+	assert.LessOrEqual(t, cache.Len(), 10)
+}

--- a/mcp/schema_cache_test.go
+++ b/mcp/schema_cache_test.go
@@ -302,6 +302,46 @@ func TestWarmFor_NilCacheNoOp(t *testing.T) {
 	require.NoError(t, WarmFor[schemaCacheTestInput](nil))
 }
 
+func TestWithCachedInputSchemaKey_EmptyKeyBypassesCache(t *testing.T) {
+	cache := NewSchemaCache()
+
+	// Two distinct types both called with key="" must not share or pollute
+	// any cache entry. Empty key disables the cache entirely for the call.
+	tool1 := NewTool("t1", WithCachedInputSchemaKey[schemaCacheTestInput](cache, ""))
+	tool2 := NewTool("t2", WithCachedInputSchemaKey[schemaCacheTestOutput](cache, ""))
+
+	assert.NotEmpty(t, tool1.RawInputSchema)
+	assert.NotEmpty(t, tool2.RawInputSchema)
+
+	// Each tool must get its own (different) freshly reflected schema, not a
+	// shared cached entry that would cause type-2 to receive type-1's schema.
+	assert.NotEqual(t, string(tool1.RawInputSchema), string(tool2.RawInputSchema))
+
+	// Cache must remain empty: nothing was read from it and nothing was
+	// written to it under the empty key.
+	assert.Equal(t, 0, cache.Len())
+	assert.False(t, cache.Has(""))
+}
+
+func TestWithCachedOutputSchemaKey_EmptyKeyBypassesCache(t *testing.T) {
+	cache := NewSchemaCache()
+
+	tool1 := NewTool("t1", WithCachedOutputSchemaKey[schemaCacheTestInput](cache, ""))
+	tool2 := NewTool("t2", WithCachedOutputSchemaKey[schemaCacheTestOutput](cache, ""))
+
+	assert.Equal(t, "object", tool1.OutputSchema.Type)
+	assert.Equal(t, "object", tool2.OutputSchema.Type)
+	assert.NotEmpty(t, tool1.OutputSchema.Properties)
+	assert.NotEmpty(t, tool2.OutputSchema.Properties)
+
+	// Distinct types must produce distinct property sets even when called
+	// with the same empty key.
+	assert.NotEqual(t, tool1.OutputSchema.Properties, tool2.OutputSchema.Properties)
+
+	assert.Equal(t, 0, cache.Len())
+	assert.False(t, cache.Has(""))
+}
+
 func TestSchemaCache_ConcurrentAccess(t *testing.T) {
 	cache := NewSchemaCache()
 	var wg sync.WaitGroup

--- a/www/docs/pages/servers/tools.mdx
+++ b/www/docs/pages/servers/tools.mdx
@@ -267,6 +267,67 @@ func listAssetsHandler(ctx context.Context, req mcp.CallToolRequest, args struct
 }
 ```
 
+### Caching Schemas for Stateless / Serverless Deployments
+
+Generating JSON schemas with `WithInputSchema[T]()` and `WithOutputSchema[T]()`
+uses reflection at server start-up. In long-running servers this is a one-time
+cost, but in serverless environments (AWS Lambda, Cloud Functions, Cloud Run
+with scale-to-zero) the server is reconstructed on every cold start and the
+reflection cost is paid again and again.
+
+Use `mcp.SchemaCache` to pre-compute schemas at build time, persist them to
+disk, and reload them at start-up:
+
+```go
+// build/warm-cache.go — run as part of your build pipeline
+func main() {
+    cache := mcp.NewSchemaCache()
+    if err := mcp.WarmFor[WeatherRequest](cache); err != nil {
+        log.Fatal(err)
+    }
+    if err := mcp.WarmFor[WeatherResponse](cache); err != nil {
+        log.Fatal(err)
+    }
+    if err := cache.Save("schemas.json"); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+At runtime, load the cache once and pass it to the cache-aware tool options.
+On a cache hit the schema is served straight from memory; on a miss the cache
+falls back to reflection and stores the result for next time, so the same
+code works locally without a pre-built cache file:
+
+```go
+var cache = func() *mcp.SchemaCache {
+    c, err := mcp.LoadSchemaCache("schemas.json")
+    if err != nil {
+        return mcp.NewSchemaCache() // fall back to live reflection
+    }
+    return c
+}()
+
+weatherTool := mcp.NewTool("get_weather",
+    mcp.WithDescription("Get current weather"),
+    mcp.WithCachedInputSchema[WeatherRequest](cache),
+    mcp.WithCachedOutputSchema[WeatherResponse](cache),
+)
+```
+
+The cache key defaults to the package-qualified Go type name
+(e.g. `main.WeatherRequest`). If you need a stable key that survives renames
+or package moves, use the explicit-key variants:
+
+```go
+cache.Warm("weather.v1.input", mcp.SchemaFor[WeatherRequest]())
+
+mcp.WithCachedInputSchemaKey[WeatherRequest](cache, "weather.v1.input")
+```
+
+`SchemaCache` is safe for concurrent use, marshals to deterministic JSON
+(sorted keys), and writes via an atomic temp-file-and-rename in `Save`.
+
 ### Schema Tags Reference
 
 MCP-Go uses the [`google/jsonschema-go`](https://github.com/google/jsonschema-go) library with the `jsonschema` struct tag for schema generation:

--- a/www/docs/pages/servers/tools.mdx
+++ b/www/docs/pages/servers/tools.mdx
@@ -320,7 +320,9 @@ The cache key defaults to the package-qualified Go type name
 or package moves, use the explicit-key variants:
 
 ```go
-cache.Warm("weather.v1.input", mcp.SchemaFor[WeatherRequest]())
+if err := mcp.WarmFor[WeatherRequest](cache, "weather.v1.input"); err != nil {
+    log.Fatal(err)
+}
 
 mcp.WithCachedInputSchemaKey[WeatherRequest](cache, "weather.v1.input")
 ```


### PR DESCRIPTION
## Description

Adds a `mcp.SchemaCache` so authors can pre-compute JSON schemas at build time, persist them, and load them on start-up — avoiding the per-cold-start reflection cost paid by `WithInputSchema[T]()` / `WithOutputSchema[T]()` in stateless / serverless deployments (AWS Lambda, Cloud Functions, Cloud Run scale-to-zero).

The new public surface in package `mcp` is:

- `SchemaCache` — concurrent-safe map of type-name → JSON schema, with `Warm` / `WarmRaw` / `Get` / `GetRaw` / `Has` / `Len` / `Keys`, deterministic (sorted-key) `MarshalJSON`/`UnmarshalJSON`, and `Save` (atomic temp-file-and-rename, parent-dir creation) plus a top-level `LoadSchemaCache`.
- `SchemaFor[T]()` / `SchemaForRaw[T]()` / `TypeKey[T]()` / `WarmFor[T](cache, key…)` — building blocks for reflecting and caching schemas with stable, type-derived keys.
- `WithCachedInputSchema[T](cache)` / `WithCachedOutputSchema[T](cache)` (and `…Key` variants) — drop-in replacements for `WithInputSchema[T]` / `WithOutputSchema[T]`. On a cache hit the schema is served from memory; on a miss they fall back to reflection and warm the cache for next time, so the same code works both in long-running servers and in serverless. Passing `nil` preserves the original reflection-only behaviour.

Typical usage (mirrors the issue's example):

```go
// build step
cache := mcp.NewSchemaCache()
_ = mcp.WarmFor[WeatherRequest](cache)
_ = mcp.WarmFor[WeatherResponse](cache)
_ = cache.Save("schemas.json")

// runtime
cache, _ := mcp.LoadSchemaCache("schemas.json")
tool := mcp.NewTool("get_weather",
    mcp.WithCachedInputSchema[WeatherRequest](cache),
    mcp.WithCachedOutputSchema[WeatherResponse](cache),
)
```

The issue also sketched `server.WithSchemaCache(cache)`, but `ToolOption`s execute at `mcp.NewTool` time and have no access to server-level state. The cache-aware `ToolOption`s give the same result with explicit data flow and no global/magic state.

Fixes #815

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

**Files:**

- `mcp/schema_cache.go` (new, 372 lines) — `SchemaCache`, `SchemaFor`/`SchemaForRaw`, `TypeKey`, `WarmFor`, `LoadSchemaCache`, and the four `WithCached*Schema` `ToolOption`s.
- `mcp/schema_cache_test.go` (new, 323 lines) — 17 tests covering warm/get round-trips, defensive copying, nil-receiver safety, deterministic marshalling, save/load to disk, cache hit vs. miss for both `WithCachedInputSchema` and `WithCachedOutputSchema`, explicit-key variants, and concurrent access.
- `www/docs/pages/servers/tools.mdx` — new "Caching Schemas for Stateless / Serverless Deployments" section under "Struct-Based Schema Definition".

**Backward compatibility:** Purely additive. `WithInputSchema` / `WithOutputSchema` are unchanged. `WithCachedInputSchema(nil)` / `WithCachedOutputSchema(nil)` behave identically to the originals, so callers can adopt the API incrementally.

**Verification:**

- `go test ./... -race` — all packages pass
- `golangci-lint run` — `0 issues.`
- `go build ./...` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a concurrency-safe schema cache with warm/load/save support and deterministic JSON persistence; helpers use cached input/output schemas and allow explicit cache keys or opt-out.
* **Documentation**
  * New guide for schema caching in stateless/serverless deployments with usage examples and keying recommendations.
* **Tests**
  * Comprehensive test suite covering warming, persistence, cache hits/misses, opt-out behavior, defensive copying, and concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->