### PR TITLE
fix(oauth): accept any 2xx token response status (#835)

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -274,7 +274,9 @@ func (h *OAuthHandler) refreshToken(ctx context.Context, refreshToken string) (*
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	// Accept any 2xx status; some authorization servers (e.g. Supabase) return
+	// 201 Created for successful token responses.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		return nil, extractOAuthError(body, resp.StatusCode, "refresh token request failed")
 	}
@@ -1027,7 +1029,9 @@ func (h *OAuthHandler) ProcessAuthorizationResponse(ctx context.Context, code, s
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	// Accept any 2xx status; some authorization servers (e.g. Supabase) return
+	// 201 Created for successful token responses.
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		body, _ := io.ReadAll(resp.Body)
 		return extractOAuthError(body, resp.StatusCode, "token request failed")
 	}

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -2220,3 +2220,109 @@ func TestExtractResourceMetadataURLs(t *testing.T) {
 		})
 	}
 }
+
+// TestOAuthHandler_ProcessAuthorizationResponse_201Created verifies that token
+// exchange succeeds when the authorization server responds with HTTP 201
+// Created instead of 200 OK. Some authorization servers (e.g. Supabase MCP)
+// return 201 Created for successful token responses, which is allowed by RFC
+// 7231 / RFC 9110 but stricter implementations would reject it. See issue
+// #835.
+func TestOAuthHandler_ProcessAuthorizationResponse_201Created(t *testing.T) {
+	tokenStore := NewMemoryTokenStore()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 serverURL,
+				"authorization_endpoint": serverURL + "/authorize",
+				"token_endpoint":         serverURL + "/token",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated) // 201 Created instead of 200 OK
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "test-access-token",
+				"refresh_token": "test-refresh-token",
+				"expires_in":    86400,
+				"token_type":    "Bearer",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	config := OAuthConfig{
+		ClientID:              "test-client",
+		ClientSecret:          "test-secret",
+		RedirectURI:           server.URL + "/callback",
+		TokenStore:            tokenStore,
+		AuthServerMetadataURL: server.URL + "/.well-known/oauth-authorization-server",
+		PKCEEnabled:           true,
+	}
+
+	handler := NewOAuthHandler(config)
+	ctx := t.Context()
+
+	const state = "test-state"
+	handler.SetExpectedState(state)
+
+	err := handler.ProcessAuthorizationResponse(ctx, "test-code", state, "test-verifier")
+	require.NoError(t, err, "token exchange should succeed for HTTP 201 Created")
+
+	saved, getErr := tokenStore.GetToken(ctx)
+	require.NoError(t, getErr, "token should be persisted")
+	assert.Equal(t, "test-access-token", saved.AccessToken)
+	assert.Equal(t, "test-refresh-token", saved.RefreshToken)
+}
+
+// TestOAuthHandler_RefreshToken_201Created verifies that the refresh token
+// exchange accepts HTTP 201 Created responses. See issue #835.
+func TestOAuthHandler_RefreshToken_201Created(t *testing.T) {
+	tokenStore := NewMemoryTokenStore()
+
+	var serverURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/.well-known/oauth-authorization-server":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 serverURL,
+				"authorization_endpoint": serverURL + "/authorize",
+				"token_endpoint":         serverURL + "/token",
+			})
+		case "/token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusCreated) // 201 Created instead of 200 OK
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"access_token":  "refreshed-access-token",
+				"refresh_token": "refreshed-refresh-token",
+				"expires_in":    3600,
+				"token_type":    "Bearer",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	serverURL = server.URL
+	defer server.Close()
+
+	config := OAuthConfig{
+		ClientID:              "test-client",
+		ClientSecret:          "test-secret",
+		RedirectURI:           "http://localhost/callback",
+		TokenStore:            tokenStore,
+		AuthServerMetadataURL: server.URL + "/.well-known/oauth-authorization-server",
+	}
+
+	handler := NewOAuthHandler(config)
+
+	token, err := handler.RefreshToken(t.Context(), "old-refresh-token")
+	require.NoError(t, err, "refresh token exchange should succeed for HTTP 201 Created")
+	assert.Equal(t, "refreshed-access-token", token.AccessToken)
+	assert.Equal(t, "refreshed-refresh-token", token.RefreshToken)
+}


### PR DESCRIPTION
## Description

The OAuth token endpoint code in `client/transport/oauth.go` only accepted `200 OK` for successful token exchanges. Some authorization servers — notably the Supabase MCP server reported in #835 — return `201 Created` for the same successful response, which is permitted by RFC 9110. As a result, browser-based OAuth flows completed successfully but `OAuthHandler.ProcessAuthorizationResponse` rejected the response and the client never persisted the token.

This PR loosens the status check in both `ProcessAuthorizationResponse` (authorization code exchange) and `RefreshToken` so that any 2xx response is treated as success and parsed as a token, while non-2xx responses still flow through `extractOAuthError` unchanged. Two regression tests spin up an `httptest` server that responds with `201 Created` on `/token` and assert the resulting token is parsed and saved correctly.

Fixes #835

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

- Files changed:
  - `client/transport/oauth.go` — replace `resp.StatusCode != http.StatusOK` with a `< 200 || >= 300` check at the two token-endpoint call sites (refresh + authorization code exchange).
  - `client/transport/oauth_test.go` — add `TestOAuthHandler_ProcessAuthorizationResponse_201Created` and `TestOAuthHandler_RefreshToken_201Created` covering the Supabase-style `201 Created` token response.
- Backward compatibility: fully preserved — `200 OK` responses continue to work exactly as before, and error handling for non-2xx responses is unchanged. Servers that previously succeeded will continue to succeed; servers that returned valid token bodies with a 2xx status other than 200 will now also succeed.
- Verification: `go test ./... -race` passes; `golangci-lint run` reports `0 issues`. The new tests were confirmed to fail on `main` and pass with the fix applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth flows now correctly accept all successful HTTP 2xx responses from servers, not just HTTP 200 OK. This applies to both authorization code exchange and token refresh operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->