### PR TITLE
docs(server): document OnBeforeAny/OnSuccess/OnError pairing (#827)

### DIFF
--- a/server/hooks.go
+++ b/server/hooks.go
@@ -16,14 +16,24 @@ type OnUnregisterSessionHookFunc func(ctx context.Context, session ClientSession
 
 // BeforeAnyHookFunc is a function that is called after the request is
 // parsed but before the method is called.
+//
+// See the Hooks type-level documentation for the pairing contract between
+// OnBeforeAny, OnSuccess, and OnError.
 type BeforeAnyHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any)
 
 // OnSuccessHookFunc is a hook that will be called after the request
 // successfully generates a result, but before the result is sent to the client.
+//
+// See the Hooks type-level documentation for the pairing contract between
+// OnBeforeAny, OnSuccess, and OnError.
 type OnSuccessHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any)
 
 // OnErrorHookFunc is a hook that will be called when an error occurs,
 // either during the request parsing or the method execution.
+//
+// See the Hooks type-level documentation for the pairing contract between
+// OnBeforeAny, OnSuccess, and OnError, including the cases in which OnError
+// may fire without a prior OnBeforeAny.
 //
 // Example usage:
 // ```
@@ -106,6 +116,40 @@ type OnAfterCancelTaskFunc func(ctx context.Context, id any, message *mcp.Cancel
 type OnBeforeCompleteFunc func(ctx context.Context, id any, message *mcp.CompleteRequest)
 type OnAfterCompleteFunc func(ctx context.Context, id any, message *mcp.CompleteRequest, result *mcp.CompleteResult)
 
+// Hooks is the registry of callbacks that fire around request handling.
+//
+// # Pairing contract
+//
+// For every invocation of OnBeforeAny for a given request id, exactly one of
+// OnSuccess or OnError will fire for the same id before the request handler
+// returns to the JSON-RPC dispatcher. This makes the OnBeforeAny / OnSuccess /
+// OnError trio safe to use as the building block for per-request bookkeeping
+// such as latency histograms, distributed tracing spans, or slow-request
+// logging.
+//
+// Two caveats apply:
+//
+//  1. OnError may fire without a prior OnBeforeAny when the dispatcher rejects
+//     a request before invoking the per-method handler. This happens for
+//     payload-parse failures (UnparsableMessageError) and capability-not-
+//     enabled errors (ErrUnsupported). Per-request bookkeeping consumers must
+//     therefore tolerate "id not found" on the OnError path; the natural
+//     sync.Map.LoadAndDelete ok-bool already covers this.
+//
+//  2. If a handler panics and neither WithRecovery nor WithResourceRecovery
+//     is installed at server construction, the panic unwinds past the
+//     dispatcher and skips both OnSuccess and OnError. OnBeforeAny will
+//     already have fired. The process is typically terminating in that case,
+//     so the leak is moot in practice; bookkeeping consumers that need to
+//     survive unrecovered panics should either install the recovery
+//     middleware or run a periodic sweeper. With recovery middleware
+//     installed, panics are converted to errors and the contract above
+//     holds.
+//
+// Hooks fire synchronously in the request goroutine, in the order they were
+// registered with the corresponding Add* method. A long-running hook will
+// delay the response to the client; offload heavy work to a separate
+// goroutine if needed.
 type Hooks struct {
 	OnRegisterSession             []OnRegisterSessionHookFunc
 	OnUnregisterSession           []OnUnregisterSessionHookFunc

--- a/server/internal/gen/hooks.go.tmpl
+++ b/server/internal/gen/hooks.go.tmpl
@@ -19,14 +19,24 @@ type OnUnregisterSessionHookFunc func(ctx context.Context, session ClientSession
 
 // BeforeAnyHookFunc is a function that is called after the request is
 // parsed but before the method is called.
+//
+// See the Hooks type-level documentation for the pairing contract between
+// OnBeforeAny, OnSuccess, and OnError.
 type BeforeAnyHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any)
 
 // OnSuccessHookFunc is a hook that will be called after the request
 // successfully generates a result, but before the result is sent to the client.
+//
+// See the Hooks type-level documentation for the pairing contract between
+// OnBeforeAny, OnSuccess, and OnError.
 type OnSuccessHookFunc func(ctx context.Context, id any, method mcp.MCPMethod, message any, result any)
 
 // OnErrorHookFunc is a hook that will be called when an error occurs,
 // either during the request parsing or the method execution.
+//
+// See the Hooks type-level documentation for the pairing contract between
+// OnBeforeAny, OnSuccess, and OnError, including the cases in which OnError
+// may fire without a prior OnBeforeAny.
 // 
 // Example usage:
 // ```
@@ -69,6 +79,40 @@ type OnBefore{{.HookName}}Func func(ctx context.Context, id any, message *mcp.{{
 {{ if .ResultIsAny }}type OnAfter{{.HookName}}Func func(ctx context.Context, id any, message *mcp.{{.ParamType}}, result any){{ else }}type OnAfter{{.HookName}}Func func(ctx context.Context, id any, message *mcp.{{.ParamType}}, result *mcp.{{.ResultType}}){{ end }}
 {{end}}
 
+// Hooks is the registry of callbacks that fire around request handling.
+//
+// # Pairing contract
+//
+// For every invocation of OnBeforeAny for a given request id, exactly one of
+// OnSuccess or OnError will fire for the same id before the request handler
+// returns to the JSON-RPC dispatcher. This makes the OnBeforeAny / OnSuccess /
+// OnError trio safe to use as the building block for per-request bookkeeping
+// such as latency histograms, distributed tracing spans, or slow-request
+// logging.
+//
+// Two caveats apply:
+//
+//  1. OnError may fire without a prior OnBeforeAny when the dispatcher rejects
+//     a request before invoking the per-method handler. This happens for
+//     payload-parse failures (UnparsableMessageError) and capability-not-
+//     enabled errors (ErrUnsupported). Per-request bookkeeping consumers must
+//     therefore tolerate "id not found" on the OnError path; the natural
+//     sync.Map.LoadAndDelete ok-bool already covers this.
+//
+//  2. If a handler panics and neither WithRecovery nor WithResourceRecovery
+//     is installed at server construction, the panic unwinds past the
+//     dispatcher and skips both OnSuccess and OnError. OnBeforeAny will
+//     already have fired. The process is typically terminating in that case,
+//     so the leak is moot in practice; bookkeeping consumers that need to
+//     survive unrecovered panics should either install the recovery
+//     middleware or run a periodic sweeper. With recovery middleware
+//     installed, panics are converted to errors and the contract above
+//     holds.
+//
+// Hooks fire synchronously in the request goroutine, in the order they were
+// registered with the corresponding Add* method. A long-running hook will
+// delay the response to the client; offload heavy work to a separate
+// goroutine if needed.
 type Hooks struct {
     OnRegisterSession   []OnRegisterSessionHookFunc
 	OnUnregisterSession   []OnUnregisterSessionHookFunc


### PR DESCRIPTION
## Description

Documents the pairing contract between `OnBeforeAny`, `OnSuccess`, and `OnError`
on the `Hooks` type so per-request bookkeeping consumers (latency histograms,
distributed tracing spans, slow-request loggers) can rely on it without a
reverse-engineering pass through `request_handler.go`.

The new type-level godoc on `Hooks` states that for every `OnBeforeAny(id)`
exactly one of `OnSuccess(id)` or `OnError(id)` will fire for the same id
before the handler returns, and calls out the two real caveats: dispatcher-
level rejections (`UnparsableMessageError`, `ErrUnsupported`) can fire
`OnError` without a prior `OnBeforeAny`, and unrecovered handler panics skip
both finalizers unless `WithRecovery` / `WithResourceRecovery` is installed.
It also notes that hooks fire synchronously in the request goroutine.

`BeforeAnyHookFunc`, `OnSuccessHookFunc`, and `OnErrorHookFunc` get short
"see Hooks for the pairing contract" cross-references so the contract is
discoverable from any of the three entry points.

Fixes #827

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

- Edits were made in the generator template (`server/internal/gen/hooks.go.tmpl`)
  and `server/hooks.go` was regenerated via `go generate ./...`, per the
  repo's `AGENTS.md`.
- Documentation-only: no behavioural change, no new tests required. `go vet`,
  `go build`, and `golangci-lint run ./server/...` are all clean.
- Files touched:
  - `server/internal/gen/hooks.go.tmpl` (source of truth)
  - `server/hooks.go` (regenerated)
- Fully backward compatible — godoc additions only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for hook types to clarify pairing contracts, error handling behavior, panic handling, and synchronous execution ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->