### PR TITLE
fix(transport): close response body on 404 in sendHTTP

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -678,6 +678,7 @@ func (c *StreamableHTTP) sendHTTP(
 
 	// universal handling for session terminated
 	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
 		c.sessionID.CompareAndSwap(sessionID, "")
 		return nil, ErrSessionTerminated
 	}


### PR DESCRIPTION
## Summary

- `sendHTTP` returns `(nil, ErrSessionTerminated)` on HTTP 404 without closing `resp.Body`
- All four callers (`SendRequest`, `SendNotification`, `createGETConnectionToServer`, `sendResponseToServer`) defer `resp.Body.Close()` only after checking `err == nil`, so the body is never closed when `sendHTTP` returns nil
- Under `listenForever` retry loops, each 404 response leaks one TCP connection
- On long-running clients this eventually exhausts file descriptors

## Fix

Close `resp.Body` before returning on the 404 path in `sendHTTP`. This is the single point of fix that protects all four callers.

## Context

Same pattern as #929 (merged into modelcontextprotocol/go-sdk): HTTP response body not closed on an early-return error path where the response is discarded.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./client/transport/` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resource cleanup during session termination to prevent potential resource leaks when receiving session termination responses from the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->