### PR TITLE
feat(server): add transport-agnostic Handle entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,6 +657,30 @@ Key examples include:
 
 MCP-Go supports stdio, SSE and streamable-HTTP transport layers. For SSE transport, you can use `SetConnectionLostHandler()` to detect and handle disconnections for implementing reconnection logic.
 
+### Embedding StreamableHTTP in non-net/http frameworks
+
+`StreamableHTTPServer` is an `http.Handler`, so it can be mounted in any
+router that speaks `net/http`. To embed it in a framework that does **not**
+go through `net/http` (e.g. [fasthttp](https://github.com/valyala/fasthttp)
+or [fiber](https://gofiber.io/)) without buffering the response through an
+adaptor, use the transport-agnostic `Handle` entry point:
+
+```go
+func (s *StreamableHTTPServer) Handle(w HTTPResponseWriter, r *HTTPRequest)
+```
+
+`HTTPRequest` is a plain struct (`Method`, `URL`, `Header`, `Body`,
+`Context`) and `HTTPResponseWriter` is a small interface (`Header`,
+`WriteHeader`, `Write`, `Flush`, `CanStream`). Implementations whose
+underlying transport cannot stream MUST return `false` from `CanStream`;
+the server will then reject GET (SSE listening) with `405 Method Not
+Allowed` and keep POST responses as buffered `application/json` instead of
+upgrading to `text/event-stream`.
+
+See the [HTTP transport docs](https://mcp-go.dev/transports/http#embedding-in-non-nethttp-frameworks)
+for a full fasthttp/fiber adapter example. `ServeHTTP` is unchanged and
+remains the conventional `net/http` entry point.
+
 ### OAuth Protected Resource Metadata
 
 Servers that require OAuth can advertise their authorization requirements

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -313,6 +313,9 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 // When WithStreamableHTTPCORS has been configured, CORS preflight (OPTIONS)
 // requests are answered directly and simple cross-origin responses are
 // decorated with the configured Access-Control-* headers before dispatch.
+//
+// ServeHTTP is the conventional net/http entry point; for non-net/http HTTP
+// frameworks (fasthttp, fiber, etc.), see Handle.
 func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.corsConfig.enabled() {
 		if s.corsConfig.handlePreflight(w, r) {
@@ -325,13 +328,38 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
+	// Read the request body up-front so the transport-agnostic core never
+	// needs to keep an io.Reader alive across SSE upgrades. Body errors are
+	// surfaced by the per-method handlers below for parity with the previous
+	// behavior (PARSE_ERROR JSON-RPC reply for POST, ignored for GET/DELETE).
+	var body []byte
+	var bodyErr error
+	if r.Method == http.MethodPost && r.Body != nil {
+		body, bodyErr = io.ReadAll(r.Body)
+	}
+
+	hr := &HTTPRequest{
+		Method:   r.Method,
+		URL:      r.URL,
+		Header:   r.Header,
+		Body:     body,
+		Context:  r.Context(),
+		original: r,
+	}
+	hw := newHTTPResponseWriterAdapter(w)
+
+	if bodyErr != nil && r.Method == http.MethodPost {
+		s.writeJSONRPCError(hw, nil, mcp.PARSE_ERROR, fmt.Sprintf("read request body error: %v", bodyErr))
+		return
+	}
+
 	switch r.Method {
 	case http.MethodPost:
-		s.handlePost(w, r)
+		s.handlePost(hw, hr)
 	case http.MethodGet:
-		s.handleGet(w, r)
+		s.handleGet(hw, hr)
 	case http.MethodDelete:
-		s.handleDelete(w, r)
+		s.handleDelete(hw, hr)
 	default:
 		http.NotFound(w, r)
 	}
@@ -398,23 +426,19 @@ func (s *StreamableHTTPServer) Shutdown(ctx context.Context) error {
 
 // --- internal methods ---
 
-func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request) {
+func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) {
 	// post request carry request/notification message
 
 	// Check content type
-	contentType := r.Header.Get("Content-Type")
+	contentType := r.header().Get("Content-Type")
 	mediaType, _, err := mime.ParseMediaType(contentType)
 	if err != nil || mediaType != "application/json" {
-		http.Error(w, "Invalid content type: must be 'application/json'", http.StatusBadRequest)
+		writeHTTPError(w, "Invalid content type: must be 'application/json'", http.StatusBadRequest)
 		return
 	}
 
-	// Check the request body is valid json, meanwhile, get the request Method
-	rawData, err := io.ReadAll(r.Body)
-	if err != nil {
-		s.writeJSONRPCError(w, nil, mcp.PARSE_ERROR, fmt.Sprintf("read request body error: %v", err))
-		return
-	}
+	// Body has already been buffered by the caller (ServeHTTP or Handle).
+	rawData := r.Body
 	// First, try to parse as a response (sampling responses don't have a method field)
 	var jsonMessage struct {
 		ID     json.RawMessage `json:"id"`
@@ -465,21 +489,21 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	// The session is ephemeral. Its life is the same as the request. It's only created
 	// for interaction with the mcp server.
 	var sessionID string
-	sessionIdManager := s.sessionIdManagerResolver.ResolveSessionIdManager(r)
+	sessionIdManager := s.resolveSessionIdManager(r)
 	if isInitializeRequest {
 		// generate a new one for initialize request
 		sessionID = sessionIdManager.Generate()
 	} else {
 		// Get session ID from header.
 		// Stateful servers need the client to carry the session ID.
-		sessionID = r.Header.Get(HeaderKeySessionID)
+		sessionID = r.header().Get(HeaderKeySessionID)
 		isTerminated, err := sessionIdManager.Validate(sessionID)
 		if err != nil {
-			http.Error(w, "Invalid session ID", http.StatusNotFound)
+			writeHTTPError(w, "Invalid session ID", http.StatusNotFound)
 			return
 		}
 		if isTerminated {
-			http.Error(w, "Session terminated", http.StatusNotFound)
+			writeHTTPError(w, "Session terminated", http.StatusNotFound)
 			return
 		}
 	}
@@ -512,9 +536,9 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	}
 
 	// Set the client context before handling the message
-	ctx := s.server.WithContext(r.Context(), session)
+	ctx := s.server.WithContext(r.ctx(), session)
 	if s.contextFunc != nil {
-		ctx = s.contextFunc(ctx, r)
+		ctx = s.contextFunc(ctx, r.asHTTPRequest())
 	}
 
 	// handle potential notifications
@@ -522,7 +546,14 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 	upgradedHeader := false
 	done := make(chan struct{})
 
-	ctx = context.WithValue(ctx, requestHeader, r.Header)
+	ctx = context.WithValue(ctx, requestHeader, r.header())
+
+	// SSE upgrades require a streaming-capable response writer; if the
+	// underlying transport can't stream, we still attempt the request but
+	// any notifications will be buffered and flushed at the end as a single
+	// application/json response (the upgrade simply won't fire).
+	canStream := w.CanStream()
+
 	go func() {
 		for {
 			select {
@@ -536,12 +567,13 @@ func (s *StreamableHTTPServer) handlePost(w http.ResponseWriter, r *http.Request
 						return
 					default:
 					}
-					defer func() {
-						flusher, ok := w.(http.Flusher)
-						if ok {
-							flusher.Flush()
-						}
-					}()
+					if !canStream {
+						// Without streaming we can't deliver notifications mid-flight;
+						// they will be dropped on the floor here. The final response
+						// path remains the buffered JSON reply below.
+						return
+					}
+					defer w.Flush()
 
 					// if there's notifications, upgradedHeader to SSE response
 					if !upgradedHeader {
@@ -586,6 +618,9 @@ drainLoop:
 	for {
 		select {
 		case nt := <-session.notificationChannel:
+			if !canStream {
+				continue
+			}
 			if !upgradedHeader {
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.Header().Set("Connection", "keep-alive")
@@ -596,9 +631,7 @@ drainLoop:
 			if err := writeSSEEvent(w, nt); err != nil {
 				s.logger.Errorf("Failed to write SSE event during drain: %v", err)
 			}
-			if flusher, ok := w.(http.Flusher); ok {
-				flusher.Flush()
-			}
+			w.Flush()
 		default:
 			break drainLoop
 		}
@@ -614,7 +647,7 @@ drainLoop:
 	// Also check upgradedHeader: a notification during HandleMessage processing
 	// may have already written SSE headers on this response, so we must continue
 	// in SSE mode to avoid writing JSON on top of SSE data.
-	if session.upgradeToSSE.Load() || upgradedHeader {
+	if (session.upgradeToSSE.Load() && canStream) || upgradedHeader {
 		if !upgradedHeader {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Connection", "keep-alive")
@@ -654,29 +687,29 @@ drainLoop:
 	}
 }
 
-func (s *StreamableHTTPServer) handleGet(w http.ResponseWriter, r *http.Request) {
+func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 	// get request is for listening to notifications
 	// https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#listening-for-messages-from-the-server
 	if s.disableStreaming {
-		s.logger.Infof("Rejected GET request: streaming is disabled (session: %s)", r.Header.Get(HeaderKeySessionID))
-		http.Error(w, "Streaming is disabled on this server", http.StatusMethodNotAllowed)
+		s.logger.Infof("Rejected GET request: streaming is disabled (session: %s)", r.header().Get(HeaderKeySessionID))
+		writeHTTPError(w, "Streaming is disabled on this server", http.StatusMethodNotAllowed)
 		return
 	}
 
-	// Check streaming support in the responseWriter. This can happen if the responseWriter has been overridden.
+	// Check streaming support in the responseWriter. This can happen if the responseWriter has been overridden,
+	// or the integrating framework cannot deliver SSE responses (CanStream returns false).
 	// If not supported, return 405 early.
-	flusher, ok := w.(http.Flusher)
-	if !ok {
-		http.Error(w, "Streaming unsupported", http.StatusMethodNotAllowed)
+	if !w.CanStream() {
+		writeHTTPError(w, "Streaming unsupported", http.StatusMethodNotAllowed)
 		return
 	}
 
-	sessionID := r.Header.Get(HeaderKeySessionID)
+	sessionID := r.header().Get(HeaderKeySessionID)
 	// The MCP specification doesn't require validating session ID for GET requests.
 	// If no session ID is provided by the client, generate one using the configured SessionIdManager
 	// so that custom session id generators are honored consistently across POST/GET flows.
 	if sessionID == "" {
-		sessionIdManager := s.sessionIdManagerResolver.ResolveSessionIdManager(r)
+		sessionIdManager := s.resolveSessionIdManager(r)
 		sessionID = sessionIdManager.Generate()
 	}
 
@@ -689,12 +722,12 @@ func (s *StreamableHTTPServer) handleGet(w http.ResponseWriter, r *http.Request)
 
 	if !loaded {
 		// We created a new session, need to register it
-		if err := s.server.RegisterSession(r.Context(), session); err != nil {
+		if err := s.server.RegisterSession(r.ctx(), session); err != nil {
 			s.activeSessions.Delete(sessionID)
-			http.Error(w, fmt.Sprintf("Session registration failed: %v", err), http.StatusBadRequest)
+			writeHTTPErrorf(w, http.StatusBadRequest, "Session registration failed: %v", err)
 			return
 		}
-		defer s.server.UnregisterSession(r.Context(), sessionID)
+		defer s.server.UnregisterSession(r.ctx(), sessionID)
 		defer s.activeSessions.Delete(sessionID)
 		defer s.sessionRequestIDs.Delete(sessionID)
 	}
@@ -707,7 +740,7 @@ func (s *StreamableHTTPServer) handleGet(w http.ResponseWriter, r *http.Request)
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 
-	flusher.Flush()
+	w.Flush()
 
 	// Start notification handler for this session
 	done := make(chan struct{})
@@ -800,6 +833,8 @@ func (s *StreamableHTTPServer) handleGet(w http.ResponseWriter, r *http.Request)
 		}()
 	}
 
+	ctx := r.ctx()
+
 	// Keep the connection open until the client disconnects
 	//
 	// There's will a Available() check when handler ends, and it maybe race with Flush(),
@@ -814,29 +849,29 @@ func (s *StreamableHTTPServer) handleGet(w http.ResponseWriter, r *http.Request)
 				s.logger.Errorf("Failed to write SSE event: %v", err)
 				return
 			}
-			flusher.Flush()
+			w.Flush()
 			s.touchSession(sessionID)
-		case <-r.Context().Done():
+		case <-ctx.Done():
 			return
 		}
 	}
 }
 
-func (s *StreamableHTTPServer) handleDelete(w http.ResponseWriter, r *http.Request) {
+func (s *StreamableHTTPServer) handleDelete(w HTTPResponseWriter, r *HTTPRequest) {
 	// delete request terminate the session
-	sessionID := r.Header.Get(HeaderKeySessionID)
-	sessionIdManager := s.sessionIdManagerResolver.ResolveSessionIdManager(r)
+	sessionID := r.header().Get(HeaderKeySessionID)
+	sessionIdManager := s.resolveSessionIdManager(r)
 	notAllowed, err := sessionIdManager.Terminate(sessionID)
 	if err != nil {
-		http.Error(w, fmt.Sprintf("Session termination failed: %v", err), http.StatusInternalServerError)
+		writeHTTPErrorf(w, http.StatusInternalServerError, "Session termination failed: %v", err)
 		return
 	}
 	if notAllowed {
-		http.Error(w, "Session termination not allowed", http.StatusMethodNotAllowed)
+		writeHTTPError(w, "Session termination not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 
-	s.cleanupSessionState(r.Context(), sessionID)
+	s.cleanupSessionState(r.ctx(), sessionID)
 
 	w.WriteHeader(http.StatusOK)
 }
@@ -854,35 +889,35 @@ func writeSSEEvent(w io.Writer, data any) error {
 }
 
 // handleSamplingResponse processes incoming sampling responses from clients
-func (s *StreamableHTTPServer) handleSamplingResponse(w http.ResponseWriter, r *http.Request, responseMessage struct {
+func (s *StreamableHTTPServer) handleSamplingResponse(w HTTPResponseWriter, r *HTTPRequest, responseMessage struct {
 	ID     json.RawMessage `json:"id"`
 	Result json.RawMessage `json:"result,omitempty"`
 	Error  json.RawMessage `json:"error,omitempty"`
 	Method mcp.MCPMethod   `json:"method,omitempty"`
 }) error {
 	// Get session ID from header
-	sessionID := r.Header.Get(HeaderKeySessionID)
+	sessionID := r.header().Get(HeaderKeySessionID)
 	if sessionID == "" {
-		http.Error(w, "Missing session ID for sampling response", http.StatusBadRequest)
+		writeHTTPError(w, "Missing session ID for sampling response", http.StatusBadRequest)
 		return fmt.Errorf("missing session ID")
 	}
 
 	// Validate session
-	sessionIdManager := s.sessionIdManagerResolver.ResolveSessionIdManager(r)
+	sessionIdManager := s.resolveSessionIdManager(r)
 	isTerminated, err := sessionIdManager.Validate(sessionID)
 	if err != nil {
-		http.Error(w, "Invalid session ID", http.StatusNotFound)
+		writeHTTPError(w, "Invalid session ID", http.StatusNotFound)
 		return err
 	}
 	if isTerminated {
-		http.Error(w, "Session terminated", http.StatusNotFound)
+		writeHTTPError(w, "Session terminated", http.StatusNotFound)
 		return fmt.Errorf("session terminated")
 	}
 
 	// Parse the request ID
 	var requestID int64
 	if err := json.Unmarshal(responseMessage.ID, &requestID); err != nil {
-		http.Error(w, "Invalid request ID in sampling response", http.StatusBadRequest)
+		writeHTTPError(w, "Invalid request ID in sampling response", http.StatusBadRequest)
 		return err
 	}
 
@@ -924,30 +959,30 @@ func (s *StreamableHTTPServer) handleSamplingResponse(w http.ResponseWriter, r *
 
 // deliverSamplingResponse delivers a sampling response to the appropriate session.
 // On failure it writes the HTTP error status directly to w.
-func (s *StreamableHTTPServer) deliverSamplingResponse(w http.ResponseWriter, sessionID string, response samplingResponseItem) error {
+func (s *StreamableHTTPServer) deliverSamplingResponse(w HTTPResponseWriter, sessionID string, response samplingResponseItem) error {
 	// Look up the active session
 	sessionInterface, ok := s.activeSessions.Load(sessionID)
 	if !ok {
-		http.Error(w, "No active session found for the given session ID", http.StatusNotFound)
+		writeHTTPError(w, "No active session found for the given session ID", http.StatusNotFound)
 		return fmt.Errorf("no active session found for session %s", sessionID)
 	}
 
 	session, ok := sessionInterface.(*streamableHttpSession)
 	if !ok {
-		http.Error(w, "Invalid session type for the given session ID", http.StatusInternalServerError)
+		writeHTTPError(w, "Invalid session type for the given session ID", http.StatusInternalServerError)
 		return fmt.Errorf("invalid session type for session %s", sessionID)
 	}
 
 	// Look up the dedicated response channel for this specific request
 	responseChannelInterface, exists := session.samplingRequests.Load(response.requestID)
 	if !exists {
-		http.Error(w, "No pending sampling request found for the given request ID", http.StatusBadRequest)
+		writeHTTPError(w, "No pending sampling request found for the given request ID", http.StatusBadRequest)
 		return fmt.Errorf("no pending request found for session %s, request %d", sessionID, response.requestID)
 	}
 
 	responseChan, ok := responseChannelInterface.(chan samplingResponseItem)
 	if !ok {
-		http.Error(w, "Failed to deliver response", http.StatusInternalServerError)
+		writeHTTPError(w, "Failed to deliver response", http.StatusInternalServerError)
 		return fmt.Errorf("invalid response channel type for session %s, request %d", sessionID, response.requestID)
 	}
 
@@ -957,14 +992,14 @@ func (s *StreamableHTTPServer) deliverSamplingResponse(w http.ResponseWriter, se
 		s.logger.Infof("Delivered sampling response for session %s, request %d", sessionID, response.requestID)
 		return nil
 	default:
-		http.Error(w, "Failed to deliver response", http.StatusInternalServerError)
+		writeHTTPError(w, "Failed to deliver response", http.StatusInternalServerError)
 		return fmt.Errorf("failed to deliver sampling response for session %s, request %d: channel full or blocked", sessionID, response.requestID)
 	}
 }
 
 // writeJSONRPCError writes a JSON-RPC error response with the given error details.
 func (s *StreamableHTTPServer) writeJSONRPCError(
-	w http.ResponseWriter,
+	w HTTPResponseWriter,
 	id any,
 	code int,
 	message string,

--- a/server/streamable_http_handle.go
+++ b/server/streamable_http_handle.go
@@ -1,0 +1,214 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+)
+
+// HTTPRequest is a transport-agnostic view of an incoming MCP HTTP request.
+// It contains everything StreamableHTTPServer.Handle needs to process a
+// request without depending on net/http server primitives, allowing
+// integration with frameworks such as fasthttp/fiber.
+//
+// All fields are read by Handle but never mutated. Body is fully buffered;
+// adapters do not need to keep an io.Reader alive for the duration of
+// streaming responses.
+type HTTPRequest struct {
+	// Method is the HTTP method ("POST", "GET", "DELETE"). Required.
+	Method string
+	// URL is the request URL. Optional; only Path is consulted by mcp-go and
+	// only when WithProtectedResourceMetadata is configured. May be nil.
+	URL *url.URL
+	// Header carries the request headers. Required.
+	Header http.Header
+	// Body is the (already buffered) request body. May be nil for GET/DELETE.
+	Body []byte
+	// Context is the request context. Cancellation is honored for streaming
+	// responses. Required.
+	Context context.Context
+
+	// original is the *http.Request that originated this HTTPRequest, when
+	// the request entered through ServeHTTP. It is forwarded to legacy hooks
+	// such as HTTPContextFunc that take a *http.Request, preserving any
+	// request-scoped state (RemoteAddr, TLS, etc.) that the synthesized
+	// request from asHTTPRequest cannot reconstruct. Nil when the request
+	// entered through Handle.
+	original *http.Request
+}
+
+// context returns Context, defaulting to context.Background() when nil so
+// internal callers don't have to nil-check.
+func (r *HTTPRequest) ctx() context.Context {
+	if r == nil || r.Context == nil {
+		return context.Background()
+	}
+	return r.Context
+}
+
+// header returns Header, defaulting to an empty http.Header when nil.
+func (r *HTTPRequest) header() http.Header {
+	if r == nil || r.Header == nil {
+		return http.Header{}
+	}
+	return r.Header
+}
+
+// asHTTPRequest builds a synthetic *http.Request that exposes the headers,
+// URL, and context of r. It is used to remain compatible with APIs that
+// historically accept a *http.Request (e.g. SessionIdManagerResolver and
+// HTTPContextFunc) when a caller has reached us through Handle.
+//
+// The returned request has no body; callers must not read it.
+func (r *HTTPRequest) asHTTPRequest() *http.Request {
+	if r == nil {
+		return nil
+	}
+	if r.original != nil {
+		return r.original
+	}
+	u := r.URL
+	if u == nil {
+		u = &url.URL{}
+	}
+	req := &http.Request{
+		Method: r.Method,
+		URL:    u,
+		Header: r.header(),
+		Host:   u.Host,
+	}
+	return req.WithContext(r.ctx())
+}
+
+// HTTPResponseWriter is the minimum surface mcp-go needs to write a
+// streamable HTTP response. Adapters for fasthttp, fiber, or other transports
+// can implement this directly to avoid going through the net/http server
+// machinery.
+//
+// Implementations whose underlying transport buffers the response (and so
+// cannot deliver SSE streams) MUST return false from CanStream and SHOULD
+// make Flush a no-op. The server uses CanStream to decide whether to
+// upgrade a POST response to text/event-stream and whether GET (which
+// requires streaming) is supported at all.
+type HTTPResponseWriter interface {
+	// Header returns the response header map. The same semantics as
+	// http.ResponseWriter.Header apply: changes after WriteHeader has been
+	// called may be ignored.
+	Header() http.Header
+	// WriteHeader sends the HTTP status code. It must be called at most once.
+	WriteHeader(statusCode int)
+	// Write writes raw response bytes. WriteHeader is implicitly called with
+	// 200 if it has not been called yet.
+	Write(p []byte) (int, error)
+	// Flush forwards any buffered bytes to the client. Implementations whose
+	// underlying transport cannot stream may make this a no-op, but in that
+	// case CanStream MUST return false.
+	Flush()
+	// CanStream reports whether Flush actually delivers bytes to the client
+	// immediately. When false, the server will not upgrade POST responses to
+	// SSE and will reject GET requests with 405 Method Not Allowed.
+	CanStream() bool
+}
+
+// httpResponseWriterAdapter adapts an http.ResponseWriter to
+// HTTPResponseWriter. Streaming support is detected via http.Flusher.
+type httpResponseWriterAdapter struct {
+	w       http.ResponseWriter
+	flusher http.Flusher // nil when underlying writer cannot stream
+}
+
+func newHTTPResponseWriterAdapter(w http.ResponseWriter) *httpResponseWriterAdapter {
+	a := &httpResponseWriterAdapter{w: w}
+	if f, ok := w.(http.Flusher); ok {
+		a.flusher = f
+	}
+	return a
+}
+
+func (a *httpResponseWriterAdapter) Header() http.Header         { return a.w.Header() }
+func (a *httpResponseWriterAdapter) WriteHeader(status int)      { a.w.WriteHeader(status) }
+func (a *httpResponseWriterAdapter) Write(p []byte) (int, error) { return a.w.Write(p) }
+
+func (a *httpResponseWriterAdapter) Flush() {
+	if a.flusher != nil {
+		a.flusher.Flush()
+	}
+}
+
+func (a *httpResponseWriterAdapter) CanStream() bool { return a.flusher != nil }
+
+// httpErrorTextHeader sets the conventional headers for plain-text HTTP
+// errors, matching net/http's http.Error behavior for response writers that
+// don't go through net/http.
+func httpErrorTextHeader(h http.Header) {
+	h.Set("Content-Type", "text/plain; charset=utf-8")
+	h.Set("X-Content-Type-Options", "nosniff")
+}
+
+// writeHTTPError writes a plain-text error response to w. Modeled after
+// net/http's http.Error so the externally observable behavior of Handle
+// matches ServeHTTP byte-for-byte.
+func writeHTTPError(w HTTPResponseWriter, msg string, code int) {
+	httpErrorTextHeader(w.Header())
+	// Drop framing headers in case any were already set, mirroring http.Error.
+	w.Header().Del("Content-Length")
+	w.WriteHeader(code)
+	_, _ = io.WriteString(w, msg+"\n")
+}
+
+// writeHTTPErrorf is a printf-style helper for writeHTTPError.
+func writeHTTPErrorf(w HTTPResponseWriter, code int, format string, args ...any) {
+	writeHTTPError(w, fmt.Sprintf(format, args...), code)
+}
+
+// Handle dispatches a single MCP request through the streamable HTTP state
+// machine using transport-agnostic primitives.
+//
+// This is the framework-agnostic entry point intended for callers integrating
+// MCP into HTTP frameworks other than net/http (e.g. fasthttp/fiber). For
+// net/http callers, ServeHTTP is the conventional and equivalent entry
+// point; in fact, ServeHTTP is implemented as a thin wrapper around Handle.
+//
+// Behavioral notes for callers integrating via Handle:
+//
+//   - WithStreamableHTTPCORS is NOT applied. Frameworks should use their
+//     native CORS middleware.
+//   - WithProtectedResourceMetadata is NOT applied. The caller should mount
+//     the metadata route separately if needed (see ProtectedResourceMetadataHandler).
+//   - WithHTTPContextFunc is honored for backwards compatibility; it receives
+//     a synthetic *http.Request derived from r so existing options keep working.
+//     Callers may also pre-populate r.Context with any values they need.
+//   - When w.CanStream() returns false, GET (SSE listening) is rejected with
+//     405 Method Not Allowed and POST responses that would otherwise upgrade
+//     to text/event-stream stay as a single buffered application/json reply.
+func (s *StreamableHTTPServer) Handle(w HTTPResponseWriter, r *HTTPRequest) {
+	if r == nil {
+		writeHTTPError(w, "nil request", http.StatusBadRequest)
+		return
+	}
+	switch r.Method {
+	case http.MethodPost:
+		s.handlePost(w, r)
+	case http.MethodGet:
+		s.handleGet(w, r)
+	case http.MethodDelete:
+		s.handleDelete(w, r)
+	default:
+		writeHTTPError(w, "404 page not found", http.StatusNotFound)
+	}
+}
+
+// resolveSessionIdManager returns the SessionIdManager configured for r,
+// preserving compatibility with custom SessionIdManagerResolver implementations
+// that take a *http.Request.
+func (s *StreamableHTTPServer) resolveSessionIdManager(r *HTTPRequest) SessionIdManager {
+	// Fast path: when the resolver is a DefaultSessionIdManagerResolver (the
+	// vast majority of deployments), the cached manager is identical to what
+	// the resolver would return and we can skip building a synthetic request.
+	if s.sessionIdManager != nil {
+		return s.sessionIdManager
+	}
+	return s.sessionIdManagerResolver.ResolveSessionIdManager(r.asHTTPRequest())
+}

--- a/server/streamable_http_handle_test.go
+++ b/server/streamable_http_handle_test.go
@@ -1,0 +1,294 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// bufferingHTTPResponseWriter is a minimal HTTPResponseWriter that buffers all
+// output. Its CanStream method always returns false, simulating an integration
+// (e.g. via fiber's adaptor.HTTPHandler) where the underlying transport cannot
+// deliver chunked SSE responses.
+type bufferingHTTPResponseWriter struct {
+	mu     sync.Mutex
+	header http.Header
+	status int
+	body   []byte
+	wrote  bool
+}
+
+func newBufferingHTTPResponseWriter() *bufferingHTTPResponseWriter {
+	return &bufferingHTTPResponseWriter{header: make(http.Header), status: http.StatusOK}
+}
+
+func (b *bufferingHTTPResponseWriter) Header() http.Header {
+	return b.header
+}
+
+func (b *bufferingHTTPResponseWriter) WriteHeader(status int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.wrote {
+		return
+	}
+	b.status = status
+	b.wrote = true
+}
+
+func (b *bufferingHTTPResponseWriter) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if !b.wrote {
+		b.wrote = true
+	}
+	b.body = append(b.body, p...)
+	return len(p), nil
+}
+
+func (b *bufferingHTTPResponseWriter) Flush() {}
+
+func (b *bufferingHTTPResponseWriter) CanStream() bool { return false }
+
+// flushableHTTPResponseWriter is an HTTPResponseWriter that records flushes so
+// tests can inspect SSE behavior without spinning up a real net/http stack.
+type flushableHTTPResponseWriter struct {
+	bufferingHTTPResponseWriter
+	flushes int
+}
+
+func newFlushableHTTPResponseWriter() *flushableHTTPResponseWriter {
+	return &flushableHTTPResponseWriter{
+		bufferingHTTPResponseWriter: bufferingHTTPResponseWriter{
+			header: make(http.Header),
+			status: http.StatusOK,
+		},
+	}
+}
+
+func (f *flushableHTTPResponseWriter) Flush() {
+	f.mu.Lock()
+	f.flushes++
+	f.mu.Unlock()
+}
+
+func (f *flushableHTTPResponseWriter) CanStream() bool { return true }
+
+func TestStreamableHTTPServer_Handle_InitializeWithoutNetHTTP(t *testing.T) {
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	srv := NewStreamableHTTPServer(mcpServer, WithStateful(true))
+
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "initialize",
+		"params": {
+			"protocolVersion": "2025-03-26",
+			"capabilities": {},
+			"clientInfo": {"name": "buffer-client", "version": "0.0.1"}
+		}
+	}`)
+
+	w := newBufferingHTTPResponseWriter()
+	r := &HTTPRequest{
+		Method:  http.MethodPost,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{"Content-Type": []string{"application/json"}},
+		Body:    body,
+		Context: t.Context(),
+	}
+
+	srv.Handle(w, r)
+
+	assert.Equal(t, http.StatusOK, w.status)
+	assert.Equal(t, "application/json", w.header.Get("Content-Type"))
+	sessionID := w.header.Get(HeaderKeySessionID)
+	assert.NotEmpty(t, sessionID, "stateful server should return a session id on initialize")
+
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.body, &resp))
+	assert.Equal(t, "2.0", resp["jsonrpc"])
+	require.Contains(t, resp, "result")
+}
+
+func TestStreamableHTTPServer_Handle_GetRejectedWhenWriterCannotStream(t *testing.T) {
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	srv := NewStreamableHTTPServer(mcpServer)
+
+	w := newBufferingHTTPResponseWriter()
+	r := &HTTPRequest{
+		Method:  http.MethodGet,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{},
+		Context: t.Context(),
+	}
+
+	srv.Handle(w, r)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.status)
+	assert.Contains(t, string(w.body), "Streaming unsupported")
+}
+
+func TestStreamableHTTPServer_Handle_PostNotificationsBufferedWhenNotStreamable(t *testing.T) {
+	// When the writer can't stream, mid-flight notifications must NOT be
+	// emitted as SSE; the server should fall back to the buffered JSON path.
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	srv := NewStreamableHTTPServer(mcpServer, WithStateLess(true))
+
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "ping"
+	}`)
+
+	w := newBufferingHTTPResponseWriter()
+	r := &HTTPRequest{
+		Method:  http.MethodPost,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{"Content-Type": []string{"application/json"}},
+		Body:    body,
+		Context: t.Context(),
+	}
+
+	srv.Handle(w, r)
+
+	assert.Equal(t, http.StatusOK, w.status)
+	assert.Equal(t, "application/json", w.header.Get("Content-Type"))
+	assert.False(t, strings.HasPrefix(string(w.body), "event:"),
+		"non-streaming writer must never receive SSE-formatted output")
+}
+
+func TestStreamableHTTPServer_Handle_InvalidContentType(t *testing.T) {
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	srv := NewStreamableHTTPServer(mcpServer)
+
+	w := newBufferingHTTPResponseWriter()
+	r := &HTTPRequest{
+		Method:  http.MethodPost,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{"Content-Type": []string{"text/plain"}},
+		Body:    []byte(`{}`),
+		Context: t.Context(),
+	}
+
+	srv.Handle(w, r)
+
+	assert.Equal(t, http.StatusBadRequest, w.status)
+	assert.Contains(t, string(w.body), "Invalid content type")
+}
+
+func TestStreamableHTTPServer_Handle_UnknownMethod(t *testing.T) {
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	srv := NewStreamableHTTPServer(mcpServer)
+
+	w := newBufferingHTTPResponseWriter()
+	r := &HTTPRequest{
+		Method:  http.MethodPatch,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{},
+		Context: t.Context(),
+	}
+
+	srv.Handle(w, r)
+
+	assert.Equal(t, http.StatusNotFound, w.status)
+}
+
+func TestStreamableHTTPServer_Handle_FlushableWriterMatchesServeHTTP(t *testing.T) {
+	// A streamable HTTPResponseWriter going through Handle should produce
+	// the same JSON body as net/http's default writer going through ServeHTTP
+	// for a vanilla initialize request.
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	srv := NewStreamableHTTPServer(mcpServer)
+
+	body := []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "initialize",
+		"params": {
+			"protocolVersion": "2025-03-26",
+			"capabilities": {},
+			"clientInfo": {"name": "stream-client", "version": "0.0.1"}
+		}
+	}`)
+
+	w := newFlushableHTTPResponseWriter()
+	r := &HTTPRequest{
+		Method:  http.MethodPost,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{"Content-Type": []string{"application/json"}},
+		Body:    body,
+		Context: t.Context(),
+	}
+
+	srv.Handle(w, r)
+
+	assert.Equal(t, http.StatusOK, w.status)
+	assert.Equal(t, "application/json", w.header.Get("Content-Type"))
+	var resp map[string]any
+	require.NoError(t, json.Unmarshal(w.body, &resp))
+	assert.Equal(t, "2.0", resp["jsonrpc"])
+	require.Contains(t, resp, "result")
+}
+
+func TestStreamableHTTPServer_Handle_ContextCarriedThrough(t *testing.T) {
+	// Values placed on HTTPRequest.Context must reach tool handlers, since
+	// pre-decorating the context is the canonical way for non-net/http
+	// integrations to replace WithHTTPContextFunc.
+	type ctxKey struct{}
+
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+
+	var seen any
+	mcpServer.AddTool(
+		mcp.NewTool("echo", mcp.WithDescription("ctx echo")),
+		func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			seen = ctx.Value(ctxKey{})
+			return mcp.NewToolResultText("ok"), nil
+		},
+	)
+
+	srv := NewStreamableHTTPServer(mcpServer, WithStateLess(true))
+
+	// Initialize first.
+	initBody := []byte(`{
+		"jsonrpc":"2.0","id":1,"method":"initialize",
+		"params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"x","version":"0"}}
+	}`)
+	w := newBufferingHTTPResponseWriter()
+	srv.Handle(w, &HTTPRequest{
+		Method:  http.MethodPost,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{"Content-Type": []string{"application/json"}},
+		Body:    initBody,
+		Context: t.Context(),
+	})
+	require.Equal(t, http.StatusOK, w.status)
+
+	// Then call the tool with a decorated context.
+	callBody := []byte(`{
+		"jsonrpc":"2.0","id":2,"method":"tools/call",
+		"params":{"name":"echo","arguments":{}}
+	}`)
+	w2 := newBufferingHTTPResponseWriter()
+	ctx := context.WithValue(t.Context(), ctxKey{}, "from-fasthttp")
+	srv.Handle(w2, &HTTPRequest{
+		Method:  http.MethodPost,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{"Content-Type": []string{"application/json"}},
+		Body:    callBody,
+		Context: ctx,
+	})
+	require.Equal(t, http.StatusOK, w2.status)
+
+	assert.Equal(t, "from-fasthttp", seen)
+}

--- a/www/docs/pages/transports/http.mdx
+++ b/www/docs/pages/transports/http.mdx
@@ -990,6 +990,179 @@ func (h *ApprovalSamplingHandler) CreateMessage(ctx context.Context, request mcp
 - Rejection at any stage returns an error to the server
 - The UI should clearly display what the server is requesting and why
 
+## Embedding in Non-net/http Frameworks
+
+`StreamableHTTPServer` exposes two equivalent entry points:
+
+- `ServeHTTP(w http.ResponseWriter, r *http.Request)` — the standard
+  `net/http` handler used by the examples above.
+- `Handle(w HTTPResponseWriter, r *HTTPRequest)` — a transport-agnostic
+  entry point that lets you embed MCP into HTTP frameworks that do **not**
+  go through `net/http` (e.g. [fasthttp](https://github.com/valyala/fasthttp)
+  or [fiber](https://gofiber.io/)) without round-tripping the response
+  through a buffering adaptor.
+
+Both methods drive the same internal state machine; `ServeHTTP` is
+implemented as a thin wrapper around `Handle`.
+
+### When to Use Which
+
+| Situation | Use |
+| --- | --- |
+| Standalone server, mounted in `http.ServeMux`, chi, gorilla/mux, etc. | `ServeHTTP` (or `srv.Start(":8080")`) |
+| Mounted in a fiber/echo/gin app via `adaptor.HTTPHandler` and you don't need streaming | `ServeHTTP` |
+| Mounted in fasthttp/fiber and you want native chunked SSE without an adaptor in the path | `Handle` |
+| Custom transport (test harness, in-memory dispatcher, alternative wire format on top of HTTP semantics) | `Handle` |
+
+:::tip
+If you only need request/response (no SSE notifications and no GET
+listening connection), the community workaround
+`fiberApp.Group("/mcp", adaptor.HTTPHandler(server.NewStreamableHTTPServer(s)))`
+is the simplest path and is fully supported.
+:::
+
+### API Surface
+
+```go
+// HTTPRequest is a transport-agnostic view of an incoming MCP HTTP request.
+type HTTPRequest struct {
+    Method  string          // "POST", "GET", "DELETE"
+    URL     *url.URL        // optional; only Path is consulted
+    Header  http.Header     // required; plain map[string][]string
+    Body    []byte          // already buffered; may be nil for GET/DELETE
+    Context context.Context // request context; cancellation is honored
+}
+
+// HTTPResponseWriter is the minimum surface mcp-go needs to write a
+// streamable HTTP response.
+type HTTPResponseWriter interface {
+    Header() http.Header
+    WriteHeader(statusCode int)
+    Write(p []byte) (int, error)
+    Flush()
+    CanStream() bool
+}
+
+func (s *StreamableHTTPServer) Handle(w HTTPResponseWriter, r *HTTPRequest)
+```
+
+### Streaming-Capability Contract
+
+The `CanStream()` bit on `HTTPResponseWriter` lets the server gracefully
+degrade when the underlying transport cannot deliver chunked responses:
+
+- **`CanStream()` returns `true`** — `Flush()` MUST forward bytes to the
+  client immediately. POST responses can upgrade to `text/event-stream`
+  when notifications fire mid-flight, and GET (the SSE listening channel)
+  is accepted.
+- **`CanStream()` returns `false`** — `Flush()` SHOULD be a no-op. POST
+  responses stay as a single buffered `application/json` reply (any
+  notifications produced during the request are dropped, since they cannot
+  be delivered without SSE). GET requests are rejected with `405 Method
+  Not Allowed`.
+
+### Adapter Example: fasthttp
+
+```go
+import (
+    "net/http"
+
+    "github.com/valyala/fasthttp"
+    "github.com/mark3labs/mcp-go/server"
+)
+
+// fasthttpResponseWriter implements server.HTTPResponseWriter on top of a
+// *fasthttp.RequestCtx. Streaming is supported via SetBodyStreamWriter.
+type fasthttpResponseWriter struct {
+    ctx     *fasthttp.RequestCtx
+    headers http.Header
+    status  int
+    written bool
+}
+
+func newFasthttpResponseWriter(ctx *fasthttp.RequestCtx) *fasthttpResponseWriter {
+    return &fasthttpResponseWriter{ctx: ctx, headers: http.Header{}, status: http.StatusOK}
+}
+
+func (w *fasthttpResponseWriter) Header() http.Header { return w.headers }
+
+func (w *fasthttpResponseWriter) WriteHeader(code int) {
+    if w.written {
+        return
+    }
+    w.status = code
+    for k, vv := range w.headers {
+        for _, v := range vv {
+            w.ctx.Response.Header.Add(k, v)
+        }
+    }
+    w.ctx.SetStatusCode(code)
+    w.written = true
+}
+
+func (w *fasthttpResponseWriter) Write(p []byte) (int, error) {
+    if !w.written {
+        w.WriteHeader(http.StatusOK)
+    }
+    return w.ctx.Write(p)
+}
+
+func (w *fasthttpResponseWriter) Flush() {
+    // fasthttp buffers the response body in-memory by default; flushing has
+    // no effect unless you hand the request off to SetBodyStreamWriter.
+}
+
+// CanStream reports false here because the simple buffered path above does
+// not deliver bytes mid-request. Wire it to true if you switch to
+// SetBodyStreamWriter for SSE.
+func (w *fasthttpResponseWriter) CanStream() bool { return false }
+
+// Bridging fasthttp headers to net/http's http.Header.
+func fromFasthttpHeader(h *fasthttp.RequestHeader) http.Header {
+    out := make(http.Header)
+    h.VisitAll(func(key, value []byte) {
+        out.Add(string(key), string(value))
+    })
+    return out
+}
+
+var mcpServer = server.NewStreamableHTTPServer(
+    server.NewMCPServer("my-server", "1.0.0"),
+)
+
+func mcpHandler(ctx *fasthttp.RequestCtx) {
+    w := newFasthttpResponseWriter(ctx)
+    r := &server.HTTPRequest{
+        Method:  string(ctx.Method()),
+        Header:  fromFasthttpHeader(&ctx.Request.Header),
+        Body:    ctx.PostBody(),
+        Context: ctx,
+    }
+    mcpServer.Handle(w, r)
+}
+```
+
+### Behavior Notes
+
+- **`WithStreamableHTTPCORS` is not applied** when entering through
+  `Handle`. Use the framework's native CORS middleware.
+- **`WithProtectedResourceMetadata` is not applied** when entering through
+  `Handle`. Mount the metadata route separately using
+  `NewProtectedResourceMetadataHandler`. See
+  [OAuth Protected Resource Metadata](#oauth-protected-resource-metadata-rfc-9728)
+  above.
+- **`WithHTTPContextFunc` is honored.** When the request entered through
+  `ServeHTTP` it receives the original `*http.Request`; when entered
+  through `Handle` it receives a synthetic `*http.Request` derived from
+  the `HTTPRequest`. Callers can also pre-decorate `r.Context` directly,
+  which is the recommended pattern for non-net/http integrations.
+- **`SessionIdManagerResolver`** still receives a `*http.Request` for
+  backwards compatibility; the synthetic request carries the headers and
+  URL needed by all built-in resolvers.
+- **Backwards compatibility:** every existing public API
+  (`NewStreamableHTTPServer`, `ServeHTTP`, `Start`, `Shutdown`, every
+  option, every session interface) is unchanged.
+
 ## Next Steps
 
 - **[In-Process Transport](/transports/inprocess)** - Learn about embedded scenarios


### PR DESCRIPTION
## Description

Adds a transport-agnostic entry point to `StreamableHTTPServer` so MCP can
be embedded in HTTP frameworks that do not go through `net/http`
(fasthttp, fiber, custom transports, in-memory test harnesses) without
buffering the response through an adaptor.

Two new exported types and one new method:

```go
type HTTPRequest struct {
    Method  string
    URL     *url.URL
    Header  http.Header
    Body    []byte
    Context context.Context
}

type HTTPResponseWriter interface {
    Header() http.Header
    WriteHeader(statusCode int)
    Write(p []byte) (int, error)
    Flush()
    CanStream() bool
}

func (s *StreamableHTTPServer) Handle(w HTTPResponseWriter, r *HTTPRequest)
```

`ServeHTTP` is refactored into a thin wrapper around `Handle` that builds
a default `httpResponseWriterAdapter` (forwards `Flush()` to
`http.Flusher` when present, returns `CanStream() == false` otherwise)
and an `HTTPRequest` retaining the original `*http.Request` for legacy
options like `WithHTTPContextFunc` and `SessionIdManagerResolver`.

The `CanStream()` capability bit lets the server gracefully degrade when
the underlying transport cannot deliver chunked responses: GET (SSE
listening) is rejected with `405 Method Not Allowed`, and POST stays as a
single buffered `application/json` reply instead of upgrading to
`text/event-stream`.

Fixes #611

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

**Files changed:**

- `server/streamable_http_handle.go` — new exported types `HTTPRequest`,
  `HTTPResponseWriter`, the `Handle` method, and the internal
  `httpResponseWriterAdapter` that wraps `http.ResponseWriter`.
- `server/streamable_http.go` — `handlePost`, `handleGet`, `handleDelete`,
  `handleSamplingResponse`, `deliverSamplingResponse`, and
  `writeJSONRPCError` now consume `(HTTPResponseWriter, *HTTPRequest)`.
  `ServeHTTP` becomes a small adapter that buffers the POST body up-front,
  wraps the writer, and dispatches into the same per-method handlers.
- `server/streamable_http_handle_test.go` — seven new tests covering
  initialize without `net/http`, GET rejection when the writer cannot
  stream, POST notifications correctly buffered when not streamable,
  invalid content type, unknown method, parity between flushable
  `Handle` and `ServeHTTP`, and context propagation through `Handle`.
- `README.md` — new subsection under `### Transports` introducing `Handle`
  with a link to the full transport docs.
- `www/docs/pages/transports/http.mdx` — new
  `## Embedding in Non-net/http Frameworks` section with a
  `ServeHTTP`-vs-`Handle` comparison table, the API surface, the
  streaming-capability contract, a concrete fasthttp adapter example,
  and behavior notes covering `WithStreamableHTTPCORS`,
  `WithProtectedResourceMetadata`, `WithHTTPContextFunc`, and
  `SessionIdManagerResolver`.

**Backwards compatibility:**

- Every existing public API (`NewStreamableHTTPServer`, `ServeHTTP`,
  `Start`, `Shutdown`, every option, every session interface) is
  unchanged.
- `WithHTTPContextFunc` is honored from both `ServeHTTP` and `Handle`.
  Under `ServeHTTP` it still receives the original `*http.Request`; under
  `Handle` it receives a synthetic `*http.Request` derived from
  `HTTPRequest` so existing options keep working.
- `SessionIdManagerResolver.ResolveSessionIdManager(*http.Request)` is
  unchanged. A small internal helper takes the fast path through the
  cached default manager and only synthesizes a request for custom
  resolvers.
- When entering through `Handle`, `WithStreamableHTTPCORS` and
  `WithProtectedResourceMetadata` are intentionally not applied: those
  are HTTP-framework-level concerns and frameworks have their own
  middleware. Documented on `Handle` and in the docs page.

**Verification:**

- `go test ./... -race` ✅
- `go vet ./...` ✅
- `golangci-lint run` ✅
- `npx vocs build` (docs site) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added transport-agnostic API to embed the server in HTTP frameworks beyond standard net/http, enabling framework flexibility with unified streaming capability negotiation.
* **Documentation**
  * Added guides for integrating with alternative HTTP frameworks, including adapter implementation patterns and behavior compatibility notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->