### PR TITLE
fix(server): add CloseSessions and prevent double-close panic on SSE sessions

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -472,6 +472,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 // service and you need to disconnect all clients independently of the server
 // lifecycle (e.g., during a configuration reload or maintenance window).
 // This signals termination; in-flight handlers exit asynchronously.
+// Sessions connecting concurrently with this call may not be terminated.
 func (s *SSEServer) CloseSessions() {
 	s.sessions.Range(func(key, value any) bool {
 		if session, ok := value.(*sseSession); ok {

--- a/server/sse.go
+++ b/server/sse.go
@@ -461,14 +461,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 	s.mu.RUnlock()
 
 	if srv != nil {
-		s.sessions.Range(func(key, value any) bool {
-			if session, ok := value.(*sseSession); ok {
-				session.closeDone()
-			}
-			s.sessions.Delete(key)
-			return true
-		})
-
+		s.CloseSessions()
 		return srv.Shutdown(ctx)
 	}
 	return nil

--- a/server/sse.go
+++ b/server/sse.go
@@ -22,6 +22,7 @@ import (
 // sseSession represents an active SSE connection.
 type sseSession struct {
 	done                chan struct{}
+	doneOnce            sync.Once
 	eventQueue          chan string // Channel for queuing events
 	sessionID           string
 	requestID           atomic.Int64
@@ -33,6 +34,14 @@ type sseSession struct {
 	resourceTemplates   sync.Map     // stores session-specific resource templates
 	clientInfo          atomic.Value // stores session-specific client info
 	clientCapabilities  atomic.Value // stores session-specific client capabilities
+}
+
+// closeDone safely closes the session's done channel exactly once,
+// preventing panics from concurrent close attempts.
+func (s *sseSession) closeDone() {
+	s.doneOnce.Do(func() {
+		close(s.done)
+	})
 }
 
 // SSEContextFunc is a function that takes an existing context and the current
@@ -454,7 +463,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 	if srv != nil {
 		s.sessions.Range(func(key, value any) bool {
 			if session, ok := value.(*sseSession); ok {
-				close(session.done)
+				session.closeDone()
 			}
 			s.sessions.Delete(key)
 			return true
@@ -463,6 +472,20 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 		return srv.Shutdown(ctx)
 	}
 	return nil
+}
+
+// CloseSessions terminates all active SSE sessions without stopping the HTTP
+// server. This is useful when the SSE server is embedded within another HTTP
+// service and you need to disconnect all clients independently of the server
+// lifecycle (e.g., during a configuration reload or maintenance window).
+func (s *SSEServer) CloseSessions() {
+	s.sessions.Range(func(key, value any) bool {
+		if session, ok := value.(*sseSession); ok {
+			session.closeDone()
+		}
+		s.sessions.Delete(key)
+		return true
+	})
 }
 
 // handleSSE handles incoming SSE connection requests.
@@ -590,7 +613,7 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprint(w, event)
 			flusher.Flush()
 		case <-r.Context().Done():
-			close(session.done)
+			session.closeDone()
 			return
 		case <-session.done:
 			return

--- a/server/sse.go
+++ b/server/sse.go
@@ -471,6 +471,7 @@ func (s *SSEServer) Shutdown(ctx context.Context) error {
 // server. This is useful when the SSE server is embedded within another HTTP
 // service and you need to disconnect all clients independently of the server
 // lifecycle (e.g., during a configuration reload or maintenance window).
+// This signals termination; in-flight handlers exit asynchronously.
 func (s *SSEServer) CloseSessions() {
 	s.sessions.Range(func(key, value any) bool {
 		if session, ok := value.(*sseSession); ok {

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -1617,6 +1617,101 @@ func readSSEEvent(sseResp *http.Response) (string, error) {
 	return string(buf[:n]), nil
 }
 
+func TestSSEServer_CloseSessions(t *testing.T) {
+	mcpServer := NewMCPServer("test", "1.0.0")
+	sseServer := NewSSEServer(mcpServer, WithBaseURL("http://localhost:0"))
+
+	ts := httptest.NewServer(sseServer)
+	defer ts.Close()
+	sseServer.baseURL = ts.URL
+
+	// Connect a client to the SSE endpoint.
+	sseResp, err := http.Get(ts.URL + "/sse")
+	if err != nil {
+		t.Fatalf("Failed to connect to SSE endpoint: %v", err)
+	}
+	defer sseResp.Body.Close()
+
+	// Read the initial endpoint event to confirm we're connected.
+	endpointEvent, err := readSSEEvent(sseResp)
+	if err != nil {
+		t.Fatalf("Failed to read endpoint event: %v", err)
+	}
+	if !strings.Contains(endpointEvent, "event: endpoint") {
+		t.Fatalf("Expected endpoint event, got: %s", endpointEvent)
+	}
+
+	// Verify at least one session exists.
+	sessionCount := 0
+	sseServer.sessions.Range(func(_, _ any) bool {
+		sessionCount++
+		return true
+	})
+	if sessionCount == 0 {
+		t.Fatal("Expected at least one active session")
+	}
+
+	// Close all sessions without stopping the HTTP server.
+	sseServer.CloseSessions()
+
+	// Verify sessions are cleaned up.
+	sessionCount = 0
+	sseServer.sessions.Range(func(_, _ any) bool {
+		sessionCount++
+		return true
+	})
+	if sessionCount != 0 {
+		t.Fatalf("Expected 0 sessions after CloseSessions, got %d", sessionCount)
+	}
+
+	// Verify the HTTP server is still running by connecting a new client.
+	sseResp2, err := http.Get(ts.URL + "/sse")
+	if err != nil {
+		t.Fatalf("HTTP server should still be running after CloseSessions: %v", err)
+	}
+	defer sseResp2.Body.Close()
+
+	endpointEvent2, err := readSSEEvent(sseResp2)
+	if err != nil {
+		t.Fatalf("Failed to read endpoint event from new connection: %v", err)
+	}
+	if !strings.Contains(endpointEvent2, "event: endpoint") {
+		t.Fatalf("Expected endpoint event on new connection, got: %s", endpointEvent2)
+	}
+}
+
+func TestSSEServer_CloseSessionsConcurrent(t *testing.T) {
+	mcpServer := NewMCPServer("test", "1.0.0")
+	sseServer := NewSSEServer(mcpServer, WithBaseURL("http://localhost:0"))
+
+	ts := httptest.NewServer(sseServer)
+	defer ts.Close()
+	sseServer.baseURL = ts.URL
+
+	// Connect a client.
+	sseResp, err := http.Get(ts.URL + "/sse")
+	if err != nil {
+		t.Fatalf("Failed to connect to SSE endpoint: %v", err)
+	}
+	defer sseResp.Body.Close()
+
+	_, err = readSSEEvent(sseResp)
+	if err != nil {
+		t.Fatalf("Failed to read endpoint event: %v", err)
+	}
+
+	// Call CloseSessions concurrently to verify no double-close panic.
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			sseServer.CloseSessions()
+		}()
+	}
+	wg.Wait()
+}
+
 // addHeaderVerificationTool adds a tool that verifies HTTP headers are passed correctly
 func addHeaderVerificationTool(mcpServer *MCPServer) {
 	mcpServer.AddTool(

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -1702,12 +1702,10 @@ func TestSSEServer_CloseSessionsConcurrent(t *testing.T) {
 
 	// Call CloseSessions concurrently to verify no double-close panic.
 	var wg sync.WaitGroup
-	for i := 0; i < 100; i++ {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+	for range 100 {
+		wg.Go(func() {
 			sseServer.CloseSessions()
-		}()
+		})
 	}
 	wg.Wait()
 }

--- a/server/sse_test.go
+++ b/server/sse_test.go
@@ -1708,6 +1708,16 @@ func TestSSEServer_CloseSessionsConcurrent(t *testing.T) {
 		})
 	}
 	wg.Wait()
+
+	// Sessions should be cleaned up regardless of which call ran first.
+	count := 0
+	sseServer.sessions.Range(func(_, _ any) bool {
+		count++
+		return true
+	})
+	if count != 0 {
+		t.Fatalf("Expected 0 sessions after concurrent CloseSessions, got %d", count)
+	}
 }
 
 // addHeaderVerificationTool adds a tool that verifies HTTP headers are passed correctly


### PR DESCRIPTION
## Description

Add `CloseSessions()` to terminate all active SSE sessions without stopping the HTTP server. This is useful when the SSE server is embedded within another HTTP service and clients need to be disconnected independently of the server lifecycle (e.g., during configuration reloads or maintenance windows).

Also fixes a pre-existing race condition where concurrent calls to `Shutdown()` and client disconnects (`r.Context().Done()`) could both attempt to `close(session.done)`, causing a panic. All close operations now go through a `sync.Once`-guarded `closeDone()` method.

Supersedes #698. Implements the same feature with the concurrency safety fix identified in review. Credit to @cowkeys for the original idea.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Changes

- Add `doneOnce sync.Once` field to `sseSession`
- Add `closeDone()` method that safely closes the done channel exactly once
- Replace direct `close(session.done)` in `Shutdown()` and `handleSSE()` with `closeDone()`
- Add `CloseSessions()` method on `SSEServer`
- Add tests: basic functionality + 100-goroutine concurrent stress test

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API to close all active Server-Sent Events (SSE) sessions without stopping the HTTP server, enabling orderly session teardown.
* **Bug Fixes**
  * Made session shutdown and cleanup safe and idempotent to prevent race conditions during shutdown and request cancellation.
* **Tests**
  * Added tests covering session closure, concurrent CloseSessions calls, cleanup validation, and re-connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->