### PR TITLE
feat(server): add WithStrictInputSchemaDefault

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -216,6 +216,7 @@ type MCPServer struct {
 	inflightCancels            sync.Map             // Maps request ID -> context.CancelFunc for in-flight requests
 	inputValidator             *inputSchemaValidator
 	outputValidator            *outputSchemaValidator
+	strictInputSchemaDefault   bool
 }
 
 // WithPaginationLimit sets the pagination limit for the server.
@@ -410,6 +411,28 @@ func WithInputSchemaValidation() ServerOption {
 		if s.inputValidator == nil {
 			s.inputValidator = newInputSchemaValidator()
 		}
+	}
+}
+
+// WithStrictInputSchemaDefault sets additionalProperties:false on every
+// registered tool's input schema when the tool author has not configured the
+// field explicitly. Tools published by such a server reject unknown property
+// names — at the client (which sees the strict schema in tools/list) and at
+// the server when [WithInputSchemaValidation] is also enabled.
+//
+// Tools that supply [mcp.Tool.RawInputSchema] are not modified: those authors
+// have opted out of the structured-schema helpers and own additionalProperties
+// themselves. Tools that explicitly call
+// [mcp.WithSchemaAdditionalProperties] are left untouched, so a single tool
+// can opt back into permissive behaviour while the server default stays
+// strict.
+//
+// The option is independent of [WithInputSchemaValidation]: setting strict
+// schemas without server-side enforcement still steers schema-aware clients
+// and language models away from unknown arguments.
+func WithStrictInputSchemaDefault() ServerOption {
+	return func(s *MCPServer) {
+		s.strictInputSchemaDefault = true
 	}
 }
 
@@ -826,6 +849,24 @@ func (s *MCPServer) ListPrompts() map[string]ServerPrompt {
 	return promptsCopy
 }
 
+// applyStrictInputSchemaDefault fills in additionalProperties:false on a
+// registered tool's structured input schema when WithStrictInputSchemaDefault
+// is set and the author has not configured the field. Tools that ship a
+// RawInputSchema are skipped — those bypass the structured-schema helpers
+// and own additionalProperties themselves.
+func (s *MCPServer) applyStrictInputSchemaDefault(tool *mcp.Tool) {
+	if !s.strictInputSchemaDefault {
+		return
+	}
+	if len(tool.RawInputSchema) > 0 {
+		return
+	}
+	if tool.InputSchema.AdditionalProperties != nil {
+		return
+	}
+	tool.InputSchema.AdditionalProperties = false
+}
+
 // AddTool registers a new tool and its handler
 func (s *MCPServer) AddTool(tool mcp.Tool, handler ToolHandlerFunc) {
 	s.AddTools(ServerTool{Tool: tool, Handler: handler})
@@ -887,6 +928,7 @@ func (s *MCPServer) AddTools(tools ...ServerTool) {
 			s.toolsMu.Unlock()
 			panic(fmt.Sprintf("tool name '%s' already registered as task tool", name))
 		}
+		s.applyStrictInputSchemaDefault(&entry.Tool)
 		s.tools[name] = entry
 	}
 	s.toolsMu.Unlock()
@@ -910,6 +952,7 @@ func (s *MCPServer) AddTaskTools(taskTools ...ServerTaskTool) {
 			s.toolsMu.Unlock()
 			panic(fmt.Sprintf("task tool name '%s' already registered as regular tool", name))
 		}
+		s.applyStrictInputSchemaDefault(&entry.Tool)
 		s.taskTools[name] = entry
 	}
 	s.toolsMu.Unlock()
@@ -934,6 +977,7 @@ func (s *MCPServer) SetTools(tools ...ServerTool) {
 			s.toolsMu.Unlock()
 			panic(fmt.Sprintf("tool name '%s' already registered as task tool", name))
 		}
+		s.applyStrictInputSchemaDefault(&entry.Tool)
 		newTools[name] = entry
 	}
 	s.tools = newTools

--- a/server/session.go
+++ b/server/session.go
@@ -386,6 +386,7 @@ func (s *MCPServer) AddSessionTools(sessionID string, tools ...ServerTool) error
 
 	// Add new tools
 	for _, tool := range tools {
+		s.applyStrictInputSchemaDefault(&tool.Tool)
 		newSessionTools[tool.Tool.Name] = tool
 	}
 

--- a/server/strict_input_schema_default_test.go
+++ b/server/strict_input_schema_default_test.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestStrictInputSchemaDefault_RegistersAdditionalPropertiesFalse pins that
+// WithStrictInputSchemaDefault sets additionalProperties:false on a tool that
+// did not configure the field, and that tools/list reflects the strict
+// schema so a schema-aware client sees it.
+func TestStrictInputSchemaDefault_RegistersAdditionalPropertiesFalse(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithStrictInputSchemaDefault())
+	tool := mcp.NewTool("kubernetes_list",
+		mcp.WithString("resourceType", mcp.Required()),
+		mcp.WithString("continue"),
+	)
+	srv.AddTool(tool, okHandler)
+
+	stored := srv.GetTool("kubernetes_list")
+	require.NotNil(t, stored)
+	assert.Equal(t, false, stored.Tool.InputSchema.AdditionalProperties)
+}
+
+// TestStrictInputSchemaDefault_PreservesExplicitOptIn confirms that an author
+// who explicitly chose permissive (true) — or who supplied a schema for
+// additionalProperties — is not overridden by the server default.
+func TestStrictInputSchemaDefault_PreservesExplicitOptIn(t *testing.T) {
+	tests := []struct {
+		name string
+		opts []mcp.ToolOption
+		want any
+	}{
+		{
+			name: "explicit true stays true",
+			opts: []mcp.ToolOption{
+				mcp.WithString("name"),
+				mcp.WithSchemaAdditionalProperties(true),
+			},
+			want: true,
+		},
+		{
+			name: "explicit schema stays as map",
+			opts: []mcp.ToolOption{
+				mcp.WithString("name"),
+				mcp.WithSchemaAdditionalProperties(map[string]any{"type": "string"}),
+			},
+			want: map[string]any{"type": "string"},
+		},
+		{
+			name: "explicit false stays false",
+			opts: []mcp.ToolOption{
+				mcp.WithString("name"),
+				mcp.WithSchemaAdditionalProperties(false),
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := NewMCPServer("test", "1.0.0", WithStrictInputSchemaDefault())
+			tool := mcp.NewTool("t", tt.opts...)
+			srv.AddTool(tool, okHandler)
+
+			stored := srv.GetTool("t")
+			require.NotNil(t, stored)
+			assert.Equal(t, tt.want, stored.Tool.InputSchema.AdditionalProperties)
+		})
+	}
+}
+
+// TestStrictInputSchemaDefault_SkipsRawInputSchema documents that tools
+// shipping a RawInputSchema are out of scope for the option. Raw is an
+// explicit opt-out of the structured-schema helpers and naive top-level
+// patching is unsafe for $ref / oneOf shapes.
+func TestStrictInputSchemaDefault_SkipsRawInputSchema(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithStrictInputSchemaDefault())
+	raw := json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"}}}`)
+	tool := mcp.Tool{
+		Name:           "raw",
+		RawInputSchema: raw,
+	}
+	srv.AddTool(tool, okHandler)
+
+	stored := srv.GetTool("raw")
+	require.NotNil(t, stored)
+	assert.JSONEq(t, string(raw), string(stored.Tool.RawInputSchema),
+		"raw schema must be preserved verbatim")
+	assert.Nil(t, stored.Tool.InputSchema.AdditionalProperties)
+}
+
+// TestStrictInputSchemaDefault_DisabledByDefault is the back-compat regression
+// guard: without the option, registered tools must keep their original
+// (nil / unset) AdditionalProperties value so existing servers do not change
+// behaviour silently.
+func TestStrictInputSchemaDefault_DisabledByDefault(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0")
+	tool := mcp.NewTool("t", mcp.WithString("name"))
+	srv.AddTool(tool, okHandler)
+
+	stored := srv.GetTool("t")
+	require.NotNil(t, stored)
+	assert.Nil(t, stored.Tool.InputSchema.AdditionalProperties)
+}
+
+// TestStrictInputSchemaDefault_RejectsUnknownPropertyWithValidation is the
+// integration check: combined with WithInputSchemaValidation, the server
+// rejects an unknown property without per-tool WithSchemaAdditionalProperties
+// calls. This is the boilerplate-removal use case.
+func TestStrictInputSchemaDefault_RejectsUnknownPropertyWithValidation(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0",
+		WithStrictInputSchemaDefault(),
+		WithInputSchemaValidation(),
+	)
+	tool := mcp.NewTool("kubernetes_list",
+		mcp.WithString("resourceType", mcp.Required()),
+		mcp.WithString("continue"),
+	)
+	srv.AddTool(tool, okHandler)
+
+	resp := callTool(t, srv, "kubernetes_list", map[string]any{
+		"resourceType": "pods",
+		"cursor":       "abc",
+	})
+	requireToolErrorContaining(t, resp, "cursor")
+}
+
+// TestStrictInputSchemaDefault_DoesNotMutateCallerTool checks that the option
+// only affects the in-server copy of the tool. Callers who pass the same
+// mcp.Tool value to multiple servers must observe their original variable
+// unchanged.
+func TestStrictInputSchemaDefault_DoesNotMutateCallerTool(t *testing.T) {
+	tool := mcp.NewTool("t", mcp.WithString("name"))
+	require.Nil(t, tool.InputSchema.AdditionalProperties)
+
+	srv := NewMCPServer("test", "1.0.0", WithStrictInputSchemaDefault())
+	srv.AddTool(tool, okHandler)
+
+	assert.Nil(t, tool.InputSchema.AdditionalProperties,
+		"caller's tool variable must remain untouched")
+
+	stored := srv.GetTool("t")
+	require.NotNil(t, stored)
+	assert.Equal(t, false, stored.Tool.InputSchema.AdditionalProperties)
+}
+
+// TestStrictInputSchemaDefault_AppliesToSetTools covers the SetTools
+// replacement path so a strict server cannot quietly fall back to permissive
+// schemas after a SetTools refresh.
+func TestStrictInputSchemaDefault_AppliesToSetTools(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithStrictInputSchemaDefault())
+	srv.SetTools(ServerTool{
+		Tool:    mcp.NewTool("t", mcp.WithString("name")),
+		Handler: okHandler,
+	})
+
+	stored := srv.GetTool("t")
+	require.NotNil(t, stored)
+	assert.Equal(t, false, stored.Tool.InputSchema.AdditionalProperties)
+}
+
+// TestStrictInputSchemaDefault_AppliesToSessionTools covers session-scoped
+// tools so a session that shadows a global tool inherits the strict default.
+func TestStrictInputSchemaDefault_AppliesToSessionTools(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithStrictInputSchemaDefault())
+	sess := &fakeSessionWithTools{
+		id:    "s1",
+		ready: true,
+		tools: map[string]ServerTool{},
+	}
+	require.NoError(t, srv.RegisterSession(t.Context(), sess))
+
+	require.NoError(t, srv.AddSessionTool("s1",
+		mcp.NewTool("t", mcp.WithString("name")), okHandler))
+
+	got := sess.GetSessionTools()["t"]
+	assert.Equal(t, false, got.Tool.InputSchema.AdditionalProperties)
+}
+
+// fakeSessionWithTools is a minimal SessionWithTools used to exercise the
+// session-scoped registration path without spinning up a full transport.
+type fakeSessionWithTools struct {
+	id    string
+	ready bool
+	tools map[string]ServerTool
+}
+
+func (f *fakeSessionWithTools) SessionID() string                              { return f.id }
+func (f *fakeSessionWithTools) NotificationChannel() chan<- mcp.JSONRPCNotification { return nil }
+func (f *fakeSessionWithTools) Initialize()                                    { f.ready = true }
+func (f *fakeSessionWithTools) Initialized() bool                              { return f.ready }
+func (f *fakeSessionWithTools) GetSessionTools() map[string]ServerTool         { return f.tools }
+func (f *fakeSessionWithTools) SetSessionTools(tools map[string]ServerTool)    { f.tools = tools }


### PR DESCRIPTION
## Summary

Adds a server option that sets `additionalProperties: false` on every registered tool's input schema in one place, instead of repeating `mcp.WithSchemaAdditionalProperties(false)` on each tool. Authors who configure `additionalProperties` explicitly (true, false, or a schema) are not overridden, and tools using `RawInputSchema` are skipped since those bypass the structured-schema helpers.

The option pairs naturally with `WithInputSchemaValidation` (#834): the strict published schema steers schema-aware clients via `tools/list`, and validation rejects unknown args server-side when both options are enabled. They remain orthogonal — strict schemas without server-side enforcement still steer well-behaved clients and language models.

Applied at registration in `AddTools`, `AddTaskTools`, `SetTools`, and `AddSessionTools`. The mutation is on the server's value-copy of the tool, so the caller's variable is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `WithStrictInputSchemaDefault` server option to configure default behavior for tool input schemas.
* **Bug Fixes**
  * Enhanced session resource validation to enforce RFC 3986 URI compliance and non-empty values.
  * Added validation for session resource templates with requirements for URIs and names.
* **Tests**
  * Added comprehensive tests for strict input schema configuration and resource validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->