### PR TITLE
fix(mcp): allow _meta on paginated requests

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -664,7 +664,7 @@ type PaginatedParams struct {
 	// Meta carries protocol-level metadata. PaginatedRequest embeds Request
 	// and shadows its Params with this type, so Meta must be declared here
 	// to be marshaled on paginated requests (tools/list, resources/list,
-	// prompts/list, resources/templates/list, roots/list).
+	// resources/templates/list, prompts/list, tasks/list).
 	Meta *Meta `json:"_meta,omitempty"`
 }
 

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -661,6 +661,11 @@ type PaginatedParams struct {
 	// An opaque token representing the current pagination position.
 	// If provided, the server should return results starting after this cursor.
 	Cursor Cursor `json:"cursor,omitempty"`
+	// Meta carries protocol-level metadata. PaginatedRequest embeds Request
+	// and shadows its Params with this type, so Meta must be declared here
+	// to be marshaled on paginated requests (tools/list, resources/list,
+	// prompts/list, resources/templates/list, roots/list).
+	Meta *Meta `json:"_meta,omitempty"`
 }
 
 type PaginatedResult struct {

--- a/mcp/types_test.go
+++ b/mcp/types_test.go
@@ -457,36 +457,65 @@ func TestCompleteParamsUnmarshalJSON(t *testing.T) {
 }
 
 func TestPaginatedParamsMetaMarshalling(t *testing.T) {
-	t.Run("ListToolsRequest with _meta serializes the meta field", func(t *testing.T) {
+	// Marshalling the full request (rather than just req.Params) is what
+	// exercises the embedding/shadowing in PaginatedRequest -> Request.
+	// Without Meta on PaginatedParams, the inner Request.Params.Meta would
+	// be silently dropped at the outer-struct level.
+	t.Run("ListToolsRequest with _meta serializes the meta field on params", func(t *testing.T) {
 		req := ListToolsRequest{}
 		req.Params.Cursor = "page-2"
 		req.Params.Meta = &Meta{
 			AdditionalFields: map[string]any{"orgId": "org-1", "appId": "app-7"},
 		}
 
-		data, err := json.Marshal(req.Params)
+		data, err := json.Marshal(req)
 		require.NoError(t, err)
-		assert.JSONEq(t, `{"cursor":"page-2","_meta":{"orgId":"org-1","appId":"app-7"}}`, string(data))
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(data, &got))
+		params, ok := got["params"].(map[string]any)
+		require.True(t, ok, "params object missing from marshaled request: %s", data)
+		assert.Equal(t, "page-2", params["cursor"])
+		meta, ok := params["_meta"].(map[string]any)
+		require.True(t, ok, "_meta object missing from marshaled params: %s", data)
+		assert.Equal(t, "org-1", meta["orgId"])
+		assert.Equal(t, "app-7", meta["appId"])
 	})
 
-	t.Run("ListToolsRequest without _meta omits the meta field", func(t *testing.T) {
+	t.Run("ListToolsRequest without _meta omits the meta field on params", func(t *testing.T) {
 		req := ListToolsRequest{}
 		req.Params.Cursor = "page-2"
 
-		data, err := json.Marshal(req.Params)
+		data, err := json.Marshal(req)
 		require.NoError(t, err)
-		assert.JSONEq(t, `{"cursor":"page-2"}`, string(data))
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(data, &got))
+		params, ok := got["params"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "page-2", params["cursor"])
+		_, hasMeta := params["_meta"]
+		assert.False(t, hasMeta, "_meta should be omitted: %s", data)
 	})
 
-	t.Run("ListToolsRequest with only _meta omits cursor", func(t *testing.T) {
+	t.Run("ListToolsRequest with only _meta serializes _meta and omits cursor", func(t *testing.T) {
 		req := ListToolsRequest{}
 		req.Params.Meta = &Meta{
 			AdditionalFields: map[string]any{"orgId": "org-1"},
 		}
 
-		data, err := json.Marshal(req.Params)
+		data, err := json.Marshal(req)
 		require.NoError(t, err)
-		assert.JSONEq(t, `{"_meta":{"orgId":"org-1"}}`, string(data))
+
+		var got map[string]any
+		require.NoError(t, json.Unmarshal(data, &got))
+		params, ok := got["params"].(map[string]any)
+		require.True(t, ok)
+		_, hasCursor := params["cursor"]
+		assert.False(t, hasCursor, "cursor should be omitted: %s", data)
+		meta, ok := params["_meta"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "org-1", meta["orgId"])
 	})
 
 	t.Run("PaginatedParams round-trips _meta via JSON", func(t *testing.T) {

--- a/mcp/types_test.go
+++ b/mcp/types_test.go
@@ -455,3 +455,56 @@ func TestCompleteParamsUnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestPaginatedParamsMetaMarshalling(t *testing.T) {
+	t.Run("ListToolsRequest with _meta serializes the meta field", func(t *testing.T) {
+		req := ListToolsRequest{}
+		req.Params.Cursor = "page-2"
+		req.Params.Meta = &Meta{
+			AdditionalFields: map[string]any{"orgId": "org-1", "appId": "app-7"},
+		}
+
+		data, err := json.Marshal(req.Params)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"cursor":"page-2","_meta":{"orgId":"org-1","appId":"app-7"}}`, string(data))
+	})
+
+	t.Run("ListToolsRequest without _meta omits the meta field", func(t *testing.T) {
+		req := ListToolsRequest{}
+		req.Params.Cursor = "page-2"
+
+		data, err := json.Marshal(req.Params)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"cursor":"page-2"}`, string(data))
+	})
+
+	t.Run("ListToolsRequest with only _meta omits cursor", func(t *testing.T) {
+		req := ListToolsRequest{}
+		req.Params.Meta = &Meta{
+			AdditionalFields: map[string]any{"orgId": "org-1"},
+		}
+
+		data, err := json.Marshal(req.Params)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"_meta":{"orgId":"org-1"}}`, string(data))
+	})
+
+	t.Run("PaginatedParams round-trips _meta via JSON", func(t *testing.T) {
+		original := PaginatedParams{
+			Cursor: "abc",
+			Meta: &Meta{
+				ProgressToken:    "tok-1",
+				AdditionalFields: map[string]any{"k": "v"},
+			},
+		}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+
+		var got PaginatedParams
+		require.NoError(t, json.Unmarshal(data, &got))
+		assert.Equal(t, original.Cursor, got.Cursor)
+		require.NotNil(t, got.Meta)
+		assert.Equal(t, original.Meta.ProgressToken, got.Meta.ProgressToken)
+		assert.Equal(t, "v", got.Meta.AdditionalFields["k"])
+	})
+}


### PR DESCRIPTION
## Description

\`PaginatedRequest\` embeds \`Request\` and shadows its \`Params\` field with its own \`PaginatedParams\` value. Both fields use the JSON tag \`params\`, so \`encoding/json\` takes the outer (PaginatedParams) and silently drops the inner (RequestParams), including its \`Meta\` field.

The practical effect: any request type that embeds \`PaginatedRequest\`, namely \`ListToolsRequest\`, \`ListPromptsRequest\`, \`ListResourcesRequest\`, \`ListResourceTemplatesRequest\`, and \`ListRootsRequest\`, cannot carry \`_meta\` on the wire even though the MCP protocol permits it on any request. The sibling \`CallToolParams\` already exposes \`Meta\`; paginated params just don't.

```go
req := mcp.ListToolsRequest{}
req.Request.Params.Meta = &mcp.Meta{...}   // compiles, doesn't marshal
data, _ := json.Marshal(req)
// {"method":"","params":{}}    <- _meta is lost
```

This blocks any in-band routing or contextual metadata on \`tools/list\` and friends. Concrete use case I hit: an internal tool-routing server that needs request-level routing context on both \`tools/list\` and \`tools/call\` failed to receive any context for \`tools/list\` because of this. We worked around it via a custom HTTP header, but the SDK's typed shape should match what the protocol allows.

## Fix

Add \`Meta *Meta\` to \`PaginatedParams\` so it survives marshalling. One-line struct change. Tests cover:
- \`ListToolsRequest\` with both cursor and \`_meta\` serializes both
- \`ListToolsRequest\` without \`_meta\` continues to omit it
- \`ListToolsRequest\` with only \`_meta\` (no cursor) serializes only \`_meta\`
- \`PaginatedParams\` JSON round-trip preserves \`Meta\`

Backward compatible: \`Meta\` is optional with \`omitempty\`. Existing callers that don't set it produce identical JSON to before.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] MCP spec compatibility implementation

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (no doc changes warranted; struct field is self-documenting and follows the existing CallToolParams precedent)

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Meta field](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta) (\`_meta\` is permitted on any request's params per the base \`Request\` schema)
- [x] Implementation follows the specification exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pagination now supports optional metadata (_meta) in list-style requests, ensuring pagination cursors and progress tokens are serialized when present.

* **Tests**
  * Added tests verifying serialization/deserialization of pagination metadata and cursor behavior; cleaned up test artifacts for clearer test output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->