### PR TITLE
fix(oauth): parse spaced resource_metadata params

### DIFF
--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -2203,6 +2203,7 @@ func TestExtractResourceMetadataURLs(t *testing.T) {
 		{"empty header", "", nil},
 		{"no resource_metadata", `Bearer realm="mcp"`, nil},
 		{"single quoted value", `Bearer resource_metadata="https://example.com/prm"`, []string{"https://example.com/prm"}},
+		{"whitespace around equals", `Bearer resource_metadata = "https://example.com/prm"`, []string{"https://example.com/prm"}},
 		{"case-insensitive name", `Bearer Resource_Metadata="https://example.com/prm"`, []string{"https://example.com/prm"}},
 		{
 			"two challenges, both carrying resource_metadata",


### PR DESCRIPTION
## Summary

This PR now keeps the OAuth protected-resource metadata change focused on one remaining regression test after the upstream OAuth discovery code was refreshed.

It adds coverage for a `WWW-Authenticate` parameter with optional whitespace around `=`:

```text
Bearer resource_metadata = "https://example.com/prm"
```

The current `extractResourceMetadataURLs` implementation already handles the broader parser behavior on `main`; this PR just locks in that spaced-parameter case so it does not regress.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Validation

Ran locally:

- `go test ./client/transport -run 'TestExtractResourceMetadataURLs|TestOAuthHandler_HandleUnauthorizedResponse'`
- `go test ./client/transport`

## Checklist

- [x] Code reviewed locally
- [x] Tests updated for the changed behavior
- [x] Scope kept focused to the OAuth protected-resource metadata seam