### PR TITLE
fix: add panic recovery to transport goroutines

### DIFF
--- a/client/transport/panic_recovery_test.go
+++ b/client/transport/panic_recovery_test.go
@@ -92,14 +92,19 @@ func TestContextAwareOfClientClose_CleanShutdown(t *testing.T) {
 		closed: make(chan struct{}),
 	}
 
-	_, childCancel := c.contextAwareOfClientClose(t.Context())
+	childCtx, childCancel := c.contextAwareOfClientClose(t.Context())
 	defer childCancel()
 
 	// Close the client channel to trigger the goroutine's select case
 	close(c.closed)
 
-	// Give goroutine time to complete (short; this path is fast)
-	time.Sleep(20 * time.Millisecond)
+	// Wait for the goroutine to cancel the child context (proves it ran)
+	select {
+	case <-childCtx.Done():
+		// Goroutine fired cancel() as expected
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for context cancellation")
+	}
 
 	// No panic means the recovery defer is in place and the goroutine exits cleanly
 	assert.False(t, logger.hasMessageContaining("panic"),

--- a/client/transport/panic_recovery_test.go
+++ b/client/transport/panic_recovery_test.go
@@ -1,0 +1,107 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// panicTestLogger captures log output for test assertions.
+type panicTestLogger struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+// Infof is a no-op for test logging.
+func (l *panicTestLogger) Infof(_ string, _ ...any) {}
+
+// Errorf captures formatted error messages for later assertion.
+func (l *panicTestLogger) Errorf(format string, v ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.messages = append(l.messages, fmt.Sprintf(format, v...))
+}
+
+// hasMessageContaining reports whether any captured message contains substr.
+// Safe for concurrent use.
+func (l *panicTestLogger) hasMessageContaining(substr string) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for _, m := range l.messages {
+		if strings.Contains(m, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// waitForMessage polls until a message containing substr appears or timeout expires.
+func (l *panicTestLogger) waitForMessage(substr string, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if l.hasMessageContaining(substr) {
+			return true
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	return false
+}
+
+// TestPanicRecovery_HandleIncomingRequest verifies that a panicking request
+// handler is recovered, logged, and does not crash the process.
+func TestPanicRecovery_HandleIncomingRequest(t *testing.T) {
+	logger := &panicTestLogger{}
+
+	c := &StreamableHTTP{
+		logger: logger,
+		closed: make(chan struct{}),
+	}
+
+	// Set a handler that panics
+	c.requestHandler = func(_ context.Context, _ JSONRPCRequest) (*JSONRPCResponse, error) {
+		panic("test panic in request handler")
+	}
+
+	request := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+	}
+	request.Method = "sampling/createMessage"
+
+	c.handleIncomingRequest(t.Context(), request)
+
+	// Wait for the goroutine to recover and log (no fixed sleep)
+	require.True(t, logger.waitForMessage("panic handling server request", 2*time.Second),
+		"expected panic recovery log message within timeout")
+}
+
+// TestContextAwareOfClientClose_CleanShutdown verifies that the context-close
+// watcher goroutine completes without crashing when the closed channel fires.
+func TestContextAwareOfClientClose_CleanShutdown(t *testing.T) {
+	logger := &panicTestLogger{}
+
+	c := &StreamableHTTP{
+		logger: logger,
+		closed: make(chan struct{}),
+	}
+
+	_, childCancel := c.contextAwareOfClientClose(t.Context())
+	defer childCancel()
+
+	// Close the client channel to trigger the goroutine's select case
+	close(c.closed)
+
+	// Give goroutine time to complete (short; this path is fast)
+	time.Sleep(20 * time.Millisecond)
+
+	// No panic means the recovery defer is in place and the goroutine exits cleanly
+	assert.False(t, logger.hasMessageContaining("panic"),
+		"unexpected panic logged during clean shutdown")
+}

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -410,11 +410,11 @@ func TestSSE(t *testing.T) {
 		// The request should fail because the context is canceled
 		reps, err := trans.SendRequest(ctx, request)
 		if err != nil {
-			t.Errorf("SendRequest failed: %v", err)
+			t.Fatalf("SendRequest failed: %v", err)
 		}
 
 		if reps.Error == nil {
-			t.Errorf("Expected error, got nil")
+			t.Fatalf("Expected error, got nil")
 		}
 
 		var responseError JSONRPCRequest

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -184,6 +184,11 @@ func (c *StreamableHTTP) Start(ctx context.Context) error {
 	// For Streamable HTTP, we don't need to establish a persistent connection by default
 	if c.getListeningEnabled {
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					c.logger.Errorf("panic in listener goroutine: %v", r)
+				}
+			}()
 			select {
 			case <-c.initialized:
 				ctx, cancel := c.contextAwareOfClientClose(ctx)
@@ -698,6 +703,11 @@ func (c *StreamableHTTP) handleSSEResponse(ctx context.Context, reader io.ReadCl
 
 	// Start a goroutine to process the SSE stream
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Errorf("panic in SSE stream reader: %v", r)
+			}
+		}()
 		// Ensure this goroutine respects the context
 		defer close(responseChan)
 
@@ -766,6 +776,11 @@ func (c *StreamableHTTP) readSSE(ctx context.Context, reader io.ReadCloser, hand
 	// This ensures ReadString returns immediately with an error instead of
 	// blocking indefinitely when the SSE stream is open but idle.
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Errorf("panic closing SSE reader: %v", r)
+			}
+		}()
 		<-ctx.Done()
 		reader.Close()
 	}()
@@ -1010,6 +1025,28 @@ func (c *StreamableHTTP) handleIncomingRequest(ctx context.Context, request JSON
 
 	// Handle the request in a goroutine to avoid blocking the SSE reader
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Errorf("panic handling server request %s: %v", request.Method, r)
+				// Attempt to send an internal error response so the server doesn't hang.
+				// Use a nested recover to prevent sendResponseToServer from propagating
+				// a secondary panic (e.g., nil serverURL during shutdown).
+				func() {
+					defer func() {
+						if r2 := recover(); r2 != nil {
+							c.logger.Errorf("failed to send error response after panic: %v", r2)
+						}
+					}()
+					errorResponse := NewJSONRPCErrorResponse(
+						request.ID,
+						mcp.INTERNAL_ERROR,
+						fmt.Sprintf("internal error: panic in request handler: %v", r),
+						nil,
+					)
+					c.sendResponseToServer(ctx, errorResponse)
+				}()
+			}
+		}()
 		// Create a new context with timeout for request handling, respecting parent context
 		requestCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 		defer cancel()
@@ -1085,6 +1122,11 @@ func (c *StreamableHTTP) sendResponseToServer(ctx context.Context, response *JSO
 func (c *StreamableHTTP) contextAwareOfClientClose(ctx context.Context) (context.Context, context.CancelFunc) {
 	newCtx, cancel := context.WithCancel(ctx)
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				c.logger.Errorf("panic in context-close watcher: %v", r)
+			}
+		}()
 		select {
 		case <-c.closed:
 			cancel()

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -555,6 +555,11 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 	canStream := w.CanStream()
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Errorf("panic in notification forwarder: %v", r)
+			}
+		}()
 		for {
 			select {
 			case nt := <-session.notificationChannel:
@@ -748,6 +753,11 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 	writeChan := make(chan any, 16)
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Errorf("panic in SSE notification writer: %v", r)
+			}
+		}()
 		for {
 			select {
 			case nt := <-session.notificationChannel:
@@ -809,6 +819,11 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 	if s.listenHeartbeatInterval > 0 {
 		// heartbeat to keep the connection alive
 		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					s.logger.Errorf("panic in heartbeat goroutine: %v", r)
+				}
+			}()
 			ticker := time.NewTicker(s.listenHeartbeatInterval)
 			defer ticker.Stop()
 			for {
@@ -1050,6 +1065,11 @@ func (s *StreamableHTTPServer) startSessionSweeper(ctx context.Context) {
 	interval := max(s.sessionIdleTTL/2, time.Second)
 
 	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Errorf("panic in session cleanup goroutine: %v", r)
+			}
+		}()
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 


### PR DESCRIPTION
## Description

Add `defer recover()` to all transport-layer goroutines in both client and server streamable HTTP transports. 9 goroutines were unprotected; a panic in any of them crashes the process silently. The request handler recovery also sends an `INTERNAL_ERROR` JSON-RPC response so servers don't hang waiting for a reply.

Fixes #860

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

**Files changed:**

- `client/transport/streamable_http.go`: add `recover()` to 5 goroutines (listener, SSE reader, reader-close watcher, request handler, context-close watcher). Request handler recovery sends `INTERNAL_ERROR` response with nested recover to guard against secondary panics.
- `server/streamable_http.go`: add `recover()` to 4 goroutines (POST notification forwarder, GET/SSE notification writer, heartbeat ticker, session cleanup sweeper).
- `client/transport/panic_recovery_test.go` (new): `TestPanicRecovery_HandleIncomingRequest` injects a panicking handler and asserts recovery is logged. `TestContextAwareOfClientClose_CleanShutdown` verifies clean goroutine exit.

**Context:**

The server already provides `WithResourceRecovery()` middleware to protect user-provided resource handlers (server.go:324), but the library's own transport goroutines had no equivalent protection. A panic in notification marshaling, SSE parsing, or session cleanup would crash the entire process silently.

Prior art: #852 fixed a double-close panic in SSE sessions.

**Test results:**

```
ok  github.com/mark3labs/mcp-go/server          13s
ok  github.com/mark3labs/mcp-go/client          42s
ok  github.com/mark3labs/mcp-go/client/transport 86s
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by adding panic recovery and logging to multiple background goroutines so unexpected panics are caught and do not crash the process.
* **Tests**
  * Added tests confirming panic recovery is logged for handler panics and that clean client shutdowns do not produce panic logs.
  * Updated a test to fail fast on request/send errors or unexpected nil responses.

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->