### PR TITLE
fix(transport): suppress closed-pipe shutdown noise

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"strings"
@@ -344,7 +345,7 @@ func (c *Stdio) readResponses(ready chan struct{}) {
 		default:
 			line, err := c.stdout.ReadString('\n')
 			if err != nil {
-				if err != io.EOF && !errors.Is(err, context.Canceled) {
+				if err != io.EOF && !errors.Is(err, context.Canceled) && !errors.Is(err, fs.ErrClosed) {
 					c.logger.Errorf("Error reading from stdout: %v", err)
 				}
 				// Signal done so in-flight SendRequest calls unblock

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -1,11 +1,13 @@
 package transport
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -553,6 +555,39 @@ func TestStdioErrors(t *testing.T) {
 		}
 	})
 }
+
+func TestStdio_ReadResponses_SuppressesClosedPipeShutdownNoise(t *testing.T) {
+	logChan := make(chan string, 1)
+	stdio := NewIO(io.NopCloser(strings.NewReader("")), nopWriteCloser{Writer: io.Discard}, io.NopCloser(strings.NewReader("")))
+	stdio.logger = &testLogger{logChan: logChan}
+	stdio.stdout = bufio.NewReader(errReader{err: &fs.PathError{Op: "read", Path: "|0", Err: fs.ErrClosed}})
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	t.Cleanup(cancel)
+
+	require.NoError(t, stdio.Start(ctx))
+
+	select {
+	case msg := <-logChan:
+		t.Fatalf("expected closed-pipe shutdown to be silent, got log %q", msg)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+type nopWriteCloser struct {
+	io.Writer
+}
+
+func (nopWriteCloser) Close() error { return nil }
+
+type errReader struct {
+	err error
+}
+
+func (r errReader) Read(_ []byte) (int, error) {
+	return 0, r.err
+}
+
 
 func TestStdio_StartGuaranteesReaderReady(t *testing.T) {
 	stdoutReader, stdoutWriter := io.Pipe()


### PR DESCRIPTION
Summary:

- suppress the benign stdio shutdown race where the stdio read loop logs a closed-pipe error during normal Close
- treat fs.ErrClosed the same as io.EOF and context.Canceled in the stdio read loop so real read failures still surface while close-path noise stays quiet
- add a focused regression test that injects a closed-pipe read error and asserts shutdown stays silent

Testing:

- go test ./client/transport -run TestStdio_ReadResponses_SuppressesClosedPipeShutdownNoise|TestStdioErrors|TestStdio_Close_ShutsDownHungChild -v

Closes #862