### PR TITLE
refactor(server): use explicit struct literal in ListTools

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1011,7 +1011,10 @@ func (s *MCPServer) ListTools() map[string]*ServerTool {
 	// Create a copy to prevent external modification
 	toolsCopy := make(map[string]*ServerTool, len(s.tools))
 	for name, tool := range s.tools {
-		toolsCopy[name] = &tool
+		toolsCopy[name] = &ServerTool{
+			Tool:    tool.Tool,
+			Handler: tool.Handler,
+		}
 	}
 	return toolsCopy
 }


### PR DESCRIPTION
## Description

Small stylistic cleanup in `MCPServer.ListTools`. The method previously built each map entry by taking the address of the range loop variable (`&tool`). On Go 1.22+ this is safe thanks to per-iteration variable scoping (and this module requires Go 1.25), but the explicit struct-literal form is clearer at the call site and matches the style used by `ListPrompts` / `ListResources` after #855.

Before:

```go
for name, tool := range s.tools {
    toolsCopy[name] = &tool
}
```

After:

```go
for name, tool := range s.tools {
    toolsCopy[name] = &ServerTool{
        Tool:    tool.Tool,
        Handler: tool.Handler,
    }
}
```

No API change, no behavior change: the returned type (`map[string]*ServerTool`), the per-entry allocation, and the isolation from the server's internal map are all identical. Existing tests for `ListTools` continue to pass with `-race`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

- Files changed: `server/server.go` (one function body, +4 / -1)
- Fully backwards compatible — the exported signature of `ListTools` is unchanged.
- Follow-up to #855, which made the analogous change to `ListPrompts` / `ListResources`; this aligns `ListTools` with that style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a data consistency issue in the server's tool listing function where tools could incorrectly share state information.

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->