### PR TITLE
fix(oauth): use LATEST_PROTOCOL_VERSION in metadata discovery (#868)

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // maxMetadataBodyBytes caps the size of an OAuth metadata document we are
@@ -534,7 +536,11 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		}
 
 		req.Header.Set("Accept", "application/json")
-		req.Header.Set("MCP-Protocol-Version", "2025-03-26")
+		// Advertise the latest protocol version this client supports. Metadata
+		// discovery happens before the MCP initialize handshake, so no negotiated
+		// version is available yet; servers that don't recognise it can fall back
+		// per the MCP spec.
+		req.Header.Set("MCP-Protocol-Version", mcp.LATEST_PROTOCOL_VERSION)
 
 		resp, err := h.httpClient.Do(req)
 		if err != nil {
@@ -729,7 +735,11 @@ func (h *OAuthHandler) fetchMetadataFromURL(ctx context.Context, metadataURL str
 	}
 
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("MCP-Protocol-Version", "2025-03-26")
+	// Advertise the latest protocol version this client supports. Metadata
+	// discovery happens before the MCP initialize handshake, so no negotiated
+	// version is available yet; servers that don't recognise it can fall back
+	// per the MCP spec.
+	req.Header.Set("MCP-Protocol-Version", mcp.LATEST_PROTOCOL_VERSION)
 
 	resp, err := h.httpClient.Do(req)
 	if err != nil {

--- a/client/transport/oauth_test.go
+++ b/client/transport/oauth_test.go
@@ -9,9 +9,11 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -2325,4 +2327,118 @@ func TestOAuthHandler_RefreshToken_201Created(t *testing.T) {
 	require.NoError(t, err, "refresh token exchange should succeed for HTTP 201 Created")
 	assert.Equal(t, "refreshed-access-token", token.AccessToken)
 	assert.Equal(t, "refreshed-refresh-token", token.RefreshToken)
+}
+
+// TestOAuthHandler_MetadataDiscovery_SendsLatestProtocolVersion verifies that
+// the OAuth metadata discovery code paths advertise mcp.LATEST_PROTOCOL_VERSION
+// in the MCP-Protocol-Version request header. Regression test for #868, where
+// the header was hardcoded to "2025-03-26".
+func TestOAuthHandler_MetadataDiscovery_SendsLatestProtocolVersion(t *testing.T) {
+	t.Run("ProtectedResourceDiscovery", func(t *testing.T) {
+		var (
+			mu             sync.Mutex
+			seenByPath     = map[string]string{}
+			serverURL      string
+		)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			seenByPath[r.URL.Path] = r.Header.Get("MCP-Protocol-Version")
+			mu.Unlock()
+
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				metadata := map[string]any{
+					"resource":              serverURL,
+					"authorization_servers": []string{serverURL},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(metadata)
+
+			case "/.well-known/oauth-authorization-server":
+				metadata := AuthServerMetadata{
+					Issuer:                serverURL,
+					AuthorizationEndpoint: serverURL + "/authorize",
+					TokenEndpoint:         serverURL + "/token",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(metadata)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+		serverURL = server.URL
+
+		handler := NewOAuthHandler(OAuthConfig{
+			ClientID:    "test-client",
+			RedirectURI: server.URL + "/callback",
+			TokenStore:  NewMemoryTokenStore(),
+			PKCEEnabled: true,
+		})
+		handler.SetBaseURL(server.URL)
+
+		_, err := handler.GetServerMetadata(t.Context())
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		got, ok := seenByPath["/.well-known/oauth-protected-resource"]
+		require.True(t, ok, "expected protected-resource discovery request")
+		assert.Equal(t, mcp.LATEST_PROTOCOL_VERSION, got,
+			"protected-resource discovery should advertise the latest protocol version")
+		assert.NotEqual(t, "2025-03-26", got,
+			"protected-resource discovery must not hardcode the legacy protocol version")
+	})
+
+	t.Run("AuthServerMetadataDiscovery", func(t *testing.T) {
+		var (
+			mu             sync.Mutex
+			authServerVer  string
+			authServerSeen bool
+			serverURL      string
+		)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/.well-known/oauth-authorization-server":
+				mu.Lock()
+				authServerSeen = true
+				authServerVer = r.Header.Get("MCP-Protocol-Version")
+				mu.Unlock()
+				metadata := AuthServerMetadata{
+					Issuer:                serverURL,
+					AuthorizationEndpoint: serverURL + "/authorize",
+					TokenEndpoint:         serverURL + "/token",
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(metadata)
+
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer server.Close()
+		serverURL = server.URL
+
+		handler := NewOAuthHandler(OAuthConfig{
+			ClientID:              "test-client",
+			RedirectURI:           server.URL + "/callback",
+			TokenStore:            NewMemoryTokenStore(),
+			AuthServerMetadataURL: server.URL + "/.well-known/oauth-authorization-server",
+			PKCEEnabled:           true,
+		})
+
+		_, err := handler.GetServerMetadata(t.Context())
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.True(t, authServerSeen, "expected oauth-authorization-server discovery request")
+		assert.Equal(t, mcp.LATEST_PROTOCOL_VERSION, authServerVer,
+			"oauth-authorization-server discovery should advertise the latest protocol version")
+		assert.NotEqual(t, "2025-03-26", authServerVer,
+			"oauth-authorization-server discovery must not hardcode the legacy protocol version")
+	})
 }


### PR DESCRIPTION
## Description

`OAuthHandler` was hardcoding `MCP-Protocol-Version: 2025-03-26` on both
metadata-discovery requests (`getServerMetadata`'s protected-resource fetch and
`fetchMetadataFromURL`). The SDK's `LATEST_PROTOCOL_VERSION` is now
`2025-11-25`, so OAuth-protected MCP servers that gate behaviour on the
negotiated protocol version (e.g. RFC 8707 resource indicators, newer
well-known endpoints) saw a stale value during discovery.

OAuth metadata discovery runs *before* the MCP initialize handshake, so no
negotiated version is available yet. This PR sends `mcp.LATEST_PROTOCOL_VERSION`
instead — servers that don't recognise it can fall back per the MCP spec, which
matches the issue reporter's preferred Option A.

Fixes #868

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

**Files changed**

- `client/transport/oauth.go` — replaced both hardcoded `"2025-03-26"` literals
  with `mcp.LATEST_PROTOCOL_VERSION`; added a brief comment at each site
  explaining the pre-handshake context. Imported `github.com/mark3labs/mcp-go/mcp`
  (already used by sibling files in the package — no cycle).
- `client/transport/oauth_test.go` — added regression test
  `TestOAuthHandler_MetadataDiscovery_SendsLatestProtocolVersion` with two
  subtests covering both discovery paths
  (`/.well-known/oauth-protected-resource` and
  `/.well-known/oauth-authorization-server`). Each asserts the captured header
  equals `mcp.LATEST_PROTOCOL_VERSION` and is **not** the legacy `2025-03-26`.

**Verification**

- The new regression test fails on `main` (`expected 2025-11-25, got 2025-03-26`)
  and passes with this fix.
- `go test ./... -race` — all packages pass.
- `golangci-lint run` — `0 issues`.

**Backwards compatibility**

- ✅ No Go-level break — internal change inside two call sites; no public API
  surface affected.
- ⚠️ Wire-level: OAuth servers that ignore the `MCP-Protocol-Version` header
  (the common case for RFC 8414/9728 metadata endpoints) are unaffected.
  Servers that gate behaviour on it will now see `2025-11-25` instead of
  `2025-03-26`, which is the correct value for a current-generation client.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced OAuth authentication to dynamically use the latest protocol version instead of a previously hard-coded version string.
* **Tests**
  * Added test coverage for protocol version discovery in OAuth metadata endpoints.

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->