### PR TITLE
feat(mcp): add 2025-11-25 sampling-with-tools and capability sub-fields (#867)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -188,7 +188,7 @@ func (c *Client) Initialize(
 	// Merge client capabilities with sampling capability if handler is configured
 	capabilities := request.Params.Capabilities
 	if c.samplingHandler != nil {
-		capabilities.Sampling = &struct{}{}
+		capabilities.Sampling = &mcp.SamplingCapability{}
 	}
 	if c.rootsHandler != nil {
 		capabilities.Roots = &struct {

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -548,7 +548,7 @@ type ClientCapabilities struct {
 		ListChanged bool `json:"listChanged,omitempty"`
 	} `json:"roots,omitempty"`
 	// Present if the client supports sampling from an LLM.
-	Sampling *struct{} `json:"sampling,omitempty"`
+	Sampling *SamplingCapability `json:"sampling,omitempty"`
 	// Present if the client supports elicitation requests from the server.
 	Elicitation *ElicitationCapability `json:"elicitation,omitempty"`
 	// Present if the client supports task-based execution.
@@ -579,7 +579,7 @@ type ServerCapabilities struct {
 		ListChanged bool `json:"listChanged,omitempty"`
 	} `json:"resources,omitempty"`
 	// Present if the server supports sending sampling requests to clients.
-	Sampling *struct{} `json:"sampling,omitempty"`
+	Sampling *SamplingCapability `json:"sampling,omitempty"`
 	// Present if the server offers any tools to call.
 	Tools *struct {
 		// Whether this server supports notifications for changes to the tool list.
@@ -1058,6 +1058,38 @@ type CreateMessageParams struct {
 	MaxTokens        int               `json:"maxTokens"`
 	StopSequences    []string          `json:"stopSequences,omitempty"`
 	Metadata         any               `json:"metadata,omitempty"`
+	// Tools the model may use during generation.
+	//
+	// Per the 2025-11-25 spec, the client MUST return an error if this field
+	// is provided but ClientCapabilities.Sampling.Tools is not declared.
+	Tools []Tool `json:"tools,omitempty"`
+	// ToolChoice controls how the model uses tools during generation.
+	//
+	// Per the 2025-11-25 spec, the client MUST return an error if this field
+	// is provided but ClientCapabilities.Sampling.Tools is not declared.
+	// When omitted the client defaults to {Mode: ToolChoiceModeAuto}.
+	ToolChoice *ToolChoice `json:"toolChoice,omitempty"`
+}
+
+// ToolChoiceMode controls tool selection behaviour during sampling.
+type ToolChoiceMode string
+
+const (
+	// ToolChoiceModeAuto lets the model decide whether to use tools. This is
+	// the default when ToolChoice is omitted.
+	ToolChoiceModeAuto ToolChoiceMode = "auto"
+	// ToolChoiceModeRequired forces the model to call at least one tool.
+	ToolChoiceModeRequired ToolChoiceMode = "required"
+	// ToolChoiceModeNone disables tool use for this sampling request.
+	ToolChoiceModeNone ToolChoiceMode = "none"
+)
+
+// ToolChoice controls tool selection behaviour for a sampling request as
+// defined by the 2025-11-25 protocol revision.
+type ToolChoice struct {
+	// Mode controls tool selection. Empty is treated as ToolChoiceModeAuto by
+	// the client.
+	Mode ToolChoiceMode `json:"mode,omitempty"`
 }
 
 // CreateMessageResult is the client's response to a sampling/create_message
@@ -1076,7 +1108,7 @@ type CreateMessageResult struct {
 // SamplingMessage describes a message issued to or received from an LLM API.
 type SamplingMessage struct {
 	Role    Role `json:"role"`
-	Content any  `json:"content"` // Can be TextContent, ImageContent or AudioContent
+	Content any  `json:"content"` // Can be TextContent, ImageContent, AudioContent, ToolUseContent or ToolResultContent
 }
 
 type Annotations struct {
@@ -1701,6 +1733,24 @@ func UnmarshalContent(data []byte) (Content, error) {
 type ElicitationCapability struct {
 	Form *struct{} `json:"form,omitempty"` // Supports form mode
 	URL  *struct{} `json:"url,omitempty"`  // Supports URL mode
+}
+
+// SamplingCapability represents the sampling capabilities of a client or server
+// as defined by the 2025-11-25 protocol revision.
+//
+// A nil pointer means the peer does not support sampling at all. A non-nil but
+// empty value (the zero value) advertises baseline sampling support without the
+// optional context-inclusion or tool-use extensions.
+type SamplingCapability struct {
+	// Context, if non-nil, advertises that the client honours the
+	// CreateMessageParams.IncludeContext field. If a peer does not declare this
+	// sub-capability, servers SHOULD only use IncludeContext "none" or omit it.
+	Context *struct{} `json:"context,omitempty"`
+	// Tools, if non-nil, advertises that the client honours the
+	// CreateMessageParams.Tools and CreateMessageParams.ToolChoice fields
+	// (sampling with tools). Servers MUST NOT send those fields unless this
+	// sub-capability is declared.
+	Tools *struct{} `json:"tools,omitempty"`
 }
 
 // NewElicitationCompleteNotification creates a new elicitation complete notification.

--- a/mcp/types_test.go
+++ b/mcp/types_test.go
@@ -537,3 +537,122 @@ func TestPaginatedParamsMetaMarshalling(t *testing.T) {
 		assert.Equal(t, "v", got.Meta.AdditionalFields["k"])
 	})
 }
+
+func TestSamplingCapability_JSON(t *testing.T) {
+	t.Run("empty capability marshals as empty object", func(t *testing.T) {
+		caps := ClientCapabilities{Sampling: &SamplingCapability{}}
+		data, err := json.Marshal(caps)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"sampling":{}}`, string(data))
+	})
+
+	t.Run("nil sampling field is omitted", func(t *testing.T) {
+		caps := ClientCapabilities{}
+		data, err := json.Marshal(caps)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{}`, string(data))
+	})
+
+	t.Run("context sub-capability marshals nested", func(t *testing.T) {
+		caps := ClientCapabilities{Sampling: &SamplingCapability{
+			Context: &struct{}{},
+		}}
+		data, err := json.Marshal(caps)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"sampling":{"context":{}}}`, string(data))
+	})
+
+	t.Run("tools sub-capability marshals nested", func(t *testing.T) {
+		caps := ClientCapabilities{Sampling: &SamplingCapability{
+			Tools: &struct{}{},
+		}}
+		data, err := json.Marshal(caps)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"sampling":{"tools":{}}}`, string(data))
+	})
+
+	t.Run("both sub-capabilities round-trip", func(t *testing.T) {
+		original := ClientCapabilities{Sampling: &SamplingCapability{
+			Context: &struct{}{},
+			Tools:   &struct{}{},
+		}}
+		data, err := json.Marshal(original)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"sampling":{"context":{},"tools":{}}}`, string(data))
+
+		var got ClientCapabilities
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.NotNil(t, got.Sampling)
+		require.NotNil(t, got.Sampling.Context)
+		require.NotNil(t, got.Sampling.Tools)
+	})
+
+	t.Run("unmarshalling bare sampling object yields empty capability", func(t *testing.T) {
+		var got ClientCapabilities
+		require.NoError(t, json.Unmarshal([]byte(`{"sampling":{}}`), &got))
+		require.NotNil(t, got.Sampling)
+		assert.Nil(t, got.Sampling.Context)
+		assert.Nil(t, got.Sampling.Tools)
+	})
+
+	t.Run("server capability uses the same shape", func(t *testing.T) {
+		caps := ServerCapabilities{Sampling: &SamplingCapability{
+			Context: &struct{}{},
+		}}
+		data, err := json.Marshal(caps)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"sampling":{"context":{}}}`, string(data))
+	})
+}
+
+func TestCreateMessageParams_ToolsJSON(t *testing.T) {
+	t.Run("tools and toolChoice are omitted when nil", func(t *testing.T) {
+		params := CreateMessageParams{
+			Messages:  []SamplingMessage{{Role: RoleUser, Content: NewTextContent("hi")}},
+			MaxTokens: 10,
+		}
+		data, err := json.Marshal(params)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "tools")
+		assert.NotContains(t, string(data), "toolChoice")
+	})
+
+	t.Run("tools and toolChoice marshal and round-trip", func(t *testing.T) {
+		params := CreateMessageParams{
+			Messages:  []SamplingMessage{{Role: RoleUser, Content: NewTextContent("hi")}},
+			MaxTokens: 10,
+			Tools: []Tool{
+				{Name: "get_weather", Description: "Look up weather"},
+			},
+			ToolChoice: &ToolChoice{Mode: ToolChoiceModeRequired},
+		}
+		data, err := json.Marshal(params)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"tools"`)
+		assert.Contains(t, string(data), `"toolChoice":{"mode":"required"}`)
+
+		var got CreateMessageParams
+		require.NoError(t, json.Unmarshal(data, &got))
+		require.Len(t, got.Tools, 1)
+		assert.Equal(t, "get_weather", got.Tools[0].Name)
+		require.NotNil(t, got.ToolChoice)
+		assert.Equal(t, ToolChoiceModeRequired, got.ToolChoice.Mode)
+	})
+
+	t.Run("empty ToolChoice marshals as empty object", func(t *testing.T) {
+		params := CreateMessageParams{
+			Messages:   []SamplingMessage{{Role: RoleUser, Content: NewTextContent("hi")}},
+			MaxTokens:  10,
+			ToolChoice: &ToolChoice{},
+		}
+		data, err := json.Marshal(params)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"toolChoice":{}`)
+	})
+
+	t.Run("tool choice mode constants match spec", func(t *testing.T) {
+		assert.Equal(t, ToolChoiceMode("auto"), ToolChoiceModeAuto)
+		assert.Equal(t, ToolChoiceMode("required"), ToolChoiceModeRequired)
+		assert.Equal(t, ToolChoiceMode("none"), ToolChoiceModeNone)
+	})
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1095,7 +1095,7 @@ func (s *MCPServer) handleInitialize(
 	}
 
 	if s.capabilities.sampling != nil && *s.capabilities.sampling {
-		capabilities.Sampling = &struct{}{}
+		capabilities.Sampling = &mcp.SamplingCapability{}
 	}
 
 	if s.capabilities.elicitation != nil && *s.capabilities.elicitation {

--- a/server/session_test.go
+++ b/server/session_test.go
@@ -1541,7 +1541,7 @@ func TestSessionWithClientInfo_Integration(t *testing.T) {
 	}
 
 	clientCapability := mcp.ClientCapabilities{
-		Sampling: &struct{}{},
+		Sampling: &mcp.SamplingCapability{},
 	}
 
 	initRequest := mcp.InitializeRequest{}

--- a/server/streamable_http_client_info_test.go
+++ b/server/streamable_http_client_info_test.go
@@ -49,7 +49,7 @@ func TestStreamableHttpSessionImplementsSessionWithClientInfo(t *testing.T) {
 
 	// Test SetClientCapabilities and GetClientCapabilities
 	expectedCapabilities := mcp.ClientCapabilities{
-		Sampling: &struct{}{},
+		Sampling: &mcp.SamplingCapability{},
 	}
 	clientInfoSession.SetClientCapabilities(expectedCapabilities)
 

--- a/www/docs/pages/clients/advanced-sampling.mdx
+++ b/www/docs/pages/clients/advanced-sampling.mdx
@@ -418,6 +418,74 @@ The client will include this in the initialization request:
 }
 ```
 
+### Sampling Sub-Capabilities (2025-11-25)
+
+The 2025-11-25 protocol revision splits sampling into a baseline capability (the empty `"sampling": {}` object above) plus two opt-in sub-capabilities that a client uses to advertise which optional `CreateMessageParams` fields it actually understands:
+
+```go
+type SamplingCapability struct {
+    // Context advertises that the client honours CreateMessageParams.IncludeContext.
+    // If nil, servers SHOULD only send IncludeContext "none" (or omit it).
+    Context *struct{} `json:"context,omitempty"`
+    // Tools advertises that the client honours CreateMessageParams.Tools and
+    // CreateMessageParams.ToolChoice (sampling with tools).
+    Tools   *struct{} `json:"tools,omitempty"`
+}
+```
+
+The corresponding wire shape when both sub-capabilities are declared:
+
+```json
+{
+  "capabilities": {
+    "sampling": { "context": {}, "tools": {} }
+  }
+}
+```
+
+`client.WithSamplingHandler` advertises only the baseline (`"sampling": {}`). Advertising the optional `Context` / `Tools` sub-capabilities through the high-level client is not yet exposed — the `Initialize` flow overrides the `Sampling` field on the supplied request when a sampling handler is registered. Until a dedicated option is added, code that needs the sub-capabilities on the wire must declare them at a lower layer (for example by sending its own `initialize` request through the transport). The type is in place so that:
+
+- **Servers** can inspect what their connected client advertised via `session.GetClientCapabilities().Sampling` (see [Capability Gating](/servers/advanced-sampling#capability-gating-2025-11-25) on the server page).
+- **Custom client integrations** that build initialize requests directly can populate the sub-capabilities today.
+
+:::warning[Compile-time break]
+`ClientCapabilities.Sampling` and `ServerCapabilities.Sampling` are now `*mcp.SamplingCapability` (previously `*struct{}`). Code that constructed the capability with a `&struct{}{}` literal must be updated to `&mcp.SamplingCapability{}`. The JSON wire format for the baseline case is unchanged.
+:::
+
+### Handling Sampling-With-Tools Requests
+
+If your handler declared `Sampling.Tools`, incoming `mcp.CreateMessageRequest` values may include `request.Tools` (a list of tools the model is allowed to call) and `request.ToolChoice` (controls how aggressively the model should reach for them). Inspect them in your handler and surface them to your LLM:
+
+```go
+func (h *MySamplingHandler) CreateMessage(ctx context.Context, request mcp.CreateMessageRequest) (*mcp.CreateMessageResult, error) {
+    var allowedTools []mcp.Tool
+    if len(request.Tools) > 0 {
+        allowedTools = request.Tools
+    }
+
+    mode := mcp.ToolChoiceModeAuto // spec default when ToolChoice is omitted
+    if request.ToolChoice != nil && request.ToolChoice.Mode != "" {
+        mode = request.ToolChoice.Mode
+    }
+
+    switch mode {
+    case mcp.ToolChoiceModeNone:
+        // Tool use is disabled for this request.
+    case mcp.ToolChoiceModeRequired:
+        // Model must call at least one tool.
+    case mcp.ToolChoiceModeAuto:
+        // Model decides.
+    }
+
+    // ... forward `allowedTools` and `mode` to your LLM client and return the
+    // response as a SamplingMessage (which may carry ToolUseContent /
+    // ToolResultContent in addition to TextContent / ImageContent / AudioContent).
+    return nil, nil
+}
+```
+
+The constructors `mcp.NewToolUseContent` and `mcp.NewToolResultContent` build the corresponding `SamplingMessage.Content` values without manually setting the `Type` discriminator.
+
 ## Error Handling
 
 Handle errors gracefully in your sampling handler:

--- a/www/docs/pages/servers/advanced-sampling.mdx
+++ b/www/docs/pages/servers/advanced-sampling.mdx
@@ -144,24 +144,82 @@ samplingRequest := mcp.CreateMessageRequest{
                 },
             },
         },
-        
+
         // Optional: System prompt for context
         SystemPrompt: "You are a helpful assistant.",
-        
+
         // Optional: Maximum tokens to generate
         MaxTokens: 1000,
-        
+
         // Optional: Temperature for randomness (0.0 to 1.0)
         Temperature: 0.7,
-        
-        // Optional: Top-p sampling parameter
-        TopP: 0.9,
-        
+
         // Optional: Stop sequences
         StopSequences: []string{"\\n\\n"},
+
+        // Optional (2025-11-25): Context inclusion hint. Only send a value other
+        // than "none" when the client advertised `sampling.context` — see
+        // [Capability Gating](#capability-gating-2025-11-25) below.
+        IncludeContext: "thisServer",
+
+        // Optional (2025-11-25): Tools the model may use during generation, and
+        // how aggressively the model should reach for them. Only send these when
+        // the client advertised `sampling.tools`.
+        Tools: []mcp.Tool{ /* ... */ },
+        ToolChoice: &mcp.ToolChoice{Mode: mcp.ToolChoiceModeAuto},
     },
 }
 ```
+
+## Capability Gating (2025-11-25)
+
+The 2025-11-25 protocol revision splits sampling into a baseline capability and two opt-in sub-capabilities. Inspect the connected session's [`ClientCapabilities.Sampling`](https://pkg.go.dev/github.com/mark3labs/mcp-go/mcp#SamplingCapability) before sending the gated fields — a conforming client MUST reject a request that violates the matrix below.
+
+| Field on `CreateMessageParams` | Required client sub-capability | Sub-capability is `nil` ⇒ |
+|--------------------------------|--------------------------------|---------------------------|
+| `IncludeContext` (any value other than `"none"`) | `Sampling.Context` | Omit the field or send `"none"` |
+| `Tools`                        | `Sampling.Tools`               | Omit the field            |
+| `ToolChoice`                   | `Sampling.Tools`               | Omit the field            |
+
+A typical pattern inside a tool handler:
+
+```go
+func askLLMWithTools(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+    session := server.ClientSessionFromContext(ctx)
+    sessionWithClient, ok := session.(server.SessionWithClientInfo)
+    if !ok {
+        return mcp.NewToolResultError("client session is not capability-aware"), nil
+    }
+    caps := sessionWithClient.GetClientCapabilities()
+
+    params := mcp.CreateMessageParams{
+        Messages:  []mcp.SamplingMessage{ /* ... */ },
+        MaxTokens: 1000,
+    }
+
+    // Only attach Tools / ToolChoice if the client opted in.
+    if caps.Sampling != nil && caps.Sampling.Tools != nil {
+        params.Tools = []mcp.Tool{ /* ... */ }
+        params.ToolChoice = &mcp.ToolChoice{Mode: mcp.ToolChoiceModeAuto}
+    }
+
+    // Only ask for context inclusion if the client opted in.
+    if caps.Sampling != nil && caps.Sampling.Context != nil {
+        params.IncludeContext = "thisServer"
+    }
+
+    result, err := mcpServer.RequestSampling(ctx, mcp.CreateMessageRequest{CreateMessageParams: params})
+    // ...
+}
+```
+
+`ToolChoiceMode` accepts three constants:
+
+| Constant | Wire value | Meaning |
+|----------|-----------|---------|
+| `mcp.ToolChoiceModeAuto`     | `"auto"`     | Model decides (default when `ToolChoice` is omitted). |
+| `mcp.ToolChoiceModeRequired` | `"required"` | Model must call at least one tool. |
+| `mcp.ToolChoiceModeNone`     | `"none"`     | Tool use is disabled for this request. |
 
 ## Message Types
 
@@ -209,6 +267,32 @@ mcp.ImageContent{
     MimeType: "image/jpeg",
 }
 ```
+
+#### Tool-Use and Tool-Result Content (2025-11-25)
+
+When sampling with tools is in play, intermediate messages in the conversation
+can also carry `ToolUseContent` (the model asked to call a tool) and
+`ToolResultContent` (the result of that call) — these flow through the same
+`SamplingMessage.Content` field:
+
+```go
+// Assistant requesting a tool call
+mcp.ToolUseContent{
+    Type:  "tool_use",
+    ID:    "tu_1",
+    Name:  "get_weather",
+    Input: map[string]any{"city": "London"},
+}
+
+// User-role message carrying the tool's output
+mcp.ToolResultContent{
+    Type:      "tool_result",
+    ToolUseID: "tu_1",
+    Content:   []mcp.Content{mcp.NewTextContent("Sunny, 22°C")},
+}
+```
+
+Use the constructors `mcp.NewToolUseContent` and `mcp.NewToolResultContent` to build these without writing the `Type` discriminator by hand.
 
 ## Error Handling
 


### PR DESCRIPTION
## Description

Adds the three closely-related sampling features from the 2025-11-25 MCP protocol revision that the SDK was advertising as `LATEST_PROTOCOL_VERSION` but did not yet model:

1. `ClientCapabilities.sampling.context` and `.tools` — client opt-in sub-capabilities (now modelled as `mcp.SamplingCapability` with `Context` and `Tools` fields).
2. `CreateMessageRequestParams.tools` and `.toolChoice` — the new sampling-with-tools payload, plus a `ToolChoice` type and `ToolChoiceMode` enum (`auto`, `required`, `none`).
3. Doc-comment fix on `SamplingMessage.Content` to mention `ToolUseContent` and `ToolResultContent` (the types already exist).

To grow `Sampling` from `*struct{}` to a named struct without an off-spec wire shape, `ClientCapabilities.Sampling` and `ServerCapabilities.Sampling` are retyped to `*mcp.SamplingCapability` (Option A from the issue — explicitly recommended for v0.x). The JSON wire format for the baseline `{"sampling":{}}` case is unchanged; the only impact is a compile-time break for code that constructed the capability with a `&struct{}{}` literal, which must switch to `&mcp.SamplingCapability{}`. All in-repo call sites are updated.

Before / after on the server side:

```go
// Before — could not legally send these fields per the 2025-11-25 schema.
params := mcp.CreateMessageParams{Messages: msgs, MaxTokens: 1000}

// After — gated on the client's advertised sub-capability.
caps := session.GetClientCapabilities()
if caps.Sampling != nil && caps.Sampling.Tools != nil {
    params.Tools = []mcp.Tool{ /* ... */ }
    params.ToolChoice = &mcp.ToolChoice{Mode: mcp.ToolChoiceModeAuto}
}
```

Fixes #867

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

> **Note on the breaking-change box:** This is a *compile-time* break only for callers that wrote `Sampling = &struct{}{}` literally. The JSON wire format is identical for the baseline case, so it is not a protocol-level breaking change. The issue author explicitly recommends accepting this for v0.x.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [schema/2025-11-25/schema.ts §ClientCapabilities.sampling & §CreateMessageRequestParams](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts#L329)
- [x] Implementation follows the specification exactly

## Additional Information

**Commits in this PR**

- `feat(mcp): add 2025-11-25 sampling-with-tools and capability sub-fields (#867)` — types, call-site updates, JSON wire-format tests.
- `docs(sampling): document SamplingCapability sub-fields and sampling-with-tools (#867)` — server and client sampling guides.

**Files changed**

| File | Change |
|------|--------|
| `mcp/types.go` | New `SamplingCapability`, `ToolChoice`, `ToolChoiceMode`; new `Tools`/`ToolChoice` on `CreateMessageParams`; retyped `Sampling` on `Client`/`ServerCapabilities`; fixed `SamplingMessage.Content` doc comment |
| `mcp/types_test.go` | New `TestSamplingCapability_JSON` (7 sub-tests) and `TestCreateMessageParams_ToolsJSON` (4 sub-tests) — verify wire format, round-trips, omit-when-nil, and enum constant values |
| `client/client.go`, `server/server.go` | `capabilities.Sampling = &mcp.SamplingCapability{}` |
| `server/session_test.go`, `server/streamable_http_client_info_test.go` | Same literal update |
| `www/docs/pages/servers/advanced-sampling.mdx` | New "Capability Gating (2025-11-25)" section + matrix; `ToolChoiceMode` constants table; `ToolUseContent`/`ToolResultContent` subsection; extended params snippet (also dropped a pre-existing fictitious `TopP` line — there is no such field) |
| `www/docs/pages/clients/advanced-sampling.mdx` | New "Sampling Sub-Capabilities (2025-11-25)" section with compile-time-break warning admonition; new "Handling Sampling-With-Tools Requests" section |

**Caveat surfaced during docs review**

`client/client.go:190-191` unconditionally overwrites `capabilities.Sampling` whenever a sampling handler is registered, so users currently cannot advertise `SamplingCapability.Context` / `.Tools` through the public `WithSamplingHandler` path even after this change. The type is in place so servers can *inspect* what was advertised and custom client integrations can construct the initialize request directly. Exposing a `WithSamplingCapability(...)` option is a small follow-up worth a separate issue.

**Verification**

- `go test ./... -race` — all packages pass
- `golangci-lint run` — 0 issues
- `go vet ./...` — clean
- `go doc` renders the new exported symbols
- `npx vocs build` — docs build clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sampling capability now supports optional tool-use configuration and context inclusion parameters.
  * Added support for tool-use and tool-result content types in sampling messages.

* **Documentation**
  * Updated sampling guides with capability gating requirements, tool configuration examples, and message content construction guidance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mark3labs/mcp-go/pull/876)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->