### PR TITLE
docs: add missing godoc comments

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	elicitationHandler ElicitationHandler
 }
 
+// ClientOption configures a Client during construction.
 type ClientOption func(*Client)
 
 // WithClientCapabilities sets the client capabilities for the client.
@@ -262,6 +263,7 @@ func (c *Client) Initialize(
 	return &result, nil
 }
 
+// Ping sends a ping request to verify the server is responsive.
 func (c *Client) Ping(ctx context.Context) error {
 	_, err := c.sendRequest(ctx, "ping", nil, nil)
 	return err
@@ -279,6 +281,7 @@ func (c *Client) ListResourcesByPage(
 	return result, nil
 }
 
+// ListResources lists all resources by following paginated responses.
 func (c *Client) ListResources(
 	ctx context.Context,
 	request mcp.ListResourcesRequest,
@@ -304,6 +307,7 @@ func (c *Client) ListResources(
 	return result, nil
 }
 
+// ListResourceTemplatesByPage manually lists resource templates by page.
 func (c *Client) ListResourceTemplatesByPage(
 	ctx context.Context,
 	request mcp.ListResourceTemplatesRequest,
@@ -315,6 +319,7 @@ func (c *Client) ListResourceTemplatesByPage(
 	return result, nil
 }
 
+// ListResourceTemplates lists all resource templates by following paginated responses.
 func (c *Client) ListResourceTemplates(
 	ctx context.Context,
 	request mcp.ListResourceTemplatesRequest,
@@ -340,6 +345,7 @@ func (c *Client) ListResourceTemplates(
 	return result, nil
 }
 
+// ReadResource reads the contents of a resource from the server.
 func (c *Client) ReadResource(
 	ctx context.Context,
 	request mcp.ReadResourceRequest,
@@ -352,6 +358,7 @@ func (c *Client) ReadResource(
 	return mcp.ParseReadResourceResult(response)
 }
 
+// Subscribe subscribes to updates for a resource.
 func (c *Client) Subscribe(
 	ctx context.Context,
 	request mcp.SubscribeRequest,
@@ -360,6 +367,7 @@ func (c *Client) Subscribe(
 	return err
 }
 
+// Unsubscribe removes a resource update subscription.
 func (c *Client) Unsubscribe(
 	ctx context.Context,
 	request mcp.UnsubscribeRequest,
@@ -368,6 +376,7 @@ func (c *Client) Unsubscribe(
 	return err
 }
 
+// ListPromptsByPage manually lists prompts by page.
 func (c *Client) ListPromptsByPage(
 	ctx context.Context,
 	request mcp.ListPromptsRequest,
@@ -379,6 +388,7 @@ func (c *Client) ListPromptsByPage(
 	return result, nil
 }
 
+// ListPrompts lists all prompts by following paginated responses.
 func (c *Client) ListPrompts(
 	ctx context.Context,
 	request mcp.ListPromptsRequest,
@@ -404,6 +414,7 @@ func (c *Client) ListPrompts(
 	return result, nil
 }
 
+// GetPrompt gets a prompt and renders it with the provided arguments.
 func (c *Client) GetPrompt(
 	ctx context.Context,
 	request mcp.GetPromptRequest,
@@ -416,6 +427,7 @@ func (c *Client) GetPrompt(
 	return mcp.ParseGetPromptResult(response)
 }
 
+// ListToolsByPage manually lists tools by page.
 func (c *Client) ListToolsByPage(
 	ctx context.Context,
 	request mcp.ListToolsRequest,
@@ -427,6 +439,7 @@ func (c *Client) ListToolsByPage(
 	return result, nil
 }
 
+// ListTools lists all tools by following paginated responses.
 func (c *Client) ListTools(
 	ctx context.Context,
 	request mcp.ListToolsRequest,
@@ -452,6 +465,7 @@ func (c *Client) ListTools(
 	return result, nil
 }
 
+// CallTool invokes a tool on the server.
 func (c *Client) CallTool(
 	ctx context.Context,
 	request mcp.CallToolRequest,
@@ -464,6 +478,7 @@ func (c *Client) CallTool(
 	return mcp.ParseCallToolResult(response)
 }
 
+// SetLevel sets the server logging level.
 func (c *Client) SetLevel(
 	ctx context.Context,
 	request mcp.SetLevelRequest,
@@ -472,6 +487,7 @@ func (c *Client) SetLevel(
 	return err
 }
 
+// Complete requests completion suggestions from the server.
 func (c *Client) Complete(
 	ctx context.Context,
 	request mcp.CompleteRequest,

--- a/client/sse.go
+++ b/client/sse.go
@@ -8,14 +8,17 @@ import (
 	"github.com/mark3labs/mcp-go/client/transport"
 )
 
+// WithHeaders sets static headers for the SSE client.
 func WithHeaders(headers map[string]string) transport.ClientOption {
 	return transport.WithHeaders(headers)
 }
 
+// WithHeaderFunc sets a function that returns headers for each SSE request.
 func WithHeaderFunc(headerFunc transport.HTTPHeaderFunc) transport.ClientOption {
 	return transport.WithHeaderFunc(headerFunc)
 }
 
+// WithHTTPClient sets a custom HTTP client for the SSE transport.
 func WithHTTPClient(httpClient *http.Client) transport.ClientOption {
 	return transport.WithHTTPClient(httpClient)
 }

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -51,6 +51,7 @@ type SSE struct {
 	oauthHandler *OAuthHandler
 }
 
+// ClientOption configures an SSE transport client.
 type ClientOption func(*SSE)
 
 // WithSSELogger sets a custom logger for the SSE client.
@@ -60,24 +61,28 @@ func WithSSELogger(logger util.Logger) ClientOption {
 	}
 }
 
+// WithHeaders sets static headers for SSE HTTP requests.
 func WithHeaders(headers map[string]string) ClientOption {
 	return func(sc *SSE) {
 		sc.headers = headers
 	}
 }
 
+// WithHeaderFunc sets a function that returns headers for SSE HTTP requests.
 func WithHeaderFunc(headerFunc HTTPHeaderFunc) ClientOption {
 	return func(sc *SSE) {
 		sc.headerFunc = headerFunc
 	}
 }
 
+// WithHTTPClient sets a custom HTTP client for the SSE transport.
 func WithHTTPClient(httpClient *http.Client) ClientOption {
 	return func(sc *SSE) {
 		sc.httpClient = httpClient
 	}
 }
 
+// WithOAuth enables OAuth authentication for the SSE transport.
 func WithOAuth(config OAuthConfig) ClientOption {
 	return func(sc *SSE) {
 		sc.oauthHandler = NewOAuthHandler(config)
@@ -386,12 +391,14 @@ func (c *SSE) handleSSEEvent(event, data string) {
 	}
 }
 
+// SetNotificationHandler sets the handler for incoming JSON-RPC notifications.
 func (c *SSE) SetNotificationHandler(handler func(notification mcp.JSONRPCNotification)) {
 	c.notifyMu.Lock()
 	defer c.notifyMu.Unlock()
 	c.onNotification = handler
 }
 
+// SetConnectionLostHandler sets the handler called when the SSE connection is lost.
 func (c *SSE) SetConnectionLostHandler(handler func(error)) {
 	c.connectionLostMu.Lock()
 	defer c.connectionLostMu.Unlock()

--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mark3labs/mcp-go/util"
 )
 
+// StreamableHTTPCOption configures a StreamableHTTP transport client.
 type StreamableHTTPCOption func(*StreamableHTTP)
 
 // WithContinuousListening enables receiving server-to-client notifications when no request is in flight.
@@ -35,19 +36,21 @@ func WithContinuousListening() StreamableHTTPCOption {
 	}
 }
 
-// WithHTTPClient sets a custom HTTP client on the StreamableHTTP transport.
+// WithHTTPBasicClient sets a custom HTTP client on the StreamableHTTP transport.
 func WithHTTPBasicClient(client *http.Client) StreamableHTTPCOption {
 	return func(sc *StreamableHTTP) {
 		sc.httpClient = client
 	}
 }
 
+// WithHTTPHeaders sets static headers for StreamableHTTP requests.
 func WithHTTPHeaders(headers map[string]string) StreamableHTTPCOption {
 	return func(sc *StreamableHTTP) {
 		sc.headers = headers
 	}
 }
 
+// WithHTTPHeaderFunc sets a function that returns headers for StreamableHTTP requests.
 func WithHTTPHeaderFunc(headerFunc HTTPHeaderFunc) StreamableHTTPCOption {
 	return func(sc *StreamableHTTP) {
 		sc.headerFunc = headerFunc
@@ -75,6 +78,8 @@ func WithHTTPLogger(logger util.Logger) StreamableHTTPCOption {
 	}
 }
 
+// WithLogger sets a custom logger for the StreamableHTTP transport.
+//
 // Deprecated: Use [WithHTTPLogger] instead.
 func WithLogger(logger util.Logger) StreamableHTTPCOption {
 	return WithHTTPLogger(logger)
@@ -832,6 +837,7 @@ func (c *StreamableHTTP) readSSE(ctx context.Context, reader io.ReadCloser, hand
 	}
 }
 
+// SendNotification sends a JSON-RPC notification to the server without expecting a response.
 func (c *StreamableHTTP) SendNotification(ctx context.Context, notification mcp.JSONRPCNotification) error {
 	// Marshal request
 	requestBody, err := json.Marshal(notification)
@@ -887,6 +893,7 @@ func (c *StreamableHTTP) SendNotification(ctx context.Context, notification mcp.
 	}
 }
 
+// SetNotificationHandler sets the handler for incoming JSON-RPC notifications.
 func (c *StreamableHTTP) SetNotificationHandler(handler func(mcp.JSONRPCNotification)) {
 	c.notifyMu.Lock()
 	defer c.notifyMu.Unlock()
@@ -900,6 +907,7 @@ func (c *StreamableHTTP) SetRequestHandler(handler RequestHandler) {
 	c.requestHandler = handler
 }
 
+// GetSessionId returns the current StreamableHTTP session ID.
 func (c *StreamableHTTP) GetSessionId() string {
 	return c.sessionID.Load().(string)
 }
@@ -958,6 +966,7 @@ func (c *StreamableHTTP) listenForever(ctx context.Context) {
 }
 
 var (
+	// ErrSessionTerminated indicates the server no longer recognizes the current session.
 	ErrSessionTerminated   = fmt.Errorf("session terminated (404). need to re-initialize")
 	ErrGetMethodNotAllowed = fmt.Errorf("GET method not allowed")
 	ErrUnauthorized        = fmt.Errorf("unauthorized (401)")

--- a/mcp/prompts.go
+++ b/mcp/prompts.go
@@ -26,6 +26,7 @@ type GetPromptRequest struct {
 	Header http.Header     `json:"-"`
 }
 
+// GetPromptParams contains parameters for a prompts/get request.
 type GetPromptParams struct {
 	// The name of the prompt or prompt template.
 	Name string `json:"name"`

--- a/util/logger.go
+++ b/util/logger.go
@@ -12,7 +12,7 @@ type Logger interface {
 
 // --- Standard Library Logger Wrapper ---
 
-// DefaultStdLogger implements Logger using the standard library's log.Logger.
+// DefaultLogger implements Logger using the standard library's log.Logger.
 func DefaultLogger() Logger {
 	return &stdLogger{
 		logger: log.Default(),


### PR DESCRIPTION
﻿## Summary
- add godoc comments for exported client and transport symbols listed in #869
- add the missing GetPromptParams godoc comment
- correct stale doc comments for DefaultLogger and WithHTTPBasicClient

## Testing
- go test ./client ./mcp ./util -run '^$'
- GOOS=linux go test -c -o "$env:TEMP\\mcp-go-transport.test" ./client/transport
- git diff --check

Notes: full client package tests timed out locally on Windows. client/transport test compilation on native Windows is blocked by existing Unix-only syscall fields in stdio_test.go, so I validated the transport package compile with GOOS=linux.

Fixes #869


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive API documentation for client operations including resource management, subscriptions, prompts, and tool execution.
  * Improved documentation coverage for client configuration options covering header management, HTTP client setup, and event notification handlers.
  * Enhanced documentation for utility functions and types.

* **Breaking Changes**
  * Updated logger constructor function naming for improved consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mark3labs/mcp-go/pull/877)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->