### PR TITLE
refactor: use MCP method constants

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -246,7 +246,7 @@ func (c *Client) Initialize(
 	notification := mcp.JSONRPCNotification{
 		JSONRPC: mcp.JSONRPC_VERSION,
 		Notification: mcp.Notification{
-			Method: "notifications/initialized",
+			Method: string(mcp.MethodNotificationInitialized),
 		},
 	}
 
@@ -263,7 +263,7 @@ func (c *Client) Initialize(
 }
 
 func (c *Client) Ping(ctx context.Context) error {
-	_, err := c.sendRequest(ctx, "ping", nil, nil)
+	_, err := c.sendRequest(ctx, string(mcp.MethodPing), nil, nil)
 	return err
 }
 
@@ -272,7 +272,7 @@ func (c *Client) ListResourcesByPage(
 	ctx context.Context,
 	request mcp.ListResourcesRequest,
 ) (*mcp.ListResourcesResult, error) {
-	result, err := listByPage[mcp.ListResourcesResult](ctx, c, request.PaginatedRequest, request.Header, "resources/list")
+	result, err := listByPage[mcp.ListResourcesResult](ctx, c, request.PaginatedRequest, request.Header, string(mcp.MethodResourcesList))
 	if err != nil {
 		return nil, err
 	}
@@ -308,7 +308,7 @@ func (c *Client) ListResourceTemplatesByPage(
 	ctx context.Context,
 	request mcp.ListResourceTemplatesRequest,
 ) (*mcp.ListResourceTemplatesResult, error) {
-	result, err := listByPage[mcp.ListResourceTemplatesResult](ctx, c, request.PaginatedRequest, request.Header, "resources/templates/list")
+	result, err := listByPage[mcp.ListResourceTemplatesResult](ctx, c, request.PaginatedRequest, request.Header, string(mcp.MethodResourcesTemplatesList))
 	if err != nil {
 		return nil, err
 	}
@@ -344,7 +344,7 @@ func (c *Client) ReadResource(
 	ctx context.Context,
 	request mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
-	response, err := c.sendRequest(ctx, "resources/read", request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodResourcesRead), request.Params, request.Header)
 	if err != nil {
 		return nil, err
 	}
@@ -356,7 +356,7 @@ func (c *Client) Subscribe(
 	ctx context.Context,
 	request mcp.SubscribeRequest,
 ) error {
-	_, err := c.sendRequest(ctx, "resources/subscribe", request.Params, request.Header)
+	_, err := c.sendRequest(ctx, string(mcp.MethodResourcesSubscribe), request.Params, request.Header)
 	return err
 }
 
@@ -364,7 +364,7 @@ func (c *Client) Unsubscribe(
 	ctx context.Context,
 	request mcp.UnsubscribeRequest,
 ) error {
-	_, err := c.sendRequest(ctx, "resources/unsubscribe", request.Params, request.Header)
+	_, err := c.sendRequest(ctx, string(mcp.MethodResourcesUnsubscribe), request.Params, request.Header)
 	return err
 }
 
@@ -372,7 +372,7 @@ func (c *Client) ListPromptsByPage(
 	ctx context.Context,
 	request mcp.ListPromptsRequest,
 ) (*mcp.ListPromptsResult, error) {
-	result, err := listByPage[mcp.ListPromptsResult](ctx, c, request.PaginatedRequest, request.Header, "prompts/list")
+	result, err := listByPage[mcp.ListPromptsResult](ctx, c, request.PaginatedRequest, request.Header, string(mcp.MethodPromptsList))
 	if err != nil {
 		return nil, err
 	}
@@ -408,7 +408,7 @@ func (c *Client) GetPrompt(
 	ctx context.Context,
 	request mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
-	response, err := c.sendRequest(ctx, "prompts/get", request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodPromptsGet), request.Params, request.Header)
 	if err != nil {
 		return nil, err
 	}
@@ -420,7 +420,7 @@ func (c *Client) ListToolsByPage(
 	ctx context.Context,
 	request mcp.ListToolsRequest,
 ) (*mcp.ListToolsResult, error) {
-	result, err := listByPage[mcp.ListToolsResult](ctx, c, request.PaginatedRequest, request.Header, "tools/list")
+	result, err := listByPage[mcp.ListToolsResult](ctx, c, request.PaginatedRequest, request.Header, string(mcp.MethodToolsList))
 	if err != nil {
 		return nil, err
 	}
@@ -456,7 +456,7 @@ func (c *Client) CallTool(
 	ctx context.Context,
 	request mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
-	response, err := c.sendRequest(ctx, "tools/call", request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodToolsCall), request.Params, request.Header)
 	if err != nil {
 		return nil, err
 	}

--- a/mcp/tasks.go
+++ b/mcp/tasks.go
@@ -111,7 +111,7 @@ func NewCancelTaskResult(task Task) CancelTaskResult {
 func NewTaskStatusNotification(task Task) TaskStatusNotification {
 	return TaskStatusNotification{
 		Notification: Notification{
-			Method: string(MethodNotificationTasksStatus),
+			Method: MethodNotificationTasksStatus,
 		},
 		Params: TaskStatusNotificationParams{
 			Task: task,

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -90,6 +90,22 @@ const (
 	// https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks
 	MethodTasksCancel MCPMethod = "tasks/cancel"
 
+	// MethodNotificationInitialized indicates that the client completed initialization.
+	// https://modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization
+	MethodNotificationInitialized MCPMethod = "notifications/initialized"
+
+	// MethodNotificationCancelled cancels an in-flight request.
+	// https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/cancellation
+	MethodNotificationCancelled MCPMethod = "notifications/cancelled"
+
+	// MethodNotificationProgress reports progress for a long-running request.
+	// https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/progress
+	MethodNotificationProgress MCPMethod = "notifications/progress"
+
+	// MethodNotificationMessage is a server-pushed log message.
+	// https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/logging
+	MethodNotificationMessage MCPMethod = "notifications/message"
+
 	// MethodNotificationResourcesListChanged notifies when the list of available resources changes.
 	// https://modelcontextprotocol.io/specification/2025-03-26/server/resources#list-changed-notification
 	MethodNotificationResourcesListChanged = "notifications/resources/list_changed"

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -177,7 +177,7 @@ func NewProgressNotification(
 ) ProgressNotification {
 	notification := ProgressNotification{
 		Notification: Notification{
-			Method: "notifications/progress",
+			Method: string(MethodNotificationProgress),
 		},
 		Params: struct {
 			ProgressToken ProgressToken `json:"progressToken"`
@@ -207,7 +207,7 @@ func NewLoggingMessageNotification(
 ) LoggingMessageNotification {
 	return LoggingMessageNotification{
 		Notification: Notification{
-			Method: "notifications/message",
+			Method: string(MethodNotificationMessage),
 		},
 		Params: struct {
 			Level  LoggingLevel `json:"level"`

--- a/server/server.go
+++ b/server/server.go
@@ -2197,7 +2197,7 @@ func (s *MCPServer) handleNotification(
 	notification mcp.JSONRPCNotification,
 ) mcp.JSONRPCMessage {
 	// Handle cancellation notifications per MCP spec
-	if notification.Method == "notifications/cancelled" {
+	if notification.Method == string(mcp.MethodNotificationCancelled) {
 		if reqID, ok := notification.Params.AdditionalFields["requestId"]; ok {
 			key := inflightKey(ctx, reqID)
 			if cancel, loaded := s.inflightCancels.LoadAndDelete(key); loaded {

--- a/server/sse.go
+++ b/server/sse.go
@@ -572,7 +572,7 @@ func (s *SSEServer) handleSSE(w http.ResponseWriter, r *http.Request) {
 						JSONRPC: "2.0",
 						ID:      mcp.NewRequestId(session.requestID.Add(1)),
 						Request: mcp.Request{
-							Method: "ping",
+							Method: string(mcp.MethodPing),
 						},
 					}
 					messageBytes, _ := json.Marshal(message)

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -601,7 +601,7 @@ func (s *StdioServer) processMessage(
 	var baseMessage struct {
 		Method string `json:"method"`
 	}
-	if json.Unmarshal(rawMessage, &baseMessage) == nil && baseMessage.Method == "tools/call" {
+	if json.Unmarshal(rawMessage, &baseMessage) == nil && baseMessage.Method == string(mcp.MethodToolsCall) {
 		// Queue tool calls for processing by workers
 		select {
 		case s.toolCallQueue <- &toolCallWork{

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -833,7 +833,7 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 						JSONRPC: "2.0",
 						ID:      mcp.NewRequestId(s.nextRequestID(sessionID)),
 						Request: mcp.Request{
-							Method: "ping",
+							Method: string(mcp.MethodPing),
 						},
 					}
 					select {


### PR DESCRIPTION
## Summary

Replaces the remaining hardcoded JSON-RPC method names from #866 with the existing `mcp.MCPMethod` constants, and adds constants for the notification methods that did not have one yet.

The change covers the client request helpers, initialized/progress/message/cancelled notifications, server keepalive pings, and the stdio tool-call dispatch guard. Existing notification constants are left untyped to avoid widening this refactor into a public API compatibility change.

## Verification

- `go test ./...`
- `git diff --check`

Closes #866.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code consistency by standardizing method naming conventions across the platform, replacing hardcoded string literals with named constants for enhanced maintainability and reduced duplication.

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->