### PR TITLE
fix: add panic recovery to SSE message handler and stdio tool call worker

### DIFF
--- a/server/sse.go
+++ b/server/sse.go
@@ -679,6 +679,21 @@ func (s *SSEServer) handleMessage(w http.ResponseWriter, r *http.Request) {
 
 	go func(ctx context.Context) {
 		defer cancel()
+		defer func() {
+			if r := recover(); r != nil {
+				log.Printf("panic recovered in SSE message handler for session %s: %v", sessionID, r)
+				// Send error response so the client doesn't hang waiting.
+				errResp := createErrorResponse(nil, mcp.INTERNAL_ERROR, fmt.Sprintf("internal panic: %v", r))
+				if eventData, err := json.Marshal(errResp); err == nil {
+					message := fmt.Sprintf("event: message\ndata: %s\n\n", eventData)
+					select {
+					case session.eventQueue <- message:
+					case <-session.done:
+					default:
+					}
+				}
+			}
+		}()
 		// Use the context that will be canceled when session is done
 		// Process message through MCPServer
 		response := s.server.HandleMessage(ctx, rawMessage)

--- a/server/sse_panic_test.go
+++ b/server/sse_panic_test.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSSEServer_MessageHandlerPanicRecovery(t *testing.T) {
+	// Create a server with a tool that panics
+	server := NewMCPServer("test", "1.0.0", WithToolCapabilities(true))
+	server.AddTools(ServerTool{
+		Tool: mcp.Tool{
+			Name:        "panic-tool",
+			Description: "A tool that panics",
+		},
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			panic("deliberate panic in SSE handler")
+		},
+	})
+
+	sseServer := NewSSEServer(server)
+	ts := httptest.NewServer(sseServer)
+	defer ts.Close()
+
+	// Connect SSE session
+	resp, err := http.Get(ts.URL + "/sse")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	// Read the endpoint event
+	buf := make([]byte, 4096)
+	n, err := resp.Body.Read(buf)
+	require.NoError(t, err)
+	body := string(buf[:n])
+	require.Contains(t, body, "event: endpoint")
+
+	// Extract message endpoint
+	var endpoint string
+	for line := range strings.SplitSeq(body, "\n") {
+		if after, ok := strings.CutPrefix(line, "data: "); ok {
+			endpoint = strings.TrimSpace(after)
+			break
+		}
+	}
+	require.NotEmpty(t, endpoint)
+
+	// Send a tool call that will panic
+	toolCall := mcp.JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+		Request: mcp.Request{Method: string(mcp.MethodToolsCall)},
+	}
+	toolCall.Params = json.RawMessage(`{"name":"panic-tool","arguments":{}}`)
+
+	callBody, _ := json.Marshal(toolCall)
+	postResp, err := http.Post(ts.URL+endpoint, "application/json", strings.NewReader(string(callBody)))
+	require.NoError(t, err)
+	postResp.Body.Close()
+
+	// Read from the SSE stream to get the error response for the panicking tool call.
+	// The response is delivered as an SSE event on the original connection.
+	buf = make([]byte, 4096)
+	n, err = resp.Body.Read(buf)
+	require.NoError(t, err)
+	sseData := string(buf[:n])
+
+	// Verify the error response was delivered via SSE (code -32603 = INTERNAL_ERROR)
+	assert.Contains(t, sseData, "-32603", "client should receive INTERNAL_ERROR code for panicking tool call")
+	assert.Contains(t, sseData, "internal panic", "error message should indicate a panic occurred")
+
+	// Server should still be alive. Send a ping to verify.
+	ping := `{"jsonrpc":"2.0","id":2,"method":"ping"}`
+	pingResp, err := http.Post(ts.URL+endpoint, "application/json", strings.NewReader(ping))
+	require.NoError(t, err)
+	defer pingResp.Body.Close()
+	assert.Less(t, pingResp.StatusCode, 300, "server should still respond after panic recovery")
+}

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -476,8 +476,17 @@ func (s *StdioServer) toolCallWorker(ctx context.Context) {
 				// Channel closed, exit worker
 				return
 			}
-			// Process the tool call
-			response := s.server.HandleMessage(work.ctx, work.message)
+			// Process the tool call with panic recovery so a single
+			// panicking handler does not kill the worker permanently.
+			response := func() (resp mcp.JSONRPCMessage) {
+				defer func() {
+					if r := recover(); r != nil {
+						s.errLogger.Printf("panic recovered in stdio tool call worker: %v", r)
+						resp = createErrorResponse(nil, mcp.INTERNAL_ERROR, fmt.Sprintf("internal panic: %v", r))
+					}
+				}()
+				return s.server.HandleMessage(work.ctx, work.message)
+			}()
 			if response != nil {
 				if err := s.writeResponse(response, work.writer); err != nil {
 					s.errLogger.Printf("Error writing tool response: %v", err)

--- a/server/stdio_panic_test.go
+++ b/server/stdio_panic_test.go
@@ -1,0 +1,100 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStdioServer_ToolCallWorkerPanicRecovery(t *testing.T) {
+	// Create a server with a tool that panics and one that works
+	server := NewMCPServer("test", "1.0.0", WithToolCapabilities(true))
+	server.AddTools(
+		ServerTool{
+			Tool: mcp.Tool{
+				Name:        "panic-tool",
+				Description: "A tool that panics",
+			},
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				panic("deliberate panic in stdio handler")
+			},
+		},
+		ServerTool{
+			Tool: mcp.Tool{
+				Name:        "safe-tool",
+				Description: "A tool that works",
+			},
+			Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				return mcp.NewToolResultText("ok"), nil
+			},
+		},
+	)
+
+	stdioServer := NewStdioServer(server)
+
+	// Build input: initialize, then panic tool call, then safe tool call
+	var input bytes.Buffer
+	initMsg := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+	panicMsg := `{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"panic-tool","arguments":{}}}`
+	safeMsg := `{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"safe-tool","arguments":{}}}`
+	input.WriteString(initMsg + "\n")
+	input.WriteString(panicMsg + "\n")
+	input.WriteString(safeMsg + "\n")
+
+	var output bytes.Buffer
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	err := stdioServer.Listen(ctx, &input, &output)
+	// Listen returns nil on EOF (input exhausted)
+	require.NoError(t, err)
+
+	// Parse responses
+	scanner := bufio.NewScanner(strings.NewReader(output.String()))
+	var responses []json.RawMessage
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		responses = append(responses, json.RawMessage(line))
+	}
+
+	// Should have at least 3 responses (initialize + panic error + safe result)
+	require.GreaterOrEqual(t, len(responses), 3, "expected at least 3 responses, got %d", len(responses))
+
+	// Verify: panic produces an error response AND safe tool gets a result
+	var foundPanicError, foundSafeResponse bool
+	for _, resp := range responses {
+		var msg struct {
+			ID     any             `json:"id"`
+			Result json.RawMessage `json:"result,omitempty"`
+			Error  json.RawMessage `json:"error,omitempty"`
+		}
+		if err := json.Unmarshal(resp, &msg); err != nil {
+			continue
+		}
+
+		// The panic recovery sends id:null (request ID not available in recover scope)
+		if msg.Error != nil && strings.Contains(string(msg.Error), "internal panic") {
+			foundPanicError = true
+		}
+
+		// Check for id=3 (safe tool response)
+		if id, ok := msg.ID.(float64); ok && int(id) == 3 {
+			foundSafeResponse = true
+			assert.NotNil(t, msg.Result, "safe tool should have a result")
+			assert.Nil(t, msg.Error, "safe tool should not have an error")
+		}
+	}
+	assert.True(t, foundPanicError, "client should receive INTERNAL_ERROR for panicking tool call")
+	assert.True(t, foundSafeResponse, "worker should survive panic and process subsequent tool calls")
+}


### PR DESCRIPTION
## Description

Add `defer recover()` to the SSE message handler goroutine and the stdio `toolCallWorker` so panicking user handlers don't crash the process or permanently reduce worker pool capacity.

Fixes #881

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes

**`server/sse.go`:**

- Add panic recovery to the message handler goroutine (line 680) that calls `HandleMessage`. On panic, logs the error and returns cleanly so the SSE session survives.

**`server/stdio.go`:**

- Wrap the `HandleMessage` call in `toolCallWorker` with an inline recover. On panic, returns an `INTERNAL_ERROR` JSON-RPC response to the client and continues processing the next queued tool call. The worker goroutine is not killed.

## Context

This completes the panic recovery coverage started in #861 (streamable HTTP transport, 9 goroutines) and #880 (task execution goroutines). The SSE and stdio transports were the remaining unprotected paths where user-provided handlers run in library-spawned goroutines.

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

## Test Results

```
ok  github.com/mark3labs/mcp-go/server  13.299s
```

New tests:

- `TestSSEServer_MessageHandlerPanicRecovery`: connects an SSE session, sends a tool call that panics, verifies server still responds to subsequent requests
- `TestStdioServer_ToolCallWorkerPanicRecovery`: sends a panicking tool call followed by a normal tool call via stdio, verifies the worker survives and processes the second call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server stability by adding panic recovery in message-processing paths so tool-handler crashes return an internal-error response and do not stop processing.
* **Tests**
  * Added tests verifying the server remains responsive after tool-handler panics, covering both SSE and stdio interaction flows.

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->