### PR TITLE
fix: add panic recovery to session hook goroutines

### DIFF
--- a/server/session.go
+++ b/server/session.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log"
 	"maps"
 	"net/url"
 
@@ -212,6 +213,11 @@ func (s *MCPServer) sendNotificationToAllClients(notification mcp.JSONRPCNotific
 					// Copy hooks pointer to local variable to avoid race condition
 					hooks := s.hooks
 					go func(sessionID string, hooks *Hooks) {
+						defer func() {
+							if r := recover(); r != nil {
+								log.Printf("mcp-go: panic in OnError hook (notification blocked, session %s): %v", sessionID, r)
+							}
+						}()
 						ctx := context.Background()
 						// Use the error hook to report the blocked channel
 						hooks.onError(ctx, nil, "notification", map[string]any{
@@ -242,6 +248,11 @@ func (s *MCPServer) sendNotificationToSpecificClient(session ClientSession, noti
 			// Copy hooks pointer to local variable to avoid race condition
 			hooks := s.hooks
 			go func(sID string, hooks *Hooks) {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("mcp-go: panic in OnError hook (notification blocked, session %s): %v", sID, r)
+					}
+				}()
 				// Use the error hook to report the blocked channel
 				hooks.onError(ctx, nil, "notification", map[string]any{
 					"method":    notification.Method,
@@ -324,6 +335,11 @@ func (s *MCPServer) sendNotificationCore(
 			// Copy hooks pointer to local variable to avoid race condition
 			hooks := s.hooks
 			go func(sessionID string, hooks *Hooks) {
+				defer func() {
+					if r := recover(); r != nil {
+						log.Printf("mcp-go: panic in OnError hook (notification blocked, session %s): %v", sessionID, r)
+					}
+				}()
 				// Use the error hook to report the blocked channel
 				hooks.onError(ctx, nil, "notification", map[string]any{
 					"method":    method,
@@ -435,6 +451,11 @@ func (s *MCPServer) AddSessionTools(sessionID string, tools ...ServerTool) error
 			if s.hooks != nil && len(s.hooks.OnError) > 0 {
 				hooks := s.hooks
 				go func(sID string, hooks *Hooks) {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("mcp-go: panic in OnError hook (tools added, session %s): %v", sID, r)
+						}
+					}()
 					ctx := context.Background()
 					hooks.onError(ctx, nil, "notification", map[string]any{
 						"method":    "notifications/tools/list_changed",
@@ -495,6 +516,11 @@ func (s *MCPServer) DeleteSessionTools(sessionID string, names ...string) error 
 			if s.hooks != nil && len(s.hooks.OnError) > 0 {
 				hooks := s.hooks
 				go func(sID string, hooks *Hooks) {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("mcp-go: panic in OnError hook (tools deleted, session %s): %v", sID, r)
+						}
+					}()
 					ctx := context.Background()
 					hooks.onError(ctx, nil, "notification", map[string]any{
 						"method":    "notifications/tools/list_changed",
@@ -573,6 +599,11 @@ func (s *MCPServer) AddSessionResources(sessionID string, resources ...ServerRes
 			if s.hooks != nil && len(s.hooks.OnError) > 0 {
 				hooks := s.hooks
 				go func(sID string, hooks *Hooks) {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("mcp-go: panic in OnError hook (resources added, session %s): %v", sID, r)
+						}
+					}()
 					ctx := context.Background()
 					hooks.onError(ctx, nil, "notification", map[string]any{
 						"method":    "notifications/resources/list_changed",
@@ -643,6 +674,11 @@ func (s *MCPServer) DeleteSessionResources(sessionID string, uris ...string) err
 			if s.hooks != nil && len(s.hooks.OnError) > 0 {
 				hooks := s.hooks
 				go func(sID string, hooks *Hooks) {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("mcp-go: panic in OnError hook (resources deleted, session %s): %v", sID, r)
+						}
+					}()
 					ctx := context.Background()
 					hooks.onError(ctx, nil, "notification", map[string]any{
 						"method":    "notifications/resources/list_changed",
@@ -717,6 +753,11 @@ func (s *MCPServer) AddSessionResourceTemplates(sessionID string, templates ...S
 			if s.hooks != nil && len(s.hooks.OnError) > 0 {
 				hooks := s.hooks
 				go func(sID string, hooks *Hooks) {
+					defer func() {
+						if r := recover(); r != nil {
+							log.Printf("mcp-go: panic in OnError hook (resource templates added, session %s): %v", sID, r)
+						}
+					}()
 					ctx := context.Background()
 					hooks.onError(ctx, nil, "notification", map[string]any{
 						"method":    "notifications/resources/list_changed",
@@ -772,6 +813,11 @@ func (s *MCPServer) DeleteSessionResourceTemplates(sessionID string, uriTemplate
 				if s.hooks != nil && len(s.hooks.OnError) > 0 {
 					hooks := s.hooks
 					go func(sID string, hooks *Hooks) {
+						defer func() {
+							if r := recover(); r != nil {
+								log.Printf("mcp-go: panic in OnError hook (resource templates deleted, session %s): %v", sID, r)
+							}
+						}()
 						ctx := context.Background()
 						hooks.onError(ctx, nil, "notification", map[string]any{
 							"method":    "notifications/resources/list_changed",

--- a/server/session_hook_panic_test.go
+++ b/server/session_hook_panic_test.go
@@ -1,0 +1,232 @@
+package server
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestSessionHookGoroutine_PanicsWithoutRecovery proves that a panicking
+// OnError hook in a session notification goroutine crashes the process.
+// This test should be run with `go test -run TestSessionHookGoroutine_PanicsWithoutRecovery`
+// and will CRASH (exit non-zero) if the bug is present.
+//
+// After the fix, this test passes because the goroutine recovers the panic.
+func TestSessionHookGoroutine_PanicsWithoutRecovery(t *testing.T) {
+	var panicRecovered atomic.Bool
+
+	// Create server with a hook that panics
+	hooks := &Hooks{}
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		panic("deliberate panic in OnError hook")
+	})
+
+	server := NewMCPServer("test", "1.0.0",
+		WithToolCapabilities(true),
+		WithHooks(hooks),
+	)
+
+	// Create a mock session with a full notification channel (to trigger the error path)
+	session := &mockSessionForPanic{
+		sessionID:    "test-session-panic",
+		initialized:  true,
+		notifyChan:   make(chan mcp.JSONRPCNotification), // unbuffered = immediately blocks
+		doneOnce:     sync.Once{},
+	}
+
+	// Register the session
+	server.sessions.Store(session.SessionID(), session)
+
+	// Send notification to all clients. The channel is unbuffered and nobody is
+	// reading from it, so the send falls into the default case which spawns
+	// a goroutine calling hooks.onError. That goroutine panics.
+
+	// This triggers the goroutine with the panicking hook
+	server.SendNotificationToAllClients("notifications/test", nil)
+
+	// Give the goroutine time to execute and (hopefully) recover
+	time.Sleep(100 * time.Millisecond)
+
+	// If we reach this point, the panic was recovered (or the test would have crashed)
+	panicRecovered.Store(true)
+	if !panicRecovered.Load() {
+		t.Fatal("should not reach here if panic was not recovered")
+	}
+}
+
+// TestSessionHookGoroutine_PanicRecoveryLogged verifies that after the fix,
+// a panicking hook in a session notification goroutine:
+// 1. Does not crash the process
+// 2. Allows subsequent notifications to continue working
+func TestSessionHookGoroutine_PanicRecoveryLogged(t *testing.T) {
+	var panicCount atomic.Int32
+
+	// First hook panics, second hook increments counter
+	hooks := &Hooks{}
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		panicCount.Add(1)
+		panic("deliberate panic in first OnError hook")
+	})
+
+	server := NewMCPServer("test", "1.0.0",
+		WithToolCapabilities(true),
+		WithHooks(hooks),
+	)
+
+	// Create mock session with full channel
+	session := &mockSessionForPanic{
+		sessionID:   "test-session-recovery",
+		initialized: true,
+		notifyChan:  make(chan mcp.JSONRPCNotification), // unbuffered blocks immediately
+		doneOnce:    sync.Once{},
+	}
+	server.sessions.Store(session.SessionID(), session)
+
+	// Send 3 notifications - each should trigger the hook goroutine
+	for i := 0; i < 3; i++ {
+		server.SendNotificationToAllClients("notifications/test", nil)
+	}
+
+	// Wait for goroutines to execute
+	time.Sleep(200 * time.Millisecond)
+
+	// All 3 hook goroutines should have fired (and panicked, then recovered)
+	if panicCount.Load() != 3 {
+		t.Errorf("expected 3 hook invocations (panics), got %d", panicCount.Load())
+	}
+}
+
+// TestSendNotificationToSpecificClient_HookPanicRecovery verifies that
+// sendNotificationToSpecificClient's hook goroutine also recovers from panics.
+func TestSendNotificationToSpecificClient_HookPanicRecovery(t *testing.T) {
+	var panicCount atomic.Int32
+
+	hooks := &Hooks{}
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		panicCount.Add(1)
+		panic("panic in specific client hook")
+	})
+
+	server := NewMCPServer("test", "1.0.0",
+		WithToolCapabilities(true),
+		WithHooks(hooks),
+	)
+
+	// Create mock session with full channel
+	session := &mockSessionForPanic{
+		sessionID:   "specific-client-test",
+		initialized: true,
+		notifyChan:  make(chan mcp.JSONRPCNotification), // unbuffered blocks immediately
+		doneOnce:    sync.Once{},
+	}
+
+	// Call SendNotificationToSpecificClient with session ID
+	server.sessions.Store(session.SessionID(), session)
+	_ = server.SendNotificationToSpecificClient(session.SessionID(), "notifications/tools/list_changed", nil)
+
+	// Wait for goroutine
+	time.Sleep(100 * time.Millisecond)
+
+	if panicCount.Load() != 1 {
+		t.Errorf("expected 1 hook invocation (panic), got %d", panicCount.Load())
+	}
+}
+
+// TestAddSessionTools_HookPanicRecovery verifies that the hook goroutine
+// spawned during AddSessionTools notification failure also recovers.
+func TestAddSessionTools_HookPanicRecovery(t *testing.T) {
+	var panicCount atomic.Int32
+
+	hooks := &Hooks{}
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		panicCount.Add(1)
+		panic("panic in AddSessionTools hook")
+	})
+
+	server := NewMCPServer("test", "1.0.0",
+		WithToolCapabilities(true),
+		WithHooks(hooks),
+	)
+
+	// Create a session that supports tools but has a full notification channel
+	session := &mockSessionForPanicWithTools{
+		mockSessionForPanic: mockSessionForPanic{
+			sessionID:   "add-tools-test",
+			initialized: true,
+			notifyChan:  make(chan mcp.JSONRPCNotification), // unbuffered blocks
+			doneOnce:    sync.Once{},
+		},
+		tools: make(map[string]ServerTool),
+	}
+	server.sessions.Store(session.SessionID(), session)
+
+	// Add a tool to the session - notification will fail (channel full),
+	// triggering the error hook goroutine which panics
+	err := server.AddSessionTools(session.SessionID(), ServerTool{
+		Tool: mcp.Tool{Name: "test-tool", Description: "test"},
+		Handler: func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultText("ok"), nil
+		},
+	})
+
+	// The tool addition itself should succeed even if the notification hook panics
+	if err != nil {
+		t.Fatalf("AddSessionTools should not fail: %v", err)
+	}
+
+	// Wait for goroutines
+	time.Sleep(100 * time.Millisecond)
+
+	// The hook fires at least once (may fire twice: once from
+	// SendNotificationToSpecificClient's blocked channel, once from the
+	// AddSessionTools notification failure path)
+	if panicCount.Load() < 1 {
+		t.Errorf("expected at least 1 hook invocation (panic), got %d", panicCount.Load())
+	}
+}
+
+// --- Mock session types ---
+
+type mockSessionForPanic struct {
+	sessionID   string
+	initialized bool
+	notifyChan  chan mcp.JSONRPCNotification
+	doneOnce    sync.Once
+}
+
+func (m *mockSessionForPanic) SessionID() string                              { return m.sessionID }
+func (m *mockSessionForPanic) Initialized() bool                              { return m.initialized }
+func (m *mockSessionForPanic) NotificationChannel() chan<- mcp.JSONRPCNotification { return m.notifyChan }
+func (m *mockSessionForPanic) Initialize()                                    {}
+func (m *mockSessionForPanic) GetLoggingLevel() mcp.LoggingLevel              { return mcp.LoggingLevelError }
+func (m *mockSessionForPanic) SetLoggingLevel(level mcp.LoggingLevel)         {}
+func (m *mockSessionForPanic) GetClientInfo() *mcp.Implementation             { return nil }
+func (m *mockSessionForPanic) SetClientInfo(info mcp.Implementation)          {}
+func (m *mockSessionForPanic) GetClientCapabilities() *mcp.ClientCapabilities { return nil }
+func (m *mockSessionForPanic) SetClientCapabilities(caps mcp.ClientCapabilities) {}
+
+type mockSessionForPanicWithTools struct {
+	mockSessionForPanic
+	tools map[string]ServerTool
+	mu    sync.RWMutex
+}
+
+func (m *mockSessionForPanicWithTools) GetSessionTools() map[string]ServerTool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cp := make(map[string]ServerTool, len(m.tools))
+	for k, v := range m.tools {
+		cp[k] = v
+	}
+	return cp
+}
+
+func (m *mockSessionForPanicWithTools) SetSessionTools(tools map[string]ServerTool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.tools = tools
+}

--- a/server/session_hook_panic_test.go
+++ b/server/session_hook_panic_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"maps"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -87,7 +88,7 @@ func TestSessionHookGoroutine_PanicRecoveryLogged(t *testing.T) {
 	server.sessions.Store(session.SessionID(), session)
 
 	// Send 3 notifications - each should trigger the hook goroutine
-	for i := 0; i < 3; i++ {
+	for range 3 {
 		server.SendNotificationToAllClients("notifications/test", nil)
 	}
 
@@ -219,9 +220,7 @@ func (m *mockSessionForPanicWithTools) GetSessionTools() map[string]ServerTool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	cp := make(map[string]ServerTool, len(m.tools))
-	for k, v := range m.tools {
-		cp[k] = v
-	}
+	maps.Copy(cp, m.tools)
 	return cp
 }
 

--- a/server/session_hook_panic_test.go
+++ b/server/session_hook_panic_test.go
@@ -54,9 +54,6 @@ func TestSessionHookGoroutine_PanicsWithoutRecovery(t *testing.T) {
 
 	// If we reach this point, the panic was recovered (or the test would have crashed)
 	panicRecovered.Store(true)
-	if !panicRecovered.Load() {
-		t.Fatal("should not reach here if panic was not recovered")
-	}
 }
 
 // TestSessionHookGoroutine_PanicRecoveryLogged verifies that after the fix,


### PR DESCRIPTION
## Problem

The 9 goroutines in `server/session.go` that invoke user-provided `OnError` hooks have no `recover()`. A panicking hook handler crashes the entire server process, terminating all connected sessions.

This is the same class of issue fixed in #861 (transport goroutines), #880 (task goroutines), and #882 (SSE/stdio handlers), now applied to the session notification layer.

## Root Cause

When a notification channel is blocked or a notification fails to send, session.go spawns a goroutine to invoke the user's `OnError` hook asynchronously. These goroutines call user-provided code (`hooks.onError(...)`) without any panic protection:

```go
go func(sID string, hooks *Hooks) {
    hooks.onError(ctx, nil, "notification", map[string]any{...}, err)
}(sessionID, hooks)
```

If the user's hook panics, the goroutine unwinds without recovery and crashes the process.

## Fix

Add `defer func() { if r := recover(); r != nil { log.Printf(...) } }()` to all 9 hook goroutines in session.go:

1. `sendNotificationToAllClients` (broadcast blocked channel)
2. `sendNotificationToSpecificClient` (specific client blocked)
3. `sendNotificationCore` (core notification blocked)
4. `AddSessionTools` (notification after adding tools)
5. `DeleteSessionTools` (notification after deleting tools)
6. `AddSessionResources` (notification after adding resources)
7. `DeleteSessionResources` (notification after deleting resources)
8. `AddSessionResourceTemplates` (notification after adding templates)
9. `DeleteSessionResourceTemplates` (notification after deleting templates)

Recovery logs via `log.Printf` since `MCPServer` has no logger field (unlike transport layers which use their own structured loggers).

## Tests

Added `session_hook_panic_test.go` with 4 tests:

- `TestSessionHookGoroutine_PanicsWithoutRecovery`: proves recovery works (would crash without fix)
- `TestSessionHookGoroutine_PanicRecoveryLogged`: proves multiple panics don't accumulate/crash
- `TestSendNotificationToSpecificClient_HookPanicRecovery`: covers the specific-client path
- `TestAddSessionTools_HookPanicRecovery`: covers the add-tools notification failure path

All pass with `-race`. Full server suite passes (14s).

## Discovery

Found by systematic goroutine audit: `grep -n "go func" server/session.go` + verify each has `recover()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience: notification-related failures and panics in background notification handlers are now recovered and logged instead of crashing, preserving continuous operation.
  * Post-action flows (e.g., adding session tools) remain functional even when notification errors occur.
* **Tests**
  * Added tests verifying panic recovery, logging, and continued notification behavior after hook failures.

<!-- review_stack_entry_start -->

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->