### PR TITLE
feat(mcp): add BaseMetadata.title, Icon.theme, Resource.size (#870)

### DIFF
--- a/mcp/base_metadata_test.go
+++ b/mcp/base_metadata_test.go
@@ -1,0 +1,199 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolTitleMarshaling verifies that Tool.Title round-trips through JSON
+// and is omitted when empty.
+func TestToolTitleMarshaling(t *testing.T) {
+	t.Run("omitted when empty", func(t *testing.T) {
+		tool := NewTool("my_tool", WithDescription("desc"))
+		data, err := json.Marshal(tool)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"title"`)
+	})
+
+	t.Run("included when set via option", func(t *testing.T) {
+		tool := NewTool("my_tool",
+			WithToolTitle("My Friendly Tool"),
+			WithDescription("desc"),
+		)
+		assert.Equal(t, "My Friendly Tool", tool.Title)
+
+		data, err := json.Marshal(tool)
+		require.NoError(t, err)
+
+		var m map[string]any
+		require.NoError(t, json.Unmarshal(data, &m))
+		assert.Equal(t, "My Friendly Tool", m["title"])
+	})
+
+	t.Run("round-trips through unmarshal", func(t *testing.T) {
+		raw := `{"name":"t","title":"Display Name","inputSchema":{"type":"object"},"annotations":{}}`
+		var tool Tool
+		require.NoError(t, json.Unmarshal([]byte(raw), &tool))
+		assert.Equal(t, "Display Name", tool.Title)
+	})
+}
+
+// TestPromptTitleMarshaling verifies Prompt.Title round-trips through JSON.
+func TestPromptTitleMarshaling(t *testing.T) {
+	t.Run("omitted when empty", func(t *testing.T) {
+		p := NewPrompt("p")
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"title"`)
+	})
+
+	t.Run("included when set via option", func(t *testing.T) {
+		p := NewPrompt("p",
+			WithPromptTitle("Pretty Prompt"),
+			WithPromptDescription("desc"),
+		)
+		assert.Equal(t, "Pretty Prompt", p.Title)
+
+		data, err := json.Marshal(p)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"title":"Pretty Prompt"`)
+
+		var rt Prompt
+		require.NoError(t, json.Unmarshal(data, &rt))
+		assert.Equal(t, "Pretty Prompt", rt.Title)
+	})
+}
+
+// TestPromptArgumentTitle verifies that PromptArgument.Title round-trips and
+// can be set via ArgumentTitle.
+func TestPromptArgumentTitle(t *testing.T) {
+	p := NewPrompt("p",
+		WithArgument("arg",
+			ArgumentTitle("Argument Display"),
+			ArgumentDescription("an arg"),
+			RequiredArgument(),
+		),
+	)
+
+	require.Len(t, p.Arguments, 1)
+	assert.Equal(t, "Argument Display", p.Arguments[0].Title)
+
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"title":"Argument Display"`)
+
+	var rt Prompt
+	require.NoError(t, json.Unmarshal(data, &rt))
+	require.Len(t, rt.Arguments, 1)
+	assert.Equal(t, "Argument Display", rt.Arguments[0].Title)
+}
+
+// TestResourceTitleAndSize verifies the new Resource fields.
+func TestResourceTitleAndSize(t *testing.T) {
+	t.Run("title and size omitted when unset", func(t *testing.T) {
+		r := NewResource("file:///x.txt", "x.txt")
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		s := string(data)
+		assert.NotContains(t, s, `"title"`)
+		assert.NotContains(t, s, `"size"`)
+	})
+
+	t.Run("title and size included when set", func(t *testing.T) {
+		r := NewResource("file:///x.txt", "x.txt",
+			WithResourceTitle("X File"),
+			WithResourceSize(1024),
+		)
+		assert.Equal(t, "X File", r.Title)
+		require.NotNil(t, r.Size)
+		assert.Equal(t, int64(1024), *r.Size)
+
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"title":"X File"`)
+		assert.Contains(t, string(data), `"size":1024`)
+
+		var rt Resource
+		require.NoError(t, json.Unmarshal(data, &rt))
+		assert.Equal(t, "X File", rt.Title)
+		require.NotNil(t, rt.Size)
+		assert.Equal(t, int64(1024), *rt.Size)
+	})
+
+	t.Run("explicit zero size is preserved", func(t *testing.T) {
+		// Pointer semantics let us distinguish a known-zero-byte resource from
+		// an unknown/unset size.
+		r := NewResource("file:///empty.txt", "empty.txt",
+			WithResourceSize(0),
+		)
+		require.NotNil(t, r.Size)
+		assert.Equal(t, int64(0), *r.Size)
+
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"size":0`)
+	})
+}
+
+// TestResourceTemplateTitle verifies that ResourceTemplate.Title round-trips.
+func TestResourceTemplateTitle(t *testing.T) {
+	rt := NewResourceTemplate("file:///{path}", "files",
+		WithTemplateTitle("All Files"),
+		WithTemplateDescription("desc"),
+	)
+	assert.Equal(t, "All Files", rt.Title)
+
+	data, err := json.Marshal(rt)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), `"title":"All Files"`)
+
+	var decoded ResourceTemplate
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.Equal(t, "All Files", decoded.Title)
+}
+
+// TestIconTheme verifies the new Icon.Theme field and constants.
+func TestIconTheme(t *testing.T) {
+	t.Run("theme omitted when empty", func(t *testing.T) {
+		icon := Icon{Src: "https://example.com/icon.png"}
+		data, err := json.Marshal(icon)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"theme"`)
+	})
+
+	t.Run("light theme marshals and unmarshals", func(t *testing.T) {
+		icon := Icon{
+			Src:   "https://example.com/light.png",
+			Theme: IconThemeLight,
+		}
+		data, err := json.Marshal(icon)
+		require.NoError(t, err)
+		assert.JSONEq(t,
+			`{"src":"https://example.com/light.png","theme":"light"}`,
+			string(data),
+		)
+
+		var decoded Icon
+		require.NoError(t, json.Unmarshal(data, &decoded))
+		assert.Equal(t, IconThemeLight, decoded.Theme)
+	})
+
+	t.Run("dark theme constant value", func(t *testing.T) {
+		assert.Equal(t, IconTheme("dark"), IconThemeDark)
+		assert.Equal(t, IconTheme("light"), IconThemeLight)
+	})
+
+	t.Run("unknown theme value unmarshals as-is", func(t *testing.T) {
+		// Forward-compat: unknown theme strings should round-trip rather than error.
+		var icon Icon
+		err := json.Unmarshal(
+			[]byte(`{"src":"x","theme":"sepia"}`),
+			&icon,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, IconTheme("sepia"), icon.Theme)
+	})
+}

--- a/mcp/base_metadata_test.go
+++ b/mcp/base_metadata_test.go
@@ -136,6 +136,28 @@ func TestResourceTitleAndSize(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, string(data), `"size":0`)
 	})
+
+	t.Run("negative size is ignored", func(t *testing.T) {
+		// Size is a byte count per the MCP schema; negative values are nonsensical
+		// and silently dropped rather than serialised back to clients.
+		r := NewResource("file:///x.txt", "x.txt",
+			WithResourceSize(-1),
+		)
+		assert.Nil(t, r.Size)
+
+		data, err := json.Marshal(r)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"size"`)
+	})
+
+	t.Run("negative size does not overwrite a previously set size", func(t *testing.T) {
+		r := NewResource("file:///x.txt", "x.txt",
+			WithResourceSize(100),
+			WithResourceSize(-5),
+		)
+		require.NotNil(t, r.Size)
+		assert.Equal(t, int64(100), *r.Size)
+	})
 }
 
 // TestResourceTemplateTitle verifies that ResourceTemplate.Title round-trips.

--- a/mcp/prompts.go
+++ b/mcp/prompts.go
@@ -52,6 +52,9 @@ type Prompt struct {
 	Meta *Meta `json:"_meta,omitempty"`
 	// The name of the prompt or prompt template.
 	Name string `json:"name"`
+	// Title is an optional human-readable, UI-friendly display name for the prompt.
+	// If not provided, clients should fall back to Name.
+	Title string `json:"title,omitempty"`
 	// An optional description of what this prompt provides
 	Description string `json:"description,omitempty"`
 	// A list of arguments to use for templating the prompt.
@@ -72,6 +75,9 @@ func (p Prompt) GetName() string {
 type PromptArgument struct {
 	// The name of the argument.
 	Name string `json:"name"`
+	// Title is an optional human-readable, UI-friendly display name for the argument.
+	// If not provided, clients should fall back to Name.
+	Title string `json:"title,omitempty"`
 	// A human-readable description of the argument.
 	Description string `json:"description,omitempty"`
 	// Whether this argument must be provided.
@@ -139,6 +145,14 @@ func WithPromptDescription(description string) PromptOption {
 	}
 }
 
+// WithPromptTitle sets the optional human-readable display title for the Prompt.
+// Per the MCP spec, clients should prefer Title over Name for display.
+func WithPromptTitle(title string) PromptOption {
+	return func(p *Prompt) {
+		p.Title = title
+	}
+}
+
 // WithPromptIcons adds icons to the Prompt.
 // Icons provide visual identifiers for the prompt.
 func WithPromptIcons(icons ...Icon) PromptOption {
@@ -175,6 +189,14 @@ func WithArgument(name string, opts ...ArgumentOption) PromptOption {
 func ArgumentDescription(desc string) ArgumentOption {
 	return func(arg *PromptArgument) {
 		arg.Description = desc
+	}
+}
+
+// ArgumentTitle sets the optional human-readable display title for a prompt argument.
+// Per the MCP spec, clients should prefer Title over Name for display.
+func ArgumentTitle(title string) ArgumentOption {
+	return func(arg *PromptArgument) {
+		arg.Title = title
 	}
 }
 

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -45,8 +45,13 @@ func WithResourceTitle(title string) ResourceOption {
 // WithResourceSize sets the size of the raw resource content in bytes.
 // This is the size before base64 encoding or any tokenization, and is used
 // by hosts to display file sizes and estimate context window usage.
+// Negative values are ignored, since the MCP schema defines size as a byte
+// count which is necessarily non-negative.
 func WithResourceSize(size int64) ResourceOption {
 	return func(r *Resource) {
+		if size < 0 {
+			return
+		}
 		r.Size = &size
 	}
 }

--- a/mcp/resources.go
+++ b/mcp/resources.go
@@ -34,6 +34,23 @@ func WithResourceDescription(description string) ResourceOption {
 	}
 }
 
+// WithResourceTitle sets the optional human-readable display title for the Resource.
+// Per the MCP spec, clients should prefer Title over Name for display.
+func WithResourceTitle(title string) ResourceOption {
+	return func(r *Resource) {
+		r.Title = title
+	}
+}
+
+// WithResourceSize sets the size of the raw resource content in bytes.
+// This is the size before base64 encoding or any tokenization, and is used
+// by hosts to display file sizes and estimate context window usage.
+func WithResourceSize(size int64) ResourceOption {
+	return func(r *Resource) {
+		r.Size = &size
+	}
+}
+
 // WithMIMEType sets the MIME type for the Resource.
 // This should indicate the format of the resource's contents.
 func WithMIMEType(mimeType string) ResourceOption {
@@ -93,6 +110,14 @@ func NewResourceTemplate(uriTemplate string, name string, opts ...ResourceTempla
 func WithTemplateDescription(description string) ResourceTemplateOption {
 	return func(t *ResourceTemplate) {
 		t.Description = description
+	}
+}
+
+// WithTemplateTitle sets the optional human-readable display title for the ResourceTemplate.
+// Per the MCP spec, clients should prefer Title over Name for display.
+func WithTemplateTitle(title string) ResourceTemplateOption {
+	return func(t *ResourceTemplate) {
+		t.Title = title
 	}
 }
 

--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -578,6 +578,9 @@ type Tool struct {
 	Meta *Meta `json:"_meta,omitempty"`
 	// The name of the tool.
 	Name string `json:"name"`
+	// Title is an optional human-readable, UI-friendly display name for the tool.
+	// If not provided, clients should use Annotations.Title (if set) and fall back to Name.
+	Title string `json:"title,omitempty"`
 	// A human-readable description of the tool.
 	Description string `json:"description,omitempty"`
 	// A JSON Schema object defining the expected parameters for the tool.
@@ -611,6 +614,9 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 
 	// Add the name and description
 	m["name"] = t.Name
+	if t.Title != "" {
+		m["title"] = t.Title
+	}
 	if t.Description != "" {
 		m["description"] = t.Description
 	}
@@ -831,6 +837,14 @@ func NewToolWithRawSchema(name, description string, schema json.RawMessage) Tool
 func WithDescription(description string) ToolOption {
 	return func(t *Tool) {
 		t.Description = description
+	}
+}
+
+// WithToolTitle sets the optional human-readable display title for the Tool.
+// Per the MCP spec, clients should prefer Title over Annotations.Title and Name for display.
+func WithToolTitle(title string) ToolOption {
+	return func(t *Tool) {
+		t.Title = title
 	}
 }
 

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -611,6 +611,16 @@ type ServerCapabilities struct {
 	Completions *struct{} `json:"completions,omitempty"`
 }
 
+// IconTheme is the background theme an icon is designed to be displayed on.
+type IconTheme string
+
+const (
+	// IconThemeLight indicates the icon is designed for use with a light background.
+	IconThemeLight IconTheme = "light"
+	// IconThemeDark indicates the icon is designed for use with a dark background.
+	IconThemeDark IconTheme = "dark"
+)
+
 // Icon represents a visual identifier for MCP entities.
 //
 // Security considerations:
@@ -628,6 +638,10 @@ type Icon struct {
 
 	// Optional size specifications (e.g., ["48x48"], ["any"] for SVG)
 	Sizes []string `json:"sizes,omitempty"`
+
+	// Theme is an optional specifier for the background theme this icon is designed for.
+	// Use IconThemeLight for light backgrounds or IconThemeDark for dark backgrounds.
+	Theme IconTheme `json:"theme,omitempty"`
 }
 
 // Implementation describes the name and version of an MCP implementation.
@@ -813,6 +827,9 @@ type Resource struct {
 	//
 	// This can be used by clients to populate UI elements.
 	Name string `json:"name"`
+	// Title is an optional human-readable, UI-friendly display name for this resource.
+	// If not provided, clients should fall back to Name.
+	Title string `json:"title,omitempty"`
 	// A description of what this resource represents.
 	//
 	// This can be used by clients to improve the LLM's understanding of
@@ -822,6 +839,13 @@ type Resource struct {
 	MIMEType string `json:"mimeType,omitempty"`
 	// Icons provides visual identifiers for the resource
 	Icons []Icon `json:"icons,omitempty"`
+	// Size is the size of the raw resource content, in bytes (i.e., before base64
+	// encoding or any tokenization), if known. This can be used by hosts to
+	// display file sizes and estimate context window usage.
+	//
+	// A pointer is used so that an explicit zero size remains distinguishable
+	// from an unset value.
+	Size *int64 `json:"size,omitempty"`
 }
 
 // GetName returns the name of the resource.
@@ -842,6 +866,9 @@ type ResourceTemplate struct {
 	//
 	// This can be used by clients to populate UI elements.
 	Name string `json:"name"`
+	// Title is an optional human-readable, UI-friendly display name for this resource template.
+	// If not provided, clients should fall back to Name.
+	Title string `json:"title,omitempty"`
 	// A description of what this template is for.
 	//
 	// This can be used by clients to improve the LLM's understanding of

--- a/www/docs/pages/servers/advanced.mdx
+++ b/www/docs/pages/servers/advanced.mdx
@@ -20,7 +20,26 @@ mcp.Icon{
 }
 ```
 
+### Theme-Specific Icons
 
+Icons can optionally declare which background theme they're designed for. Clients use the hint to pick the right asset when rendering against a light or dark UI:
+
+```go
+icons := []mcp.Icon{
+    {
+        Src:      "https://example.com/icons/tool-light.svg",
+        MIMEType: "image/svg+xml",
+        Theme:    mcp.IconThemeLight,    // Designed for light backgrounds
+    },
+    {
+        Src:      "https://example.com/icons/tool-dark.svg",
+        MIMEType: "image/svg+xml",
+        Theme:    mcp.IconThemeDark,     // Designed for dark backgrounds
+    },
+}
+```
+
+The `Theme` field is optional — an icon without a theme is treated as theme-agnostic. The supported constants are `mcp.IconThemeLight` and `mcp.IconThemeDark`; unknown values are passed through unchanged for forward compatibility.
 
 Explore powerful features that make MCP-Go servers production-ready: typed tools, session management, middleware, hooks, and more.
 

--- a/www/docs/pages/servers/prompts.mdx
+++ b/www/docs/pages/servers/prompts.mdx
@@ -40,6 +40,24 @@ prompt := mcp.NewPrompt("code_review",
 )
 ```
 
+### Display Title
+
+Prompts and their arguments can carry a human-readable display title. Clients render the title in pickers and UI surfaces; the `name` stays a stable programmatic identifier.
+
+```go
+prompt := mcp.NewPrompt("code_review",
+    mcp.WithPromptTitle("Code Review"),                            // Shown in UI
+    mcp.WithPromptDescription("Review code for best practices"),
+    mcp.WithArgument("code",
+        mcp.ArgumentTitle("Source Code"),                          // Argument display name
+        mcp.ArgumentDescription("The code to review"),
+        mcp.RequiredArgument(),
+    ),
+)
+```
+
+When `Title` is empty, clients fall back to `Name`. Both fields serialise with `omitempty`, so existing prompts that don't set a title are unchanged on the wire.
+
 ## Prompt Templates
 
 ### Basic Code Review Prompt

--- a/www/docs/pages/servers/resources.mdx
+++ b/www/docs/pages/servers/resources.mdx
@@ -37,6 +37,46 @@ resource := mcp.NewResource(
 )
 ```
 
+### Display Title
+
+Resources and resource templates can carry a human-readable display title separate from the `name`. Clients show the title in file browsers and pickers; `name` remains a stable identifier suitable for programmatic lookup.
+
+```go
+resource := mcp.NewResource(
+    "docs://readme",
+    "readme.md",                                          // name (stable identifier)
+    mcp.WithResourceTitle("Project README"),              // Shown in UI
+    mcp.WithResourceDescription("Main project documentation"),
+    mcp.WithMIMEType("text/markdown"),
+)
+
+// Same option exists on resource templates
+template := mcp.NewResourceTemplate(
+    "users://{user_id}",
+    "user-profile",
+    mcp.WithTemplateTitle("User Profile"),
+    mcp.WithTemplateDescription("Profile information for a specific user"),
+)
+```
+
+If `Title` is empty, clients fall back to `Name`. The field serialises with `omitempty`, so resources that don't set a title are unchanged on the wire.
+
+### Resource Size
+
+When the raw byte size of a resource is known in advance, set it so hosts can render file sizes and pre-budget context-window usage without fetching the body:
+
+```go
+resource := mcp.NewResource(
+    "file:///var/log/app.log",
+    "app.log",
+    mcp.WithResourceTitle("Application Log"),
+    mcp.WithMIMEType("text/plain"),
+    mcp.WithResourceSize(2_048_576),    // 2 MiB, measured before base64 encoding
+)
+```
+
+`Size` is exposed as `*int64` on the `Resource` struct so an explicit zero-byte resource is distinguishable from an unknown size. Omit `WithResourceSize` entirely when the size is unknown.
+
 ## Static Resources
 
 Static resources have fixed URIs and typically serve predetermined content.

--- a/www/docs/pages/servers/tools.mdx
+++ b/www/docs/pages/servers/tools.mdx
@@ -24,6 +24,26 @@ tool := mcp.NewTool("calculate",
 
 ## Tool Definition
 
+### Display Title
+
+Tools can carry a human-readable display title separate from their programmatic `name`. Clients display titles in tool pickers and UI surfaces; the `name` is reserved for model-facing identifiers.
+
+```go
+tool := mcp.NewTool("calculate_arithmetic",
+    mcp.WithToolTitle("Calculator"),               // Shown in UI
+    mcp.WithDescription("Perform arithmetic operations"),
+    // ... parameters
+)
+```
+
+Per the [MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/server/tools), clients should resolve the display label in this order:
+
+1. `Title` (the top-level field set by `WithToolTitle`)
+2. `Annotations.Title` (legacy hint set by `WithTitleAnnotation`, see [Tool Annotations](#tool-annotations))
+3. `Name`
+
+Both fields are optional; omitting them falls back to the next candidate.
+
 ### Tool Icons
 
 Tools can include visual identifiers using icons. Icons must use HTTPS or data URIs:


### PR DESCRIPTION
## Description

Catches the Go SDK up to three additive optional fields that exist in the [MCP 2025-11-25 schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts) but were missing from the corresponding Go types: `BaseMetadata.title`, `Icon.theme`, and `Resource.size`. None of these fields are `required`, so this is a feature-parity gap rather than a wire-format break — clients previously had no way to read display titles, theme-specific icons, or resource sizes.

All changes are additive and backwards compatible: every new field carries `omitempty`, so existing payloads stay byte-identical when fields are unset, and no existing struct literal in the repo uses positional form.

```go
// Before — only name and description available
tool := mcp.NewTool("calculate_arithmetic",
    mcp.WithDescription("Perform arithmetic operations"),
)

// After — clients can now show a friendly UI label
tool := mcp.NewTool("calculate_arithmetic",
    mcp.WithToolTitle("Calculator"),
    mcp.WithDescription("Perform arithmetic operations"),
)

resource := mcp.NewResource("file:///var/log/app.log", "app.log",
    mcp.WithResourceTitle("Application Log"),
    mcp.WithResourceSize(2_048_576), // pre-fetch size hint for the host
)

icon := mcp.Icon{
    Src:   "https://example.com/icons/tool-dark.svg",
    Theme: mcp.IconThemeDark,        // hint for dark-theme UIs
}
```

Fixes #870

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [BaseMetadata, Icon, Resource — schema 2025-11-25](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/main/schema/2025-11-25/schema.ts)
- [x] Implementation follows the specification exactly

## Additional Information

**Gap 1 — `BaseMetadata.title`** added to:

- `Tool` (+ `WithToolTitle` option, emitted from `Tool.MarshalJSON`)
- `Prompt` (+ `WithPromptTitle`)
- `PromptArgument` (+ `ArgumentTitle`)
- `Resource` (+ `WithResourceTitle`)
- `ResourceTemplate` (+ `WithTemplateTitle`)

Per the spec, the display-precedence order for `Tool` is now `Title → Annotations.Title → Name`; for the others it is simply `Title → Name`.

**Gap 2 — `Icon.theme`**: new `IconTheme` string type with `IconThemeLight` and `IconThemeDark` constants, plus `Theme` field on `Icon`. Unknown theme values are passed through unchanged for forward compatibility.

**Gap 3 — `Resource.size`**: new `Size *int64` field on `Resource` (+ `WithResourceSize` helper). Pointer keeps an explicit zero-byte resource distinguishable from an unknown size.

**Files changed**

- `mcp/tools.go`, `mcp/prompts.go`, `mcp/resources.go`, `mcp/types.go` — new fields, options, constants, and `MarshalJSON` update
- `mcp/base_metadata_test.go` — new file, 6 round-trip JSON tests covering omit-when-empty, set-via-option, explicit-zero size, and unknown-theme forward compat
- `www/docs/pages/servers/tools.mdx` — new "Display Title" subsection with the precedence rules
- `www/docs/pages/servers/prompts.mdx` — new "Display Title" subsection covering both `WithPromptTitle` and `ArgumentTitle`
- `www/docs/pages/servers/resources.mdx` — new "Display Title" and "Resource Size" subsections
- `www/docs/pages/servers/advanced.mdx` — new "Theme-Specific Icons" block under the existing Icons section

**Backwards compatibility**: ✅ Fully additive. All new fields are `omitempty`; positional struct literals are not used anywhere in the repo. Tests, vet, and `golangci-lint` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional display titles for tools, prompts, prompt arguments, resources, and resource templates to improve UI presentation.
  * Icons may specify light/dark themes.
  * Resources can declare content size.
* **Documentation**
  * Added docs for display titles, resource size, and theme-specific icons.
* **Tests**
  * Expanded JSON round-trip tests covering title, resource size behavior, and icon theme serialization and compatibility.

<!-- review_stack_entry_start -->

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->