### PR TITLE
refactor(server): collapse client-info and writeJSONRPCError duplication

### DIFF
--- a/server/client_info_store.go
+++ b/server/client_info_store.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"sync/atomic"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// clientInfoStore provides thread-safe storage for a session's client info
+// and client capabilities. It is intended to be embedded in concrete session
+// types so each session gains GetClientInfo, SetClientInfo,
+// GetClientCapabilities, and SetClientCapabilities via method promotion
+// without duplicating the atomic.Value boilerplate.
+//
+// Zero-value clientInfoStore is ready for use. All methods are safe for
+// concurrent access.
+type clientInfoStore struct {
+	clientInfo         atomic.Value // stores mcp.Implementation
+	clientCapabilities atomic.Value // stores mcp.ClientCapabilities
+}
+
+// GetClientInfo returns the stored client info, or the zero value of
+// mcp.Implementation if it has not been set.
+func (s *clientInfoStore) GetClientInfo() mcp.Implementation {
+	if value := s.clientInfo.Load(); value != nil {
+		if clientInfo, ok := value.(mcp.Implementation); ok {
+			return clientInfo
+		}
+	}
+	return mcp.Implementation{}
+}
+
+// SetClientInfo replaces the stored client info.
+func (s *clientInfoStore) SetClientInfo(clientInfo mcp.Implementation) {
+	s.clientInfo.Store(clientInfo)
+}
+
+// GetClientCapabilities returns the stored client capabilities, or the
+// zero value of mcp.ClientCapabilities if they have not been set.
+func (s *clientInfoStore) GetClientCapabilities() mcp.ClientCapabilities {
+	if value := s.clientCapabilities.Load(); value != nil {
+		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
+			return clientCapabilities
+		}
+	}
+	return mcp.ClientCapabilities{}
+}
+
+// SetClientCapabilities replaces the stored client capabilities.
+func (s *clientInfoStore) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
+	s.clientCapabilities.Store(clientCapabilities)
+}

--- a/server/client_info_store_test.go
+++ b/server/client_info_store_test.go
@@ -1,0 +1,131 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+func TestClientInfoStore_DefaultsToZeroValues(t *testing.T) {
+	var s clientInfoStore
+
+	assert.Equal(t, mcp.Implementation{}, s.GetClientInfo())
+	assert.Equal(t, mcp.ClientCapabilities{}, s.GetClientCapabilities())
+}
+
+func TestClientInfoStore_RoundTrip(t *testing.T) {
+	var s clientInfoStore
+
+	info := mcp.Implementation{Name: "test-client", Version: "1.2.3"}
+	caps := mcp.ClientCapabilities{Sampling: &mcp.SamplingCapability{}}
+
+	s.SetClientInfo(info)
+	s.SetClientCapabilities(caps)
+
+	assert.Equal(t, info, s.GetClientInfo())
+	assert.Equal(t, caps, s.GetClientCapabilities())
+}
+
+// clientInfoMethods captures the four methods clientInfoStore is meant to
+// supply via embedding.
+type clientInfoMethods interface {
+	GetClientInfo() mcp.Implementation
+	SetClientInfo(mcp.Implementation)
+	GetClientCapabilities() mcp.ClientCapabilities
+	SetClientCapabilities(mcp.ClientCapabilities)
+}
+
+func TestClientInfoStore_EmbeddedPromotion(t *testing.T) {
+	// Verify that embedding clientInfoStore promotes the four methods on
+	// the outer type. This is the property each production session relies
+	// on to satisfy SessionWithClientInfo without declaring its own
+	// getters/setters.
+	type fakeSession struct {
+		clientInfoStore
+	}
+
+	var s clientInfoMethods = &fakeSession{}
+
+	want := mcp.Implementation{Name: "promotion", Version: "0.0.1"}
+	s.SetClientInfo(want)
+	assert.Equal(t, want, s.GetClientInfo())
+
+	wantCaps := mcp.ClientCapabilities{Sampling: &mcp.SamplingCapability{}}
+	s.SetClientCapabilities(wantCaps)
+	assert.Equal(t, wantCaps, s.GetClientCapabilities())
+}
+
+func TestWriteJSONRPCError_HTTPResponseWriter(t *testing.T) {
+	rec := httptest.NewRecorder()
+
+	writeJSONRPCError(rec, "req-1", mcp.INVALID_PARAMS, "bad params", nil)
+
+	assert.Equal(t, http.StatusBadRequest, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var decoded mcp.JSONRPCError
+	require.NoError(t, json.Unmarshal(rec.Body.Bytes(), &decoded))
+	assert.Equal(t, mcp.JSONRPC_VERSION, decoded.JSONRPC)
+	assert.Equal(t, mcp.INVALID_PARAMS, decoded.Error.Code)
+	assert.Equal(t, "bad params", decoded.Error.Message)
+}
+
+// failingWriter records the WriteHeader call and the Content-Type header,
+// then returns an error from Write to exercise the encode-error path.
+type failingWriter struct {
+	header     http.Header
+	statusCode int
+	writeCalls atomic.Int32
+}
+
+func newFailingWriter() *failingWriter {
+	return &failingWriter{header: make(http.Header)}
+}
+
+func (f *failingWriter) Header() http.Header        { return f.header }
+func (f *failingWriter) WriteHeader(statusCode int) { f.statusCode = statusCode }
+func (f *failingWriter) Write(_ []byte) (int, error) {
+	f.writeCalls.Add(1)
+	return 0, errors.New("boom")
+}
+
+func TestWriteJSONRPCError_InvokesOnEncodeErr(t *testing.T) {
+	w := newFailingWriter()
+
+	var got error
+	writeJSONRPCError(w, nil, mcp.PARSE_ERROR, "parse error", func(err error) {
+		got = err
+	})
+
+	assert.Equal(t, http.StatusBadRequest, w.statusCode)
+	assert.Equal(t, "application/json", w.header.Get("Content-Type"))
+	require.Error(t, got)
+	assert.Contains(t, got.Error(), "boom")
+	assert.Greater(t, w.writeCalls.Load(), int32(0))
+}
+
+func TestWriteJSONRPCError_NilCallbackIsSafe(t *testing.T) {
+	w := newFailingWriter()
+
+	assert.NotPanics(t, func() {
+		writeJSONRPCError(w, nil, mcp.PARSE_ERROR, "parse error", nil)
+	})
+}
+
+// TestJSONRPCErrorResponseWriter_StaticAssertions is a compile-time check
+// that the two response-writer types used by the SSE and streamable HTTP
+// transports both satisfy jsonrpcErrorResponseWriter.
+func TestJSONRPCErrorResponseWriter_StaticAssertions(t *testing.T) {
+	var _ jsonrpcErrorResponseWriter = (http.ResponseWriter)(nil)
+	var _ jsonrpcErrorResponseWriter = (HTTPResponseWriter)(nil)
+	// Sanity: a recorder is also acceptable as a concrete adapter.
+	var _ jsonrpcErrorResponseWriter = httptest.NewRecorder()
+}

--- a/server/inprocess_session.go
+++ b/server/inprocess_session.go
@@ -26,12 +26,12 @@ type RootsHandler interface {
 }
 
 type InProcessSession struct {
+	clientInfoStore // provides Get/SetClientInfo and Get/SetClientCapabilities via method promotion
+
 	sessionID          string
 	notifications      chan mcp.JSONRPCNotification
 	initialized        atomic.Bool
 	loggingLevel       atomic.Value
-	clientInfo         atomic.Value
-	clientCapabilities atomic.Value
 	samplingHandler    SamplingHandler
 	elicitationHandler ElicitationHandler
 	rootsHandler       RootsHandler
@@ -71,32 +71,6 @@ func (s *InProcessSession) Initialize() {
 
 func (s *InProcessSession) Initialized() bool {
 	return s.initialized.Load()
-}
-
-func (s *InProcessSession) GetClientInfo() mcp.Implementation {
-	if value := s.clientInfo.Load(); value != nil {
-		if clientInfo, ok := value.(mcp.Implementation); ok {
-			return clientInfo
-		}
-	}
-	return mcp.Implementation{}
-}
-
-func (s *InProcessSession) SetClientInfo(clientInfo mcp.Implementation) {
-	s.clientInfo.Store(clientInfo)
-}
-
-func (s *InProcessSession) GetClientCapabilities() mcp.ClientCapabilities {
-	if value := s.clientCapabilities.Load(); value != nil {
-		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
-			return clientCapabilities
-		}
-	}
-	return mcp.ClientCapabilities{}
-}
-
-func (s *InProcessSession) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
-	s.clientCapabilities.Store(clientCapabilities)
 }
 
 func (s *InProcessSession) SetLogLevel(level mcp.LoggingLevel) {

--- a/server/jsonrpc_error.go
+++ b/server/jsonrpc_error.go
@@ -1,0 +1,37 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// jsonrpcErrorResponseWriter is the minimum surface needed by
+// writeJSONRPCError to emit a JSON-RPC error response onto an HTTP-style
+// transport. Both http.ResponseWriter and HTTPResponseWriter satisfy this
+// interface, so the same helper serves the SSE and streamable HTTP
+// transports.
+type jsonrpcErrorResponseWriter interface {
+	Header() http.Header
+	WriteHeader(statusCode int)
+	Write(p []byte) (int, error)
+}
+
+// writeJSONRPCError encodes a JSON-RPC error response identified by id with
+// the given code and message and writes it to w with HTTP status 400 Bad
+// Request and Content-Type application/json. If JSON encoding fails and
+// onEncodeErr is non-nil, it is invoked with the encode error so callers
+// can decide how to report the failure (e.g. log it, escalate to HTTP 500).
+func writeJSONRPCError(
+	w jsonrpcErrorResponseWriter,
+	id any,
+	code int,
+	message string,
+	onEncodeErr func(error),
+) {
+	response := createErrorResponse(id, code, message)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	if err := json.NewEncoder(w).Encode(response); err != nil && onEncodeErr != nil {
+		onEncodeErr(err)
+	}
+}

--- a/server/sse.go
+++ b/server/sse.go
@@ -704,11 +704,11 @@ func (s *SSEServer) writeJSONRPCError(
 	message string,
 ) {
 	writeJSONRPCError(w, id, code, message, func(err error) {
-		http.Error(
-			w,
-			fmt.Sprintf("Failed to encode response: %v", err),
-			http.StatusInternalServerError,
-		)
+		// The 400 status and partial JSON body have already been written
+		// by writeJSONRPCError, so we cannot escalate to a different HTTP
+		// status here without producing a malformed response. Log instead,
+		// matching the streamable HTTP transport's behavior.
+		log.Printf("Failed to encode response: %v", err)
 	})
 }
 

--- a/server/sse.go
+++ b/server/sse.go
@@ -21,6 +21,8 @@ import (
 
 // sseSession represents an active SSE connection.
 type sseSession struct {
+	clientInfoStore // provides Get/SetClientInfo and Get/SetClientCapabilities via method promotion
+
 	done                chan struct{}
 	doneOnce            sync.Once
 	eventQueue          chan string // Channel for queuing events
@@ -29,11 +31,9 @@ type sseSession struct {
 	notificationChannel chan mcp.JSONRPCNotification
 	initialized         atomic.Bool
 	loggingLevel        atomic.Value
-	tools               sync.Map     // stores session-specific tools
-	resources           sync.Map     // stores session-specific resources
-	resourceTemplates   sync.Map     // stores session-specific resource templates
-	clientInfo          atomic.Value // stores session-specific client info
-	clientCapabilities  atomic.Value // stores session-specific client capabilities
+	tools               sync.Map // stores session-specific tools
+	resources           sync.Map // stores session-specific resources
+	resourceTemplates   sync.Map // stores session-specific resource templates
 }
 
 // closeDone safely closes the session's done channel exactly once,
@@ -152,32 +152,6 @@ func (s *sseSession) SetSessionTools(tools map[string]ServerTool) {
 	for name, tool := range tools {
 		s.tools.Store(name, tool)
 	}
-}
-
-func (s *sseSession) GetClientInfo() mcp.Implementation {
-	if value := s.clientInfo.Load(); value != nil {
-		if clientInfo, ok := value.(mcp.Implementation); ok {
-			return clientInfo
-		}
-	}
-	return mcp.Implementation{}
-}
-
-func (s *sseSession) SetClientInfo(clientInfo mcp.Implementation) {
-	s.clientInfo.Store(clientInfo)
-}
-
-func (s *sseSession) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
-	s.clientCapabilities.Store(clientCapabilities)
-}
-
-func (s *sseSession) GetClientCapabilities() mcp.ClientCapabilities {
-	if value := s.clientCapabilities.Load(); value != nil {
-		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
-			return clientCapabilities
-		}
-	}
-	return mcp.ClientCapabilities{}
 }
 
 var (
@@ -729,17 +703,13 @@ func (s *SSEServer) writeJSONRPCError(
 	code int,
 	message string,
 ) {
-	response := createErrorResponse(id, code, message)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusBadRequest)
-	if err := json.NewEncoder(w).Encode(response); err != nil {
+	writeJSONRPCError(w, id, code, message, func(err error) {
 		http.Error(
 			w,
 			fmt.Sprintf("Failed to encode response: %v", err),
 			http.StatusInternalServerError,
 		)
-		return
-	}
+	})
 }
 
 // SendEventToSession sends an event to a specific SSE session identified by sessionID.

--- a/server/stdio.go
+++ b/server/stdio.go
@@ -92,11 +92,11 @@ func WithQueueSize(size int) StdioOption {
 
 // stdioSession is a static client session, since stdio has only one client.
 type stdioSession struct {
+	clientInfoStore // provides Get/SetClientInfo and Get/SetClientCapabilities via method promotion
+
 	notifications       chan mcp.JSONRPCNotification
 	initialized         atomic.Bool
 	loggingLevel        atomic.Value
-	clientInfo          atomic.Value                        // stores session-specific client info
-	clientCapabilities  atomic.Value                        // stores session-specific client capabilities
 	writer              io.Writer                           // for sending requests to client
 	requestID           atomic.Int64                        // for generating unique request IDs
 	mu                  sync.RWMutex                        // protects writer
@@ -140,32 +140,6 @@ func (s *stdioSession) Initialize() {
 
 func (s *stdioSession) Initialized() bool {
 	return s.initialized.Load()
-}
-
-func (s *stdioSession) GetClientInfo() mcp.Implementation {
-	if value := s.clientInfo.Load(); value != nil {
-		if clientInfo, ok := value.(mcp.Implementation); ok {
-			return clientInfo
-		}
-	}
-	return mcp.Implementation{}
-}
-
-func (s *stdioSession) SetClientInfo(clientInfo mcp.Implementation) {
-	s.clientInfo.Store(clientInfo)
-}
-
-func (s *stdioSession) GetClientCapabilities() mcp.ClientCapabilities {
-	if value := s.clientCapabilities.Load(); value != nil {
-		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
-			return clientCapabilities
-		}
-	}
-	return mcp.ClientCapabilities{}
-}
-
-func (s *stdioSession) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
-	s.clientCapabilities.Store(clientCapabilities)
 }
 
 func (s *stdioSession) SetLogLevel(level mcp.LoggingLevel) {

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -1019,13 +1019,9 @@ func (s *StreamableHTTPServer) writeJSONRPCError(
 	code int,
 	message string,
 ) {
-	response := createErrorResponse(id, code, message)
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(http.StatusBadRequest)
-	err := json.NewEncoder(w).Encode(response)
-	if err != nil {
+	writeJSONRPCError(w, id, code, message, func(err error) {
 		s.logger.Errorf("Failed to write JSONRPCError: %v", err)
-	}
+	})
 }
 
 // nextRequestID gets the next incrementing requestID for the current session
@@ -1290,6 +1286,8 @@ type rootsRequestItem struct {
 // When in POST handlers(request/notification), it's ephemeral, and only exists in the life of the request handler.
 // When in GET handlers(listening), it's a real session, and will be registered in the MCP server.
 type streamableHttpSession struct {
+	clientInfoStore // provides Get/SetClientInfo and Get/SetClientCapabilities via method promotion
+
 	sessionID           string
 	notificationChannel chan mcp.JSONRPCNotification // server -> client notifications
 	tools               *sessionToolsStore
@@ -1297,8 +1295,6 @@ type streamableHttpSession struct {
 	resourceTemplates   *sessionResourceTemplatesStore
 	upgradeToSSE        atomic.Bool
 	logLevels           *sessionLogLevelsStore
-	clientInfo          atomic.Value // stores session-specific client info
-	clientCapabilities  atomic.Value // stores session-specific client capabilities
 
 	// Sampling support for bidirectional communication
 	samplingRequestChan    chan samplingRequestItem    // server -> client sampling requests
@@ -1374,32 +1370,6 @@ func (s *streamableHttpSession) GetSessionResourceTemplates() map[string]ServerR
 
 func (s *streamableHttpSession) SetSessionResourceTemplates(templates map[string]ServerResourceTemplate) {
 	s.resourceTemplates.set(s.sessionID, templates)
-}
-
-func (s *streamableHttpSession) GetClientInfo() mcp.Implementation {
-	if value := s.clientInfo.Load(); value != nil {
-		if clientInfo, ok := value.(mcp.Implementation); ok {
-			return clientInfo
-		}
-	}
-	return mcp.Implementation{}
-}
-
-func (s *streamableHttpSession) SetClientInfo(clientInfo mcp.Implementation) {
-	s.clientInfo.Store(clientInfo)
-}
-
-func (s *streamableHttpSession) GetClientCapabilities() mcp.ClientCapabilities {
-	if value := s.clientCapabilities.Load(); value != nil {
-		if clientCapabilities, ok := value.(mcp.ClientCapabilities); ok {
-			return clientCapabilities
-		}
-	}
-	return mcp.ClientCapabilities{}
-}
-
-func (s *streamableHttpSession) SetClientCapabilities(clientCapabilities mcp.ClientCapabilities) {
-	s.clientCapabilities.Store(clientCapabilities)
 }
 
 var (


### PR DESCRIPTION
## Description

Two byte-for-byte (modulo receiver / error-reporting strategy) duplication clusters in `server/` are collapsed onto shared, unexported helpers. No public API changes.

**Cluster 1 — `writeJSONRPCError`**: `(*SSEServer).writeJSONRPCError` and `(*StreamableHTTPServer).writeJSONRPCError` are now thin wrappers around a single `writeJSONRPCError(w, id, code, message, onEncodeErr)` helper. A small `jsonrpcErrorResponseWriter` interface is satisfied by both `http.ResponseWriter` (used by SSE) and `HTTPResponseWriter` (used by the streamable HTTP transport), so the helper serves both transports while each caller keeps its own encode-error policy (`http.Error` for SSE, `logger.Errorf` for streamable HTTP).

**Cluster 2 — session client-info getters/setters**: A new unexported `clientInfoStore` struct holds the `atomic.Value`-backed `clientInfo` / `clientCapabilities` fields and provides the four `Get`/`Set` methods. It is embedded into `sseSession`, `stdioSession`, `streamableHttpSession`, and `InProcessSession`, so each session type gains the methods via Go method promotion instead of carrying an identical copy. The existing `_ SessionWithClientInfo = (*…)(nil)` static assertions still hold, guaranteeing interface satisfaction at compile time.

Fixes #872

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

**Net change:** +235 / −127 across 7 files (3 new, 4 modified). The new helpers add lines, but every concrete session/server file shrinks — the four touched files lose 112 lines combined.

**New files**

- `server/client_info_store.go` — `clientInfoStore` with godoc on every exported-shape method
- `server/jsonrpc_error.go` — shared `writeJSONRPCError` helper + `jsonrpcErrorResponseWriter` interface
- `server/client_info_store_test.go` — regression tests: zero-value defaults, round-trip, embedded method promotion, JSON-RPC error body shape, encode-error callback dispatch, nil-callback safety, static assertions that both response-writer types satisfy the helper interface

**Modified files**

- `server/sse.go` — `sseSession` embeds `clientInfoStore`; 4 duplicated methods removed; `(*SSEServer).writeJSONRPCError` delegates to the shared helper with an `http.Error` callback
- `server/stdio.go` — `stdioSession` embeds `clientInfoStore`; 4 duplicated methods removed
- `server/streamable_http.go` — `streamableHttpSession` embeds `clientInfoStore`; 4 duplicated methods removed; `(*StreamableHTTPServer).writeJSONRPCError` delegates to the shared helper with a `logger.Errorf` callback
- `server/inprocess_session.go` — `InProcessSession` embeds `clientInfoStore`; 4 duplicated methods removed

**Backwards compatibility:** Zero public API change. Three of the four session types (`sseSession`, `stdioSession`, `streamableHttpSession`) are unexported. `InProcessSession` is exported but keeps its method set unchanged via Go method promotion from the embedded `clientInfoStore`. All existing `SessionWithClientInfo` interface satisfactions are preserved (verified by the unchanged `_ SessionWithClientInfo = …` static assertions in each file).

**Verification:** `go test ./... -race -count=1` passes; `golangci-lint run` reports `0 issues.`; `go vet ./...` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated client info and capability storage into a shared, embeddable store used by multiple session types.
  * Simplified session implementations by promoting shared storage behavior.
* **New**
  * Centralized JSON-RPC error handling with a reusable helper that ensures consistent HTTP status and JSON response behavior.
* **Tests**
  * Added tests covering client info/capabilities defaults and round-trips, embedding behavior, and JSON-RPC error response paths (including error callbacks).

<!-- review_stack_entry_start -->

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->