### PR TITLE
Add Title and Size to ResourceLink (match Resource / spec)

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1234,10 +1234,20 @@ type ResourceLink struct {
 	URI string `json:"uri"`
 	// The name of the resource.
 	Name string `json:"name"`
+	// Title is an optional human-readable, UI-friendly display name for this resource.
+	// If not provided, clients should fall back to Name.
+	Title string `json:"title,omitempty"`
 	// The description of the resource.
 	Description string `json:"description"`
 	// The MIME type of the resource.
 	MIMEType string `json:"mimeType"`
+	// Size is the size of the raw resource content, in bytes (i.e., before base64
+	// encoding or any tokenization), if known. This can be used by hosts to
+	// display file sizes and estimate context window usage.
+	//
+	// A pointer is used so that an explicit zero size remains distinguishable
+	// from an unset value.
+	Size *int64 `json:"size,omitempty"`
 }
 
 func (ResourceLink) isContent() {}

--- a/mcp/types_test.go
+++ b/mcp/types_test.go
@@ -96,51 +96,55 @@ func TestResourceLinkSerialization(t *testing.T) {
 
 // TestResourceLinkTitleAndSize mirrors TestResourceTitleAndSize: per the MCP
 // spec a ResourceLink carries the same metadata as a Resource, so Title and
-// Size must round-trip through JSON the same way they do for Resource.
+// Size must round-trip through JSON the same way they do for Resource. The
+// pointer Size lets an explicit zero stay distinguishable from an unset value.
 func TestResourceLinkTitleAndSize(t *testing.T) {
-	t.Run("title and size omitted when unset", func(t *testing.T) {
-		rl := NewResourceLink("file:///x.txt", "x.txt", "", "")
-		data, err := json.Marshal(rl)
-		require.NoError(t, err)
-		s := string(data)
-		assert.NotContains(t, s, `"title"`)
-		assert.NotContains(t, s, `"size"`)
-	})
+	tests := []struct {
+		name        string
+		title       string
+		size        *int64
+		wantJSON    []string
+		notWantJSON []string
+	}{
+		{
+			name:        "title and size omitted when unset",
+			notWantJSON: []string{`"title"`, `"size"`},
+		},
+		{
+			name:     "title and size round-trip when set",
+			title:    "X File",
+			size:     ToInt64Ptr(1024),
+			wantJSON: []string{`"title":"X File"`, `"size":1024`},
+		},
+		{
+			name:     "explicit zero size is preserved",
+			size:     ToInt64Ptr(0),
+			wantJSON: []string{`"size":0`},
+		},
+	}
 
-	t.Run("title and size round-trip when set", func(t *testing.T) {
-		size := int64(1024)
-		rl := NewResourceLink("file:///x.txt", "x.txt", "desc", "text/plain")
-		rl.Title = "X File"
-		rl.Size = &size
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rl := NewResourceLink("file:///x.txt", "x.txt", "", "")
+			rl.Title = tt.title
+			rl.Size = tt.size
 
-		data, err := json.Marshal(rl)
-		require.NoError(t, err)
-		assert.Contains(t, string(data), `"title":"X File"`)
-		assert.Contains(t, string(data), `"size":1024`)
+			data, err := json.Marshal(rl)
+			require.NoError(t, err)
+			s := string(data)
+			for _, want := range tt.wantJSON {
+				assert.Contains(t, s, want)
+			}
+			for _, notWant := range tt.notWantJSON {
+				assert.NotContains(t, s, notWant)
+			}
 
-		var rt ResourceLink
-		require.NoError(t, json.Unmarshal(data, &rt))
-		assert.Equal(t, "X File", rt.Title)
-		require.NotNil(t, rt.Size)
-		assert.Equal(t, int64(1024), *rt.Size)
-	})
-
-	t.Run("explicit zero size is preserved", func(t *testing.T) {
-		// Pointer semantics let us distinguish a known-zero-byte resource from
-		// an unknown/unset size.
-		size := int64(0)
-		rl := NewResourceLink("file:///empty.txt", "empty.txt", "", "")
-		rl.Size = &size
-
-		data, err := json.Marshal(rl)
-		require.NoError(t, err)
-		assert.Contains(t, string(data), `"size":0`)
-
-		var rt ResourceLink
-		require.NoError(t, json.Unmarshal(data, &rt))
-		require.NotNil(t, rt.Size)
-		assert.Equal(t, int64(0), *rt.Size)
-	})
+			var rt ResourceLink
+			require.NoError(t, json.Unmarshal(data, &rt))
+			assert.Equal(t, tt.title, rt.Title)
+			assert.Equal(t, tt.size, rt.Size)
+		})
+	}
 }
 
 func TestCallToolResultWithResourceLink(t *testing.T) {

--- a/mcp/types_test.go
+++ b/mcp/types_test.go
@@ -94,6 +94,55 @@ func TestResourceLinkSerialization(t *testing.T) {
 	assert.Equal(t, "application/pdf", unmarshaled.MIMEType)
 }
 
+// TestResourceLinkTitleAndSize mirrors TestResourceTitleAndSize: per the MCP
+// spec a ResourceLink carries the same metadata as a Resource, so Title and
+// Size must round-trip through JSON the same way they do for Resource.
+func TestResourceLinkTitleAndSize(t *testing.T) {
+	t.Run("title and size omitted when unset", func(t *testing.T) {
+		rl := NewResourceLink("file:///x.txt", "x.txt", "", "")
+		data, err := json.Marshal(rl)
+		require.NoError(t, err)
+		s := string(data)
+		assert.NotContains(t, s, `"title"`)
+		assert.NotContains(t, s, `"size"`)
+	})
+
+	t.Run("title and size round-trip when set", func(t *testing.T) {
+		size := int64(1024)
+		rl := NewResourceLink("file:///x.txt", "x.txt", "desc", "text/plain")
+		rl.Title = "X File"
+		rl.Size = &size
+
+		data, err := json.Marshal(rl)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"title":"X File"`)
+		assert.Contains(t, string(data), `"size":1024`)
+
+		var rt ResourceLink
+		require.NoError(t, json.Unmarshal(data, &rt))
+		assert.Equal(t, "X File", rt.Title)
+		require.NotNil(t, rt.Size)
+		assert.Equal(t, int64(1024), *rt.Size)
+	})
+
+	t.Run("explicit zero size is preserved", func(t *testing.T) {
+		// Pointer semantics let us distinguish a known-zero-byte resource from
+		// an unknown/unset size.
+		size := int64(0)
+		rl := NewResourceLink("file:///empty.txt", "empty.txt", "", "")
+		rl.Size = &size
+
+		data, err := json.Marshal(rl)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"size":0`)
+
+		var rt ResourceLink
+		require.NoError(t, json.Unmarshal(data, &rt))
+		require.NotNil(t, rt.Size)
+		assert.Equal(t, int64(0), *rt.Size)
+	})
+}
+
 func TestCallToolResultWithResourceLink(t *testing.T) {
 	result := &CallToolResult{
 		Content: []Content{

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -666,6 +666,12 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 			return nil, fmt.Errorf("resource_link uri or name is missing")
 		}
 		c := NewResourceLink(uri, name, description, mimeType)
+		c.Title = ExtractString(contentMap, "title")
+		if value, ok := contentMap["size"]; ok && value != nil {
+			if size, err := cast.ToInt64E(value); err == nil && size >= 0 {
+				c.Size = &size
+			}
+		}
 		c.Annotations = annotations
 		return c, nil
 

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -206,6 +206,29 @@ func TestParseContent(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "resource link with title and size",
+			contentMap: map[string]any{
+				"type":        "resource_link",
+				"uri":         "file:///test.txt",
+				"name":        "test.txt",
+				"title":       "Test File",
+				"description": "A test file",
+				"mimeType":    "text/plain",
+				// json.Unmarshal into map[string]any decodes numbers as float64.
+				"size": float64(42),
+			},
+			expected: ResourceLink{
+				Type:        ContentTypeLink,
+				URI:         "file:///test.txt",
+				Name:        "test.txt",
+				Title:       "Test File",
+				Description: "A test file",
+				MIMEType:    "text/plain",
+				Size:        ToInt64Ptr(42),
+			},
+			expectError: false,
+		},
+		{
 			name: "embedded resource with annotations",
 			contentMap: map[string]any{
 				"type": "resource",

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -229,6 +229,38 @@ func TestParseContent(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "resource link with zero size is preserved",
+			contentMap: map[string]any{
+				"type": "resource_link",
+				"uri":  "file:///empty.txt",
+				"name": "empty.txt",
+				"size": float64(0),
+			},
+			expected: ResourceLink{
+				Type: ContentTypeLink,
+				URI:  "file:///empty.txt",
+				Name: "empty.txt",
+				Size: ToInt64Ptr(0),
+			},
+			expectError: false,
+		},
+		{
+			name: "resource link with negative size is rejected",
+			contentMap: map[string]any{
+				"type": "resource_link",
+				"uri":  "file:///x.txt",
+				"name": "x.txt",
+				"size": float64(-1),
+			},
+			expected: ResourceLink{
+				Type: ContentTypeLink,
+				URI:  "file:///x.txt",
+				Name: "x.txt",
+				Size: nil,
+			},
+			expectError: false,
+		},
+		{
 			name: "embedded resource with annotations",
 			contentMap: map[string]any{
 				"type": "resource",
@@ -617,8 +649,10 @@ func TestParseContent(t *testing.T) {
 					assert.Equal(t, exp.Type, act.Type)
 					assert.Equal(t, exp.URI, act.URI)
 					assert.Equal(t, exp.Name, act.Name)
+					assert.Equal(t, exp.Title, act.Title)
 					assert.Equal(t, exp.Description, act.Description)
 					assert.Equal(t, exp.MIMEType, act.MIMEType)
+					assert.Equal(t, exp.Size, act.Size)
 					assert.Equal(t, exp.Annotations, act.Annotations)
 				case EmbeddedResource:
 					act, ok := result.(EmbeddedResource)


### PR DESCRIPTION
## Description

In the MCP spec, [`ResourceLink` extends `Resource`](https://modelcontextprotocol.io/specification/2025-06-18/schema#resourcelink) and carries the same metadata. #885 (v0.54.0) added `Title` and `Size` to the `Resource` struct, but `ResourceLink` is a standalone struct in this SDK and didn't pick them up — so Go clients currently drop `title` and `size` when a server returns them in a `resource_link` content block. (Python's SDK gets both for free via `class ResourceLink(Resource)`.)

This PR brings `ResourceLink` back in line with `Resource` and the spec:

- Add `Title` (`string`, `omitempty`) and `Size` (`*int64`, `omitempty`) to `ResourceLink`, with the same field comments and pointer semantics as `Resource` — an explicit zero `size` stays distinguishable from unset.
- Parse `title` and `size` in `ParseContent`'s `resource_link` case so they survive the generic-map decode path used by `CallToolResult` round-trips.
- `NewResourceLink`'s signature is unchanged (no breaking change to the public API). Like `Annotations`, the optional `Title`/`Size` are set on the returned struct by callers who need them.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Resource](https://modelcontextprotocol.io/specification/2025-06-18/schema#resource) / [ResourceLink](https://modelcontextprotocol.io/specification/2025-06-18/schema#resourcelink)
- [x] Implementation follows the specification exactly

## Additional Information

Tests:

- `TestResourceLinkTitleAndSize` mirrors the existing `TestResourceTitleAndSize` (omitted-when-unset, JSON round-trip, explicit-zero-preserved).
- Added a `TestParseContent` table case (`resource link with title and size`) covering the generic-map decode path.
- `go build ./... && go vet ./... && go test ./...` all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Resource links now support optional Title and Size metadata for improved display and informational detail; JSON round-trip preserves explicit zero size and omits unset fields.
* **Tests**
  * Added and extended tests to cover serialization, parsing, preservation of zero size, omission when unset, and handling of negative size values.

<!-- review_stack_entry_start -->

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->