### PR TITLE
perf(mcp): reduce content unmarshal allocations

### DIFF
--- a/mcp/content_benchmark_test.go
+++ b/mcp/content_benchmark_test.go
@@ -1,0 +1,38 @@
+package mcp
+
+import "testing"
+
+var benchmarkContent Content
+
+func BenchmarkUnmarshalContent(b *testing.B) {
+	cases := []struct {
+		name string
+		data []byte
+	}{
+		{
+			name: "text",
+			data: []byte(`{"type":"text","text":"The quick brown fox jumps over the lazy dog."}`),
+		},
+		{
+			name: "tool_use",
+			data: []byte(`{"type":"tool_use","id":"call_123","name":"lookup_weather","input":{"city":"London","unit":"celsius","includeForecast":true}}`),
+		},
+		{
+			name: "tool_result",
+			data: []byte(`{"type":"tool_result","toolUseId":"call_123","content":[{"type":"text","text":"Sunny, 22C"}],"isError":false}`),
+		},
+	}
+
+	for _, tc := range cases {
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				content, err := UnmarshalContent(tc.data)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkContent = content
+			}
+		})
+	}
+}

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1728,12 +1728,14 @@ func MarshalContent(content Content) ([]byte, error) {
 
 // UnmarshalContent implements custom JSON unmarshaling for Content interface
 func UnmarshalContent(data []byte) (Content, error) {
-	var raw map[string]any
+	var raw struct {
+		Type any `json:"type"`
+	}
 	if err := json.Unmarshal(data, &raw); err != nil {
 		return nil, err
 	}
 
-	contentType, ok := raw["type"].(string)
+	contentType, ok := raw.Type.(string)
 	if !ok {
 		return nil, fmt.Errorf("missing or invalid type field")
 	}


### PR DESCRIPTION
## Summary

- Avoid decoding content payloads into map[string]any just to read the type discriminator.
- Add benchmark coverage for common content variants.

## Benchmarks

`go test ./mcp -run '^$' -bench BenchmarkUnmarshalContent -benchmem -count=5`

Allocation results:

- text: 1008 B/op, 22 allocs/op -> 624 B/op, 15 allocs/op
- tool_use: 1944 B/op, 49 allocs/op -> 1104 B/op, 27 allocs/op
- tool_result: 2912 B/op, 70 allocs/op -> 1720 B/op, 42 allocs/op

## Tests

- `go test ./mcp`
- `go test ./mcp -race`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added performance benchmarks for content parsing to measure efficiency and resource usage.
* **Refactor**
  * Optimized content parsing to improve performance and reduce memory allocations.

<!-- review_stack_entry_start -->

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->