### PR TITLE
discuss: how to surface ClientOptions on convenience constructors

### DIFF
--- a/client/constructor_options_test.go
+++ b/client/constructor_options_test.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+)
+
+// TestNewStdioClient_AppliesClientOptions exercises the new constructor's
+// promise: every ClientOption passed in the variadic slot is applied to the
+// returned client. WithSession is convenient because it sets a single bool
+// observable from the test.
+func TestNewStdioClient_AppliesClientOptions(t *testing.T) {
+	// Use a no-op command for the underlying subprocess; the test only
+	// cares that NewStdioClient applies the options before returning.
+	c, err := NewStdioClient("true", nil, nil, WithSession())
+	if err != nil {
+		t.Fatalf("NewStdioClient: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	if !c.initialized {
+		t.Fatalf("WithSession not applied; initialized=false")
+	}
+}
+
+// TestNewSSEClient_AppliesClientOptions verifies that NewSSEClient routes
+// the variadic ClientOption arguments through to the constructed client
+// while keeping transportOpts separate.
+func TestNewSSEClient_AppliesClientOptions(t *testing.T) {
+	c, err := NewSSEClient(
+		"http://example.invalid/sse",
+		[]transport.ClientOption{transport.WithHeaders(map[string]string{"x-test": "1"})},
+		WithSession(),
+	)
+	if err != nil {
+		t.Fatalf("NewSSEClient: %v", err)
+	}
+	if !c.initialized {
+		t.Fatalf("WithSession not applied; initialized=false")
+	}
+}
+
+// TestNewStreamableHTTPClient_AppliesClientOptions verifies the same routing
+// for the streamable-http convenience constructor.
+func TestNewStreamableHTTPClient_AppliesClientOptions(t *testing.T) {
+	c, err := NewStreamableHTTPClient(
+		"http://example.invalid/mcp",
+		nil,
+		WithSession(),
+	)
+	if err != nil {
+		t.Fatalf("NewStreamableHTTPClient: %v", err)
+	}
+	if !c.initialized {
+		t.Fatalf("WithSession not applied; initialized=false")
+	}
+}
+
+// TestNewStreamableHTTPClient_PreservesAutoSession asserts that the
+// existing "transport reports an active session ID → set WithSession"
+// behaviour from NewStreamableHttpClient is preserved on the new
+// constructor. The fixture transport here has no session, so initialized
+// reflects only the caller-supplied opts.
+func TestNewStreamableHTTPClient_PreservesAutoSession(t *testing.T) {
+	c, err := NewStreamableHTTPClient("http://example.invalid/mcp", nil)
+	if err != nil {
+		t.Fatalf("NewStreamableHTTPClient: %v", err)
+	}
+	if c.initialized {
+		t.Fatalf("initialized=true without an active session; auto-session must not fire")
+	}
+}

--- a/client/http.go
+++ b/client/http.go
@@ -20,3 +20,29 @@ func NewStreamableHttpClient(baseURL string, options ...transport.StreamableHTTP
 	}
 	return NewClient(trans, clientOptions...), nil
 }
+
+// NewStreamableHTTPClient creates a new streamable-http-based MCP client
+// with the given base URL, applying the provided transport-level options
+// when constructing the transport and the provided client-level options
+// to the returned client.
+//
+// Pass transport options (e.g. transport.WithContinuousListening) as a
+// slice in transportOpts, and client options (e.g. WithTracer,
+// WithPropagator) as the variadic opts. When the transport reports an
+// active session ID at construction time, WithSession is appended
+// automatically so the returned client skips re-initialisation.
+func NewStreamableHTTPClient(
+	baseURL string,
+	transportOpts []transport.StreamableHTTPCOption,
+	opts ...ClientOption,
+) (*Client, error) {
+	trans, err := transport.NewStreamableHTTP(baseURL, transportOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create streamable-http transport: %w", err)
+	}
+	clientOpts := opts
+	if trans.GetSessionId() != "" {
+		clientOpts = append(clientOpts, WithSession())
+	}
+	return NewClient(trans, clientOpts...), nil
+}

--- a/client/sse.go
+++ b/client/sse.go
@@ -51,6 +51,31 @@ func NewSSEMCPClient(baseURL string, options ...transport.ClientOption) (*Client
 	return NewClient(sseTransport), nil
 }
 
+// NewSSEClient creates a new SSE-based MCP client with the given base URL,
+// applying the provided transport-level options when constructing the
+// transport and the provided client-level options to the returned client.
+//
+// Pass transport options (e.g. WithHeaders, WithHTTPClient) as a slice in
+// transportOpts, and client options (e.g. WithTracer, WithPropagator) as
+// the variadic opts:
+//
+//	c, err := client.NewSSEClient(
+//	    url,
+//	    []transport.ClientOption{client.WithHeaders(h)},
+//	    client.WithTracer(t),
+//	)
+func NewSSEClient(
+	baseURL string,
+	transportOpts []transport.ClientOption,
+	opts ...ClientOption,
+) (*Client, error) {
+	sseTransport, err := transport.NewSSE(baseURL, transportOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SSE transport: %w", err)
+	}
+	return NewClient(sseTransport, opts...), nil
+}
+
 // GetEndpoint returns the current endpoint URL for the SSE connection.
 //
 // Note: This method only works with SSE transport, or it will panic.

--- a/client/stdio.go
+++ b/client/stdio.go
@@ -44,6 +44,30 @@ func NewStdioMCPClientWithOptions(
 	return NewClient(stdioTransport), nil
 }
 
+// NewStdioClient creates a new stdio-based MCP client that communicates with
+// a subprocess. It launches the specified command with the given environment
+// variables and arguments, starts the underlying transport, and applies the
+// supplied client-level options (e.g. WithTracer, WithPropagator) to the
+// returned client.
+//
+// Callers that need transport-level options (e.g. a custom command function)
+// should fall back to NewStdioMCPClientWithOptions or construct the transport
+// directly with transport.NewStdioWithOptions and call NewClient.
+func NewStdioClient(
+	command string,
+	env []string,
+	args []string,
+	opts ...ClientOption,
+) (*Client, error) {
+	stdioTransport := transport.NewStdioWithOptions(command, env, args)
+
+	if err := stdioTransport.Start(context.Background()); err != nil {
+		return nil, fmt.Errorf("failed to start stdio transport: %w", err)
+	}
+
+	return NewClient(stdioTransport, opts...), nil
+}
+
 // GetStderr returns a reader for the stderr output of the subprocess.
 // This can be used to capture error messages or logs from the subprocess.
 //


### PR DESCRIPTION
## Problem

The convenience client constructors reserve their variadic slot for transport-level options:

```go
func NewStdioMCPClient(command string, env []string, args ...string) (*Client, error)
func NewSSEMCPClient(baseURL string, options ...transport.ClientOption) (*Client, error)
func NewStreamableHttpClient(baseURL string, options ...transport.StreamableHTTPCOption) (*Client, error)
```

Client-level options — `WithTracer`, `WithPropagator`, `WithSession`, `WithSamplingHandler`, `WithRootsHandler`, `WithElicitationHandler`, `WithClientCapabilities` — have no entry point on these constructors. Today users have to drop to the lower-level `NewClient(transport, opts...)` and reproduce the transport-construction code (notably the `stdio.Start(ctx)` step the convenience helpers paper over).

This PR is open for design discussion before code lands. Below are the alternatives I see; the current commits show **Option C** as a worked example but I'd rather the maintainer pick.

## Option A — modify the existing signatures (breaking)

```go
func NewStdioMCPClient(command string, env []string, args []string, opts ...ClientOption) (*Client, error)
func NewSSEMCPClient(baseURL string, transportOpts []transport.ClientOption, opts ...ClientOption) (*Client, error)
func NewStreamableHttpClient(baseURL string, transportOpts []transport.StreamableHTTPCOption, opts ...ClientOption) (*Client, error)
```

- **Pros**: single canonical constructor per transport. No duplicated API surface.
- **Cons**: breaks every existing call site. For stdio, `args ...string` becomes `args []string` so callers wrap their args in a slice literal. For SSE / streamable-http, transport options move to a leading slice parameter.
- Pre-1.0 library, so this is on the table.

## Option B — method on `*Client` for post-construction options

```go
func (c *Client) With(opts ...ClientOption) *Client
```

Call sites:

```go
c, err := client.NewStdioMCPClient(cmd, env, args...)
if err != nil { ... }
c.With(client.WithTracer(t), client.WithPropagator(p))
```

- **Pros**: non-breaking. One method covers all three transports. Reads idiomatically (Go fluent-builder pattern).
- **Cons**: option application is a separate statement from construction; can't fold into a single expression because of `err` return.

## Option C — add new constructors alongside the existing ones

```go
func NewStdioClient(command string, env []string, args []string, opts ...ClientOption) (*Client, error)
func NewSSEClient(baseURL string, transportOpts []transport.ClientOption, opts ...ClientOption) (*Client, error)
func NewStreamableHTTPClient(baseURL string, transportOpts []transport.StreamableHTTPCOption, opts ...ClientOption) (*Client, error)
```

- **Pros**: non-breaking.
- **Cons**: doubles the constructor surface. Two near-identical entry points per transport, the docs have to explain the difference.

The current commits on this branch implement Option C. Tests pass; `NewStreamableHTTPClient` preserves the auto-`WithSession` behaviour from the existing constructor when the transport reports an active session ID.

## Recommendation

I'd lean Option A — pre-1.0 is the right time, the migration is mechanical, and Option C's duplicate surface bothers me. But I want your call before pushing code in one direction.

Happy to reshape the PR into whichever option you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new constructor functions for creating MCP clients with consistent option handling across stdio, SSE, and HTTP-based transports.
  * Enhanced client construction to support variadic client options uniformly across all transport types.

* **Tests**
  * Added comprehensive test coverage validating constructor behavior and client option application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mark3labs/mcp-go/pull/891?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->