### PR TITLE
fix(tools): print errors to stderr for invalid jsonschema tags

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"reflect"
 	"strconv"
 
@@ -862,6 +863,7 @@ func WithInputSchema[T any]() ToolOption {
 	return func(t *Tool) {
 		schema, err := jsonschema.For[T](&jsonschema.ForOptions{IgnoreInvalidTypes: true})
 		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
 			return
 		}
 
@@ -912,6 +914,7 @@ func WithOutputSchema[T any]() ToolOption {
 	return func(t *Tool) {
 		schema, err := jsonschema.For[T](&jsonschema.ForOptions{IgnoreInvalidTypes: true})
 		if err != nil {
+			fmt.Fprintln(os.Stderr, err)
 			return
 		}
 

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -1,8 +1,12 @@
 package mcp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -758,6 +762,47 @@ func TestToolWithInputSchema(t *testing.T) {
 	assert.Equal(t, false, schemaMap["additionalProperties"])
 }
 
+// TestToolWithInputSchemaJsonSchemaTagError tests that the WithInputSchema
+// function prints an error to stderr if a jsonschema tag is invalid.
+func TestToolWithInputSchemaJsonSchemaTagError(t *testing.T) {
+	type TestInput struct {
+		Name  string `json:"name" jsonschema:"description=Person's name"` // Invalid jsonschema tag
+		Age   int    `json:"age" jsonschema:"Person's age"`
+		Email string `json:"email,omitempty" jsonschema:"Email address"`
+	}
+
+	var (
+		expectedStderrPrefix = "For[mcp.TestInput]():" // jsonschema.For[T] error prefix
+		buf                  bytes.Buffer
+		origStderr, r, w     *os.File
+		err                  error
+	)
+
+	// Redirect stderr
+	origStderr = os.Stderr
+	r, w, err = os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	_ = NewTool("test_tool",
+		WithDescription("Test tool with input schema that has an invalid jsonschema tag"),
+		WithInputSchema[TestInput](),
+	)
+
+	// Restore stderr
+	err = w.Close()
+	require.NoError(t, err)
+	os.Stderr = origStderr
+
+	// Read stderr output into buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	if !strings.HasPrefix(buf.String(), expectedStderrPrefix) {
+		t.Errorf("expected stderr to have prefix %q, got %q", expectedStderrPrefix, buf.String())
+	}
+}
+
 // TestToolWithOutputSchema tests that the WithOutputSchema function
 // generates an MCP-compatible JSON output schema for a tool
 func TestToolWithOutputSchema(t *testing.T) {
@@ -847,6 +892,47 @@ func TestToolWithOutputSchema(t *testing.T) {
 				assert.Nil(t, outputSchema)
 			}
 		})
+	}
+}
+
+// TestToolWithOutputSchemaJsonSchemaTagError tests that the WithOutputSchema
+// function prints an error to stderr if a jsonschema tag is invalid.
+func TestToolWithOutputSchemaJsonSchemaTagError(t *testing.T) {
+	type TestOutput struct {
+		Name  string `json:"name" jsonschema:"description=Person's name"` // Invalid jsonschema tag
+		Age   int    `json:"age" jsonschema:"Person's age"`
+		Email string `json:"email,omitempty" jsonschema:"Email address"`
+	}
+
+	var (
+		expectedStderrPrefix = "For[mcp.TestOutput]():" // jsonschema.For[T] error prefix
+		buf                  bytes.Buffer
+		origStderr, r, w     *os.File
+		err                  error
+	)
+
+	// Redirect stderr
+	origStderr = os.Stderr
+	r, w, err = os.Pipe()
+	require.NoError(t, err)
+	os.Stderr = w
+
+	_ = NewTool("test_tool",
+		WithDescription("Test tool with output schema that has an invalid jsonschema tag"),
+		WithOutputSchema[TestOutput](),
+	)
+
+	// Restore stderr
+	err = w.Close()
+	require.NoError(t, err)
+	os.Stderr = origStderr
+
+	// Read stderr output into buffer
+	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+
+	if !strings.HasPrefix(buf.String(), expectedStderrPrefix) {
+		t.Errorf("expected stderr to have prefix %q, got %q", expectedStderrPrefix, buf.String())
 	}
 }
 

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -797,6 +797,8 @@ func TestToolWithInputSchemaJsonSchemaTagError(t *testing.T) {
 	// Read stderr output into buffer
 	_, err = io.Copy(&buf, r)
 	require.NoError(t, err)
+	err = r.Close()
+	require.NoError(t, err)
 
 	if !strings.HasPrefix(buf.String(), expectedStderrPrefix) {
 		t.Errorf("expected stderr to have prefix %q, got %q", expectedStderrPrefix, buf.String())
@@ -929,6 +931,8 @@ func TestToolWithOutputSchemaJsonSchemaTagError(t *testing.T) {
 
 	// Read stderr output into buffer
 	_, err = io.Copy(&buf, r)
+	require.NoError(t, err)
+	err = r.Close()
 	require.NoError(t, err)
 
 	if !strings.HasPrefix(buf.String(), expectedStderrPrefix) {


### PR DESCRIPTION
## Description

<!-- Provide a concise description of the changes in this PR -->

Print errors to stderr for invalid jsonschema tags in WithInputSchema() and WithOutputSchema().

## Type of Change

<!-- Please select all the relevant options by replacing [ ] with [x] -->

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

<!-- Please select all that apply by replacing [ ] with [x] -->

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

<!-- Any additional information that might be useful for reviewers -->

<!-- If not applicable, remove this section -->

Added printing of errors from `jsonschema.For[T]()` in `WithInputSchema()` and `WithOutputSchema()` to stderr so when an invalid jsonschema tag is encountered the functions don't fail silently.

E.g. an invalid jsonschema tag such as `jsonschema:"description=Person's name"` will now print the error returned from `jsonschema.For[T]()` to stderr, such as `For[mcp.TestOutput](): tag must not begin with 'WORD=': \"description=Person's name\"`.

Have added two unit tests to test an invalid jsonschema tag error is printed to stderr.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Schema validation errors are now written to error output (stderr) instead of being silent, improving visibility when configuration or struct-tag issues occur.
* **Tests**
  * Added tests that verify schema validation errors are emitted to error output and include identifying prefixes for input and output schema issues.

<!-- review_stack_entry_start -->

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->