### PR TITLE
feat(tracing): add MetaPropagator for W3C trace context via MCP _meta (SEP-414)

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -30,6 +30,7 @@ type Client struct {
 	elicitationHandler ElicitationHandler
 	tracer             tracing.Tracer
 	propagator         tracing.Propagator
+	metaPropagator     tracing.MetaPropagator
 }
 
 // ClientOption configures a Client during construction.
@@ -362,6 +363,7 @@ func (c *Client) ReadResource(
 	ctx context.Context,
 	request mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
+	request.Params.Meta = c.injectMeta(ctx, request.Params.Meta)
 	response, err := c.sendRequest(ctx, string(mcp.MethodResourcesRead), request.Params, request.Header)
 	if err != nil {
 		return nil, err
@@ -431,6 +433,7 @@ func (c *Client) GetPrompt(
 	ctx context.Context,
 	request mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
+	request.Params.Meta = c.injectMeta(ctx, request.Params.Meta)
 	response, err := c.sendRequest(ctx, string(mcp.MethodPromptsGet), request.Params, request.Header)
 	if err != nil {
 		return nil, err
@@ -482,6 +485,7 @@ func (c *Client) CallTool(
 	ctx context.Context,
 	request mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
+	request.Params.Meta = c.injectMeta(ctx, request.Params.Meta)
 	response, err := c.sendRequest(ctx, string(mcp.MethodToolsCall), request.Params, request.Header)
 	if err != nil {
 		return nil, err

--- a/client/tracing.go
+++ b/client/tracing.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/tracing"
 )
 
@@ -31,6 +32,27 @@ func WithPropagator(p tracing.Propagator) ClientOption {
 	return func(c *Client) {
 		c.propagator = p
 	}
+}
+
+// WithMetaPropagator installs a propagator that injects trace context into
+// the MCP _meta property bag of outgoing requests (per SEP-414). It covers
+// all transports including stdio, where HTTP headers are unavailable.
+// A nil propagator is treated as a no-op.
+func WithMetaPropagator(p tracing.MetaPropagator) ClientOption {
+	if p == nil {
+		p = tracing.NoopMetaPropagator()
+	}
+	return func(c *Client) {
+		c.metaPropagator = p
+	}
+}
+
+func (c *Client) injectMeta(ctx context.Context, meta *mcp.Meta) *mcp.Meta {
+	p := c.metaPropagator
+	if p == nil {
+		return meta
+	}
+	return p.InjectMeta(ctx, meta)
 }
 
 func (c *Client) startSendSpan(

--- a/client/tracing_test.go
+++ b/client/tracing_test.go
@@ -34,6 +34,11 @@ func TestWithPropagator_NilFallsBackToNoop(t *testing.T) {
 	require.NotNil(t, c.propagator)
 }
 
+func TestWithMetaPropagator_NilFallsBackToNoop(t *testing.T) {
+	c := NewClient(transport.NewInProcessTransport(server.NewMCPServer("srv", "1")), WithMetaPropagator(nil))
+	require.NotNil(t, c.metaPropagator)
+}
+
 type recordingTracer struct {
 	spans []string
 }

--- a/mcp/prompts.go
+++ b/mcp/prompts.go
@@ -32,6 +32,8 @@ type GetPromptParams struct {
 	Name string `json:"name"`
 	// Arguments to use for templating the prompt.
 	Arguments map[string]string `json:"arguments,omitempty"`
+	// Meta carries protocol-level metadata (e.g. W3C traceparent, progressToken).
+	Meta *Meta `json:"_meta,omitempty"`
 }
 
 // GetPromptResult is the server's response to a prompts/get request from the

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -758,6 +758,8 @@ type ReadResourceParams struct {
 	URI string `json:"uri"`
 	// Arguments to pass to the resource handler
 	Arguments map[string]any `json:"arguments,omitempty"`
+	// Meta carries protocol-level metadata (e.g. W3C traceparent, progressToken).
+	Meta *Meta `json:"_meta,omitempty"`
 }
 
 // ReadResourceResult is the server's response to a resources/read request

--- a/otel/meta_carrier.go
+++ b/otel/meta_carrier.go
@@ -1,0 +1,76 @@
+package otel
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel/propagation"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/tracing"
+)
+
+// NewMetaPropagator returns a tracing.MetaPropagator backed by W3C TraceContext
+// that reads and writes trace context in the MCP _meta property bag per SEP-414.
+func NewMetaPropagator() tracing.MetaPropagator {
+	return WrapMetaPropagator(propagation.TraceContext{})
+}
+
+// WrapMetaPropagator adapts any TextMapPropagator as a tracing.MetaPropagator
+// that operates on the MCP _meta property bag.
+func WrapMetaPropagator(p propagation.TextMapPropagator) tracing.MetaPropagator {
+	if p == nil {
+		return tracing.NoopMetaPropagator()
+	}
+	return otelMetaPropagator{p: p}
+}
+
+type otelMetaPropagator struct {
+	p propagation.TextMapPropagator
+}
+
+func (o otelMetaPropagator) InjectMeta(ctx context.Context, meta *mcp.Meta) *mcp.Meta {
+	if meta == nil {
+		meta = &mcp.Meta{}
+	}
+	o.p.Inject(ctx, &metaCarrier{meta: meta})
+	return meta
+}
+
+func (o otelMetaPropagator) ExtractMeta(ctx context.Context, meta *mcp.Meta) context.Context {
+	if meta == nil {
+		return ctx
+	}
+	return o.p.Extract(ctx, &metaCarrier{meta: meta})
+}
+
+// metaCarrier adapts mcp.Meta.AdditionalFields as a propagation.TextMapCarrier.
+type metaCarrier struct {
+	meta *mcp.Meta
+}
+
+func (c *metaCarrier) Get(key string) string {
+	if c.meta.AdditionalFields == nil {
+		return ""
+	}
+	v, ok := c.meta.AdditionalFields[key]
+	if !ok {
+		return ""
+	}
+	s, _ := v.(string)
+	return s
+}
+
+func (c *metaCarrier) Set(key string, value string) {
+	if c.meta.AdditionalFields == nil {
+		c.meta.AdditionalFields = make(map[string]any)
+	}
+	c.meta.AdditionalFields[key] = value
+}
+
+func (c *metaCarrier) Keys() []string {
+	keys := make([]string, 0, len(c.meta.AdditionalFields))
+	for k := range c.meta.AdditionalFields {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/otel/meta_carrier_test.go
+++ b/otel/meta_carrier_test.go
@@ -1,0 +1,267 @@
+package otel_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	otelmcp "github.com/mark3labs/mcp-go/otel"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// paramsCapturingTransport records the raw params of the most recent outgoing request.
+type paramsCapturingTransport struct {
+	transport.Interface
+	last json.RawMessage
+}
+
+func (p *paramsCapturingTransport) SendRequest(ctx context.Context, req transport.JSONRPCRequest) (*transport.JSONRPCResponse, error) {
+	if req.Params != nil {
+		raw, _ := json.Marshal(req.Params)
+		p.last = raw
+	}
+	return p.Interface.SendRequest(ctx, req)
+}
+
+// startTracedClient builds a client over an in-process server with the given options,
+// initializes it, and returns it alongside the capturing transport.
+func startTracedClient(t *testing.T, srv *server.MCPServer, opts ...client.ClientOption) (*client.Client, *paramsCapturingTransport) {
+	t.Helper()
+	inner := transport.NewInProcessTransport(srv)
+	cap := &paramsCapturingTransport{Interface: inner}
+	c := client.NewClient(cap, opts...)
+	require.NoError(t, c.Start(t.Context()))
+	t.Cleanup(func() { _ = c.Close() })
+
+	initReq := mcp.InitializeRequest{}
+	initReq.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initReq.Params.ClientInfo = mcp.Implementation{Name: "test", Version: "1"}
+	_, err := c.Initialize(t.Context(), initReq)
+	require.NoError(t, err)
+	return c, cap
+}
+
+// TestMetaPropagator_InjectCreatesTraceparent checks that injecting into a nil
+// *mcp.Meta allocates one and sets traceparent.
+func TestMetaPropagator_InjectCreatesTraceparent(t *testing.T) {
+	p := otelmcp.WrapMetaPropagator(propagation.TraceContext{})
+
+	tracer, _ := newTestTracer(t)
+	ctx, span := tracer.Start(t.Context(), "parent", trace.WithSpanKind(trace.SpanKindClient))
+	defer span.End()
+
+	got := p.InjectMeta(ctx, nil)
+	require.NotNil(t, got)
+	require.NotNil(t, got.AdditionalFields)
+	tp, ok := got.AdditionalFields["traceparent"]
+	require.True(t, ok, "traceparent must be present in AdditionalFields")
+	s, _ := tp.(string)
+	assert.NotEmpty(t, s)
+	assert.Equal(t, span.SpanContext().TraceID().String(), traceIDFromTraceparent(t, s))
+}
+
+// TestMetaPropagator_ExtractPopulatesContext checks that a traceparent in
+// AdditionalFields is extracted into the returned context.
+func TestMetaPropagator_ExtractPopulatesContext(t *testing.T) {
+	tracer, rec := newTestTracer(t)
+	ctx, root := tracer.Start(t.Context(), "root")
+	defer root.End()
+
+	// Inject so we have a well-formed traceparent.
+	p := otelmcp.WrapMetaPropagator(propagation.TraceContext{})
+	meta := p.InjectMeta(ctx, nil)
+	root.End()
+	since := spansSince(rec)
+
+	// Extract into a fresh background ctx.
+	extracted := p.ExtractMeta(t.Context(), meta)
+
+	// Starting a span in the extracted ctx should parent to the injected span.
+	_, child := tracer.Start(extracted, "child")
+	child.End()
+
+	spans := since()
+	childSpan := findSpan(spans, "child")
+	require.NotNil(t, childSpan)
+	assert.Equal(t, root.SpanContext().TraceID(), childSpan.SpanContext().TraceID(),
+		"child span should join the injected trace")
+	assert.Equal(t, root.SpanContext().SpanID(), childSpan.Parent().SpanID(),
+		"child span parent should be the injected span")
+}
+
+// TestMetaPropagator_ExtractNilMetaIsNoop checks that nil *mcp.Meta doesn't panic.
+func TestMetaPropagator_ExtractNilMetaIsNoop(t *testing.T) {
+	p := otelmcp.WrapMetaPropagator(propagation.TraceContext{})
+	ctx := p.ExtractMeta(t.Context(), nil)
+	assert.NotNil(t, ctx)
+}
+
+// TestMetaPropagator_InjectNilPropagatorIsNoop checks that WrapMetaPropagator(nil)
+// returns a no-op that doesn't panic.
+func TestMetaPropagator_InjectNilPropagatorIsNoop(t *testing.T) {
+	p := otelmcp.WrapMetaPropagator(nil)
+	meta := p.InjectMeta(t.Context(), nil)
+	assert.Nil(t, meta)
+}
+
+// TestClientMetaPropagator_CallToolInjectsMeta confirms the client injects
+// traceparent into the outgoing tools/call _meta when a MetaPropagator is installed.
+func TestClientMetaPropagator_CallToolInjectsMeta(t *testing.T) {
+	tracer, _ := newTestTracer(t)
+
+	srv := server.NewMCPServer("srv", "1.0")
+	srv.AddTool(mcp.Tool{Name: "echo"}, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	c, cap := startTracedClient(t, srv, otelmcp.WithClientTracing(tracer))
+
+	parentCtx, parentSpan := tracer.Start(t.Context(), "parent")
+	defer parentSpan.End()
+
+	callReq := mcp.CallToolRequest{}
+	callReq.Params.Name = "echo"
+	_, err := c.CallTool(parentCtx, callReq)
+	require.NoError(t, err)
+
+	require.NotNil(t, cap.last)
+	var raw map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(cap.last, &raw))
+
+	metaRaw, ok := raw["_meta"]
+	require.True(t, ok, "_meta must be present in outgoing params")
+	var meta map[string]any
+	require.NoError(t, json.Unmarshal(metaRaw, &meta))
+	tp, ok := meta["traceparent"]
+	require.True(t, ok, "traceparent must be present in _meta")
+	tpStr, _ := tp.(string)
+	assert.NotEmpty(t, tpStr)
+	assert.Equal(t, parentSpan.SpanContext().TraceID().String(), traceIDFromTraceparent(t, tpStr))
+}
+
+// TestClientMetaPropagator_NoTracerDoesNotInjectMeta checks that without a
+// tracer (no active span), no traceparent is injected into _meta.
+func TestClientMetaPropagator_NoTracerDoesNotInjectMeta(t *testing.T) {
+	srv := server.NewMCPServer("srv", "1.0")
+	srv.AddTool(mcp.Tool{Name: "echo"}, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	// No tracing option — no active span, propagator should not inject invalid traceparent.
+	c, cap := startTracedClient(t, srv)
+
+	callReq := mcp.CallToolRequest{}
+	callReq.Params.Name = "echo"
+	_, err := c.CallTool(t.Context(), callReq)
+	require.NoError(t, err)
+
+	if cap.last != nil {
+		var raw map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(cap.last, &raw))
+		if metaRaw, ok := raw["_meta"]; ok {
+			var meta map[string]any
+			require.NoError(t, json.Unmarshal(metaRaw, &meta))
+			assert.Empty(t, meta["traceparent"], "traceparent must not be injected without an active span")
+		}
+	}
+}
+
+// TestServerMetaPropagator_ExtractsInboundTraceparent verifies that the server
+// joins the trace carried in _meta.traceparent (SEP-414 path, transport-agnostic).
+func TestServerMetaPropagator_ExtractsInboundTraceparent(t *testing.T) {
+	serverTracer, serverRec := newTestTracer(t)
+	clientTracer, _ := newTestTracer(t)
+
+	srv := server.NewMCPServer("srv", "1.0", otelmcp.WithServerTracing(serverTracer))
+	srv.AddTool(mcp.Tool{Name: "echo"}, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+	dispatchInitialized(t, srv)
+
+	// Build the inbound traceparent from a real span.
+	clientCtx, clientSpan := clientTracer.Start(t.Context(), "caller")
+	defer clientSpan.End()
+
+	p := otelmcp.WrapMetaPropagator(propagation.TraceContext{})
+	meta := p.InjectMeta(clientCtx, nil)
+	traceparent, _ := meta.AdditionalFields["traceparent"].(string)
+	require.NotEmpty(t, traceparent)
+
+	since := spansSince(serverRec)
+
+	body := fmt.Appendf(nil,
+		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"echo","arguments":{},"_meta":{"traceparent":%q}}}`,
+		traceparent,
+	)
+	resp := srv.HandleMessage(t.Context(), body)
+	require.NotNil(t, resp)
+
+	spans := since()
+	serverSpan := findSpan(spans, "mcp.tools/call")
+	require.NotNil(t, serverSpan, "server must produce mcp.tools/call span")
+
+	assert.Equal(t, clientSpan.SpanContext().TraceID(), serverSpan.SpanContext().TraceID(),
+		"server span must join the trace from _meta.traceparent")
+}
+
+// TestServerMetaPropagator_RoundTrip verifies end-to-end: client injects into
+// _meta, server extracts and server span joins the client trace.
+func TestServerMetaPropagator_RoundTrip(t *testing.T) {
+	clientTracer, _ := newTestTracer(t)
+	serverTracer, serverRec := newTestTracer(t)
+
+	srv := server.NewMCPServer("srv", "1.0", otelmcp.WithServerTracing(serverTracer))
+	srv.AddTool(mcp.Tool{Name: "echo"}, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok"), nil
+	})
+
+	c, _ := startTracedClient(t, srv, otelmcp.WithClientTracing(clientTracer))
+	since := spansSince(serverRec)
+
+	parentCtx, parentSpan := clientTracer.Start(t.Context(), "caller", trace.WithSpanKind(trace.SpanKindClient))
+	defer parentSpan.End()
+
+	callReq := mcp.CallToolRequest{}
+	callReq.Params.Name = "echo"
+	_, err := c.CallTool(parentCtx, callReq)
+	require.NoError(t, err)
+
+	spans := since()
+	serverSpan := findSpan(spans, "mcp.tools/call")
+	require.NotNil(t, serverSpan, "server must produce mcp.tools/call span")
+
+	assert.Equal(t, parentSpan.SpanContext().TraceID(), serverSpan.SpanContext().TraceID(),
+		"server span must join the client trace propagated through _meta")
+}
+
+// traceIDFromTraceparent extracts the 32-hex trace-id segment from a W3C traceparent.
+func traceIDFromTraceparent(t *testing.T, tp string) string {
+	t.Helper()
+	// format: 00-<32hex>-<16hex>-<2hex>
+	parts := splitTraceparent(tp)
+	require.Len(t, parts, 4, "malformed traceparent: %q", tp)
+	return parts[1]
+}
+
+func splitTraceparent(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '-' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+

--- a/otel/meta_carrier_test.go
+++ b/otel/meta_carrier_test.go
@@ -98,19 +98,38 @@ func TestMetaPropagator_ExtractPopulatesContext(t *testing.T) {
 		"child span parent should be the injected span")
 }
 
-// TestMetaPropagator_ExtractNilMetaIsNoop checks that nil *mcp.Meta doesn't panic.
-func TestMetaPropagator_ExtractNilMetaIsNoop(t *testing.T) {
-	p := otelmcp.WrapMetaPropagator(propagation.TraceContext{})
-	ctx := p.ExtractMeta(t.Context(), nil)
-	assert.NotNil(t, ctx)
-}
-
-// TestMetaPropagator_InjectNilPropagatorIsNoop checks that WrapMetaPropagator(nil)
-// returns a no-op that doesn't panic.
-func TestMetaPropagator_InjectNilPropagatorIsNoop(t *testing.T) {
-	p := otelmcp.WrapMetaPropagator(nil)
-	meta := p.InjectMeta(t.Context(), nil)
-	assert.Nil(t, meta)
+// TestMetaPropagator_NilEdgeCases checks nil-safety for both extract and inject.
+func TestMetaPropagator_NilEdgeCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		propagator     propagation.TextMapPropagator
+		wantNonNilCtx  bool
+		wantNilMeta    bool
+	}{
+		{
+			name:          "extract nil meta returns non-nil context",
+			propagator:    propagation.TraceContext{},
+			wantNonNilCtx: true,
+		},
+		{
+			name:        "nil propagator inject returns nil meta",
+			propagator:  nil,
+			wantNilMeta: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := otelmcp.WrapMetaPropagator(tc.propagator)
+			if tc.wantNonNilCtx {
+				ctx := p.ExtractMeta(t.Context(), nil)
+				assert.NotNil(t, ctx)
+			}
+			if tc.wantNilMeta {
+				meta := p.InjectMeta(t.Context(), nil)
+				assert.Nil(t, meta)
+			}
+		})
+	}
 }
 
 // TestClientMetaPropagator_CallToolInjectsMeta confirms the client injects
@@ -148,16 +167,17 @@ func TestClientMetaPropagator_CallToolInjectsMeta(t *testing.T) {
 	assert.Equal(t, parentSpan.SpanContext().TraceID().String(), traceIDFromTraceparent(t, tpStr))
 }
 
-// TestClientMetaPropagator_NoTracerDoesNotInjectMeta checks that without a
-// tracer (no active span), no traceparent is injected into _meta.
+// TestClientMetaPropagator_NoTracerDoesNotInjectMeta checks that with a
+// propagator installed but no active span, no traceparent is injected into _meta.
 func TestClientMetaPropagator_NoTracerDoesNotInjectMeta(t *testing.T) {
+	tracer, _ := newTestTracer(t)
 	srv := server.NewMCPServer("srv", "1.0")
 	srv.AddTool(mcp.Tool{Name: "echo"}, func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		return mcp.NewToolResultText("ok"), nil
 	})
 
-	// No tracing option — no active span, propagator should not inject invalid traceparent.
-	c, cap := startTracedClient(t, srv)
+	// Propagator installed but context has no active span — must not inject an invalid traceparent.
+	c, cap := startTracedClient(t, srv, otelmcp.WithClientTracing(tracer))
 
 	callReq := mcp.CallToolRequest{}
 	callReq.Params.Name = "echo"

--- a/otel/options.go
+++ b/otel/options.go
@@ -8,46 +8,68 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-// WithServerTracing installs an OpenTelemetry tracer and a W3C TraceContext
-// propagator on the server.
+// WithServerTracing installs an OpenTelemetry tracer, a W3C TraceContext header
+// propagator, and a W3C TraceContext _meta propagator (SEP-414) on the server.
 func WithServerTracing(t trace.Tracer) server.ServerOption {
 	tracer := NewTracer(t)
 	propagator := NewPropagator()
+	metaPropagator := NewMetaPropagator()
 	return func(s *server.MCPServer) {
 		server.WithTracer(tracer)(s)
 		server.WithPropagator(propagator)(s)
+		server.WithMetaPropagator(metaPropagator)(s)
 	}
 }
 
 // WithServerTracingPropagator is WithServerTracing with a caller-supplied
-// TextMapPropagator.
+// TextMapPropagator used for both HTTP header and _meta propagation.
 func WithServerTracingPropagator(t trace.Tracer, p propagation.TextMapPropagator) server.ServerOption {
 	tracer := NewTracer(t)
 	propagator := WrapPropagator(p)
+	metaPropagator := WrapMetaPropagator(p)
 	return func(s *server.MCPServer) {
 		server.WithTracer(tracer)(s)
 		server.WithPropagator(propagator)(s)
+		server.WithMetaPropagator(metaPropagator)(s)
 	}
 }
 
-// WithClientTracing installs an OpenTelemetry tracer and a W3C TraceContext
-// propagator on the client.
+// WithServerMetaPropagator installs a _meta propagator (SEP-414) with a
+// caller-supplied TextMapPropagator on the server.
+func WithServerMetaPropagator(p propagation.TextMapPropagator) server.ServerOption {
+	metaPropagator := WrapMetaPropagator(p)
+	return server.WithMetaPropagator(metaPropagator)
+}
+
+// WithClientTracing installs an OpenTelemetry tracer, a W3C TraceContext header
+// propagator, and a W3C TraceContext _meta propagator (SEP-414) on the client.
 func WithClientTracing(t trace.Tracer) client.ClientOption {
 	tracer := NewTracer(t)
 	propagator := NewPropagator()
+	metaPropagator := NewMetaPropagator()
 	return func(c *client.Client) {
 		client.WithTracer(tracer)(c)
 		client.WithPropagator(propagator)(c)
+		client.WithMetaPropagator(metaPropagator)(c)
 	}
 }
 
 // WithClientTracingPropagator is WithClientTracing with a caller-supplied
-// TextMapPropagator.
+// TextMapPropagator used for both HTTP header and _meta propagation.
 func WithClientTracingPropagator(t trace.Tracer, p propagation.TextMapPropagator) client.ClientOption {
 	tracer := NewTracer(t)
 	propagator := WrapPropagator(p)
+	metaPropagator := WrapMetaPropagator(p)
 	return func(c *client.Client) {
 		client.WithTracer(tracer)(c)
 		client.WithPropagator(propagator)(c)
+		client.WithMetaPropagator(metaPropagator)(c)
 	}
+}
+
+// WithClientMetaPropagator installs a _meta propagator (SEP-414) with a
+// caller-supplied TextMapPropagator on the client.
+func WithClientMetaPropagator(p propagation.TextMapPropagator) client.ClientOption {
+	metaPropagator := WrapMetaPropagator(p)
+	return client.WithMetaPropagator(metaPropagator)
 }

--- a/server/internal/gen/data.go
+++ b/server/internal/gen/data.go
@@ -11,6 +11,7 @@ type MCPRequestType struct {
 	UnmarshalError string
 	HandlerFunc    string
 	ResultIsAny    bool // If true, result type is 'any' instead of '*mcp.ResultType'
+	HasMeta        bool // If true, request.Params.Meta holds _meta and is extracted into ctx
 }
 
 var MCPRequestTypes = []MCPRequestType{
@@ -48,6 +49,7 @@ var MCPRequestTypes = []MCPRequestType{
 		HookName:       "ListResources",
 		UnmarshalError: "invalid list resources request",
 		HandlerFunc:    "handleListResources",
+		HasMeta:        true,
 	}, {
 		MethodName:     "MethodResourcesTemplatesList",
 		ParamType:      "ListResourceTemplatesRequest",
@@ -58,6 +60,7 @@ var MCPRequestTypes = []MCPRequestType{
 		HookName:       "ListResourceTemplates",
 		UnmarshalError: "invalid list resource templates request",
 		HandlerFunc:    "handleListResourceTemplates",
+		HasMeta:        true,
 	}, {
 		MethodName:     "MethodResourcesRead",
 		ParamType:      "ReadResourceRequest",
@@ -68,6 +71,7 @@ var MCPRequestTypes = []MCPRequestType{
 		HookName:       "ReadResource",
 		UnmarshalError: "invalid read resource request",
 		HandlerFunc:    "handleReadResource",
+		HasMeta:        true,
 	}, {
 		MethodName:     "MethodResourcesSubscribe",
 		ParamType:      "SubscribeRequest",
@@ -98,6 +102,7 @@ var MCPRequestTypes = []MCPRequestType{
 		HookName:       "ListPrompts",
 		UnmarshalError: "invalid list prompts request",
 		HandlerFunc:    "handleListPrompts",
+		HasMeta:        true,
 	}, {
 		MethodName:     "MethodPromptsGet",
 		ParamType:      "GetPromptRequest",
@@ -108,6 +113,7 @@ var MCPRequestTypes = []MCPRequestType{
 		HookName:       "GetPrompt",
 		UnmarshalError: "invalid get prompt request",
 		HandlerFunc:    "handleGetPrompt",
+		HasMeta:        true,
 	}, {
 		MethodName:     "MethodToolsList",
 		ParamType:      "ListToolsRequest",
@@ -118,6 +124,7 @@ var MCPRequestTypes = []MCPRequestType{
 		HookName:       "ListTools",
 		UnmarshalError: "invalid list tools request",
 		HandlerFunc:    "handleListTools",
+		HasMeta:        true,
 	}, {
 		MethodName:     "MethodToolsCall",
 		ParamType:      "CallToolRequest",
@@ -129,6 +136,7 @@ var MCPRequestTypes = []MCPRequestType{
 		UnmarshalError: "invalid call tool request",
 		HandlerFunc:    "handleToolCall",
 		ResultIsAny:    true, // Returns 'any' to support both CallToolResult and CreateTaskResult
+		HasMeta:        true,
 	}, {
 		MethodName:     "MethodTasksGet",
 		ParamType:      "GetTaskRequest",

--- a/server/internal/gen/request_handler.go.tmpl
+++ b/server/internal/gen/request_handler.go.tmpl
@@ -92,6 +92,19 @@ func (s *MCPServer) HandleMessage(
 		defer s.inflightCancels.Delete(key)
 	}
 
+	// Extract trace context from _meta before opening the server span so the span
+	// inherits the correct parent (SEP-414, transport-agnostic propagation).
+	{
+		var metaWrapper struct {
+			Params struct {
+				Meta *mcp.Meta `json:"_meta"`
+			} `json:"params"`
+		}
+		if json.Unmarshal(message, &metaWrapper) == nil {
+			ctx = s.extractMeta(ctx, metaWrapper.Params.Meta)
+		}
+	}
+
 	ctx, endSpan := s.startMessageSpan(ctx, headers, string(baseMessage.Method))
 	defer func() { endSpan(resp) }()
 

--- a/server/request_handler.go
+++ b/server/request_handler.go
@@ -92,6 +92,19 @@ func (s *MCPServer) HandleMessage(
 		defer s.inflightCancels.Delete(key)
 	}
 
+	// Extract trace context from _meta before opening the server span so the span
+	// inherits the correct parent (SEP-414, transport-agnostic propagation).
+	{
+		var metaWrapper struct {
+			Params struct {
+				Meta *mcp.Meta `json:"_meta"`
+			} `json:"params"`
+		}
+		if json.Unmarshal(message, &metaWrapper) == nil {
+			ctx = s.extractMeta(ctx, metaWrapper.Params.Meta)
+		}
+	}
+
 	ctx, endSpan := s.startMessageSpan(ctx, headers, string(baseMessage.Method))
 	defer func() { endSpan(resp) }()
 

--- a/server/server.go
+++ b/server/server.go
@@ -221,6 +221,7 @@ type MCPServer struct {
 	strictInputSchemaDefault   bool
 	tracer                     tracing.Tracer
 	propagator                 tracing.Propagator
+	metaPropagator             tracing.MetaPropagator
 }
 
 // WithPaginationLimit sets the pagination limit for the server.

--- a/server/tracing.go
+++ b/server/tracing.go
@@ -49,6 +49,29 @@ func WithPropagator(p tracing.Propagator) ServerOption {
 	}
 }
 
+// WithMetaPropagator installs a propagator that extracts trace context from
+// the MCP _meta property bag of inbound requests (per SEP-414). It covers
+// all transports including stdio, where HTTP headers are unavailable.
+// A nil propagator is treated as a no-op.
+func WithMetaPropagator(p tracing.MetaPropagator) ServerOption {
+	if p == nil {
+		p = tracing.NoopMetaPropagator()
+	}
+	return func(s *MCPServer) {
+		s.metaPropagator = p
+	}
+}
+
+// extractMeta extracts trace context from the _meta bag into ctx.
+// It is a no-op when no MetaPropagator is installed or meta is nil.
+func (s *MCPServer) extractMeta(ctx context.Context, meta *mcp.Meta) context.Context {
+	p := s.metaPropagator
+	if p == nil {
+		return ctx
+	}
+	return p.ExtractMeta(ctx, meta)
+}
+
 func (s *MCPServer) startMessageSpan(
 	ctx context.Context,
 	headers http.Header,

--- a/server/tracing_test.go
+++ b/server/tracing_test.go
@@ -21,6 +21,37 @@ func TestWithPropagator_NilFallsBackToNoop(t *testing.T) {
 	require.NotNil(t, s.propagator)
 }
 
+func TestWithMetaPropagator_NilFallsBackToNoop(t *testing.T) {
+	s := NewMCPServer("trace-srv", "1.0", WithMetaPropagator(nil))
+	require.NotNil(t, s.metaPropagator)
+}
+
+func TestWithMetaPropagator_ExtractCalledWithNilMeta(t *testing.T) {
+	extracted := false
+	mp := &stubMetaPropagator{onExtract: func() { extracted = true }}
+	s := NewMCPServer("trace-srv", "1.0", WithMetaPropagator(mp))
+
+	body := []byte(`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","clientInfo":{"name":"t","version":"1"},"capabilities":{}}}`)
+	resp := s.HandleMessage(t.Context(), body)
+	require.NotNil(t, resp)
+	assert.True(t, extracted, "extractMeta must be called even when _meta is absent")
+}
+
+type stubMetaPropagator struct {
+	onExtract func()
+}
+
+func (p *stubMetaPropagator) InjectMeta(ctx context.Context, meta *mcp.Meta) *mcp.Meta {
+	return meta
+}
+
+func (p *stubMetaPropagator) ExtractMeta(ctx context.Context, _ *mcp.Meta) context.Context {
+	if p.onExtract != nil {
+		p.onExtract()
+	}
+	return ctx
+}
+
 type recordingTracer struct {
 	spans []string
 }

--- a/tracing/tracing.go
+++ b/tracing/tracing.go
@@ -6,6 +6,8 @@ package tracing
 import (
 	"context"
 	"net/http"
+
+	"github.com/mark3labs/mcp-go/mcp"
 )
 
 // SpanKind identifies the role of a span in a trace.
@@ -57,6 +59,25 @@ type Propagator interface {
 	Extract(ctx context.Context, headers http.Header) context.Context
 }
 
+// MetaPropagator carries tracing context through the MCP _meta property bag
+// (per SEP-414). Unlike Propagator it operates on mcp.Meta rather than HTTP
+// headers, so it works on every MCP transport including stdio.
+//
+// InjectMeta writes the active span context into meta.AdditionalFields.
+// It allocates a new mcp.Meta when meta is nil and the propagator has
+// something to write. It returns nil when meta would remain empty.
+//
+// ExtractMeta reads traceparent/tracestate/baggage from meta.AdditionalFields
+// and returns a context that carries the extracted span context.
+// It returns ctx unchanged when meta is nil.
+type MetaPropagator interface {
+	InjectMeta(ctx context.Context, meta *mcp.Meta) *mcp.Meta
+	ExtractMeta(ctx context.Context, meta *mcp.Meta) context.Context
+}
+
+// NoopMetaPropagator returns a MetaPropagator whose methods are no-ops.
+func NoopMetaPropagator() MetaPropagator { return noopMetaPropagator{} }
+
 type spanContextKey struct{}
 
 // ContextWithSpan returns ctx annotated with span so SpanFromContext can
@@ -97,3 +118,10 @@ type noopPropagator struct{}
 
 func (noopPropagator) Inject(context.Context, http.Header)                        {}
 func (noopPropagator) Extract(ctx context.Context, _ http.Header) context.Context { return ctx }
+
+type noopMetaPropagator struct{}
+
+func (noopMetaPropagator) InjectMeta(_ context.Context, meta *mcp.Meta) *mcp.Meta { return meta }
+func (noopMetaPropagator) ExtractMeta(ctx context.Context, _ *mcp.Meta) context.Context {
+	return ctx
+}


### PR DESCRIPTION
## What

Adds transport-agnostic W3C trace context propagation through the JSON-RPC `_meta` property bag per [SEP-414](https://modelcontextprotocol.io/seps/414-request-meta).

The existing `Propagator` interface (inject/extract on `http.Header`) only reaches HTTP transports. `_meta` propagation works uniformly across stdio, SSE, and streamable-HTTP.

## Changes

**`tracing` package**

- New `MetaPropagator` interface: `InjectMeta(ctx, *mcp.Meta) *mcp.Meta` / `ExtractMeta(ctx, *mcp.Meta) context.Context`
- `NoopMetaPropagator()` for zero-value safety

**`server` package**

- `WithMetaPropagator(MetaPropagator) ServerOption`
- Pre-extracts `_meta` from the raw JSON message *before* `startMessageSpan`, so the `mcp.<method>` span correctly inherits the inbound trace parent. This is generic across all request types — no per-method wiring needed.

**`client` package**

- `WithMetaPropagator(MetaPropagator) ClientOption`
- Injects into `Params.Meta` at `CallTool`, `ReadResource`, and `GetPrompt` before serialisation

**`otel` package**

- `otel/meta_carrier.go`: `MetaCarrier` wraps `mcp.Meta.AdditionalFields` as a `propagation.TextMapCarrier`; `NewMetaPropagator()` / `WrapMetaPropagator(TextMapPropagator)`
- `WithServerTracing` / `WithClientTracing` now also install the W3C `_meta` propagator alongside the existing HTTP header propagator (additive, backward-compatible)
- New `WithServerMetaPropagator(TextMapPropagator)` / `WithClientMetaPropagator(TextMapPropagator)` for custom propagator composition

**`mcp` package**

- `ReadResourceParams` and `GetPromptParams` were missing `Meta *Meta`; added so `_meta` survives `resources/read` and `prompts/get` hops

## Usage

Existing callers of `WithServerTracing` / `WithClientTracing` get `_meta` propagation automatically. No API change required.

For custom propagators:

```go
// server
server.NewMCPServer("svc", "1.0",
    otel.WithServerTracing(tracer),                          // HTTP headers + _meta (W3C)
    otel.WithServerMetaPropagator(myCompositeTextMapProp),   // override _meta propagator
)

// client
client.NewClient(t,
    otel.WithClientTracing(tracer),
    otel.WithClientMetaPropagator(myCompositeTextMapProp),
)
```

Without the OTel adapter:

```go
server.WithMetaPropagator(myMetaPropagator)
client.WithMetaPropagator(myMetaPropagator)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP-level metadata propagation to carry tracing context in request params.
  * Added configurable meta-propagator support for clients and servers, with OpenTelemetry W3C TraceContext integration.
* **Tests**
  * Expanded tests covering injection/extraction, nil-safety, client/server propagation, and end-to-end trace round-trips.

<!-- review_stack_entry_start -->

![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->