### PR TITLE
fix: enforce tool/prompt filters at call time, not just list time

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1619,11 +1619,11 @@ func matchesTemplate(uri string, template *mcp.URITemplate) bool {
 	return template.Regexp().MatchString(uri)
 }
 
-func (s *MCPServer) handleListPrompts(
-	ctx context.Context,
-	id any,
-	request mcp.ListPromptsRequest,
-) (*mcp.ListPromptsResult, *requestError) {
+// filteredPrompts builds the full prompt candidate set and applies all
+// registered prompt filters. This is the single source of truth for which
+// prompts are visible in a given context, used by both handleListPrompts
+// and handleGetPrompt to guarantee consistent behavior.
+func (s *MCPServer) filteredPrompts(ctx context.Context) []mcp.Prompt {
 	s.promptsMu.RLock()
 	prompts := make([]mcp.Prompt, 0, len(s.prompts))
 	for _, prompt := range s.prompts {
@@ -1644,6 +1644,16 @@ func (s *MCPServer) handleListPrompts(
 		}
 	}
 	s.promptFiltersMu.RUnlock()
+
+	return prompts
+}
+
+func (s *MCPServer) handleListPrompts(
+	ctx context.Context,
+	id any,
+	request mcp.ListPromptsRequest,
+) (*mcp.ListPromptsResult, *requestError) {
+	prompts := s.filteredPrompts(ctx)
 
 	promptsToReturn, nextCursor, err := listByPagination(
 		ctx,
@@ -1684,30 +1694,29 @@ func (s *MCPServer) handleGetPrompt(
 		}
 	}
 
-	// Enforce prompt filters at get time to prevent access to filtered-out prompts.
-	// Without this check, a client that knows a prompt's name could bypass the
-	// visibility restrictions applied in prompts/list.
+	// Enforce prompt filters at get time to prevent access to filtered-out
+	// prompts. Uses the same filteredPrompts helper as prompts/list so that
+	// filters see the identical full candidate set.
 	s.promptFiltersMu.RLock()
-	if len(s.promptFilters) > 0 {
-		s.promptsMu.RLock()
-		prompt, promptExists := s.prompts[request.Params.Name]
-		s.promptsMu.RUnlock()
-		if promptExists {
-			visible := []mcp.Prompt{prompt}
-			for _, filter := range s.promptFilters {
-				visible = filter(ctx, visible)
+	hasFilters := len(s.promptFilters) > 0
+	s.promptFiltersMu.RUnlock()
+	if hasFilters {
+		visible := s.filteredPrompts(ctx)
+		found := false
+		for _, p := range visible {
+			if p.Name == request.Params.Name {
+				found = true
+				break
 			}
-			if len(visible) == 0 {
-				s.promptFiltersMu.RUnlock()
-				return nil, &requestError{
-					id:   id,
-					code: mcp.INVALID_PARAMS,
-					err:  fmt.Errorf("prompt '%s' not found: %w", request.Params.Name, ErrPromptNotFound),
-				}
+		}
+		if !found {
+			return nil, &requestError{
+				id:   id,
+				code: mcp.INVALID_PARAMS,
+				err:  fmt.Errorf("prompt '%s' not found: %w", request.Params.Name, ErrPromptNotFound),
 			}
 		}
 	}
-	s.promptFiltersMu.RUnlock()
 
 	finalHandler := handler
 
@@ -1732,11 +1741,11 @@ func (s *MCPServer) handleGetPrompt(
 	return result, nil
 }
 
-func (s *MCPServer) handleListTools(
-	ctx context.Context,
-	id any,
-	request mcp.ListToolsRequest,
-) (*mcp.ListToolsResult, *requestError) {
+// filteredTools builds the full tool candidate set (global + task + session)
+// and applies all registered tool filters. This is the single source of truth
+// for which tools are visible in a given context, used by both handleListTools
+// and handleToolCall to guarantee consistent behavior.
+func (s *MCPServer) filteredTools(ctx context.Context) []mcp.Tool {
 	// Get the base tools from the server (both regular and task tools)
 	s.toolsMu.RLock()
 	tools := make([]mcp.Tool, 0, len(s.tools)+len(s.taskTools))
@@ -1804,6 +1813,16 @@ func (s *MCPServer) handleListTools(
 		}
 	}
 	s.toolFiltersMu.RUnlock()
+
+	return tools
+}
+
+func (s *MCPServer) handleListTools(
+	ctx context.Context,
+	id any,
+	request mcp.ListToolsRequest,
+) (*mcp.ListToolsResult, *requestError) {
+	tools := s.filteredTools(ctx)
 
 	// Apply pagination
 	toolsToReturn, nextCursor, err := listByPagination(
@@ -1880,17 +1899,22 @@ func (s *MCPServer) handleToolCall(
 		}
 	}
 
-	// Enforce tool filters at call time to prevent access to filtered-out tools.
-	// Without this check, a client that knows a tool's name could bypass the
-	// visibility restrictions applied in tools/list.
+	// Enforce tool filters at call time to prevent access to filtered-out
+	// tools. Uses the same filteredTools helper as tools/list so that filters
+	// see the identical full candidate set (global + task + session tools).
 	s.toolFiltersMu.RLock()
-	if len(s.toolFilters) > 0 {
-		visible := []mcp.Tool{tool.Tool}
-		for _, filter := range s.toolFilters {
-			visible = filter(ctx, visible)
+	hasFilters := len(s.toolFilters) > 0
+	s.toolFiltersMu.RUnlock()
+	if hasFilters {
+		visible := s.filteredTools(ctx)
+		found := false
+		for _, t := range visible {
+			if t.Name == request.Params.Name {
+				found = true
+				break
+			}
 		}
-		if len(visible) == 0 {
-			s.toolFiltersMu.RUnlock()
+		if !found {
 			return nil, &requestError{
 				id:   id,
 				code: mcp.INVALID_PARAMS,
@@ -1898,7 +1922,6 @@ func (s *MCPServer) handleToolCall(
 			}
 		}
 	}
-	s.toolFiltersMu.RUnlock()
 
 	// Validate task support requirements
 	if tool.Tool.Execution != nil && tool.Tool.Execution.TaskSupport == mcp.TaskSupportRequired {

--- a/server/server.go
+++ b/server/server.go
@@ -71,13 +71,19 @@ type ToolHandlerMiddleware func(ToolHandlerFunc) ToolHandlerFunc
 // ResourceHandlerMiddleware is a middleware function that wraps a ResourceHandlerFunc.
 type ResourceHandlerMiddleware func(ResourceHandlerFunc) ResourceHandlerFunc
 
-// ToolFilterFunc is a function that filters tools based on context, typically using session information.
+// ToolFilterFunc is a function that filters tools based on context, typically
+// using session information. Filters are applied both when listing tools
+// (tools/list) and when calling tools (tools/call), so a filtered-out tool
+// cannot be discovered or invoked.
 type ToolFilterFunc func(ctx context.Context, tools []mcp.Tool) []mcp.Tool
 
 // PromptHandlerMiddleware is a middleware function that wraps a PromptHandlerFunc.
 type PromptHandlerMiddleware func(PromptHandlerFunc) PromptHandlerFunc
 
-// PromptFilterFunc is a function that filters prompts based on context, typically using session information.
+// PromptFilterFunc is a function that filters prompts based on context,
+// typically using session information. Filters are applied both when listing
+// prompts (prompts/list) and when retrieving prompts (prompts/get), so a
+// filtered-out prompt cannot be discovered or accessed.
 type PromptFilterFunc func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt
 
 // ServerTool combines a Tool with its ToolHandlerFunc.
@@ -342,7 +348,11 @@ func WithResourceRecovery() ServerOption {
 	})
 }
 
-// WithToolFilter adds a filter function that will be applied to tools before they are returned in list_tools
+// WithToolFilter adds a filter function that controls tool visibility and access.
+// The filter is applied both when listing tools (tools/list) and when calling
+// tools (tools/call). A tool that is filtered out cannot be discovered or
+// invoked, ensuring that filters act as an access control boundary rather than
+// just a visibility hint.
 func WithToolFilter(
 	toolFilter ToolFilterFunc,
 ) ServerOption {
@@ -365,7 +375,10 @@ func WithPromptHandlerMiddleware(
 	}
 }
 
-// WithPromptFilter adds a filter function that will be applied to prompts before they are returned in list_prompts
+// WithPromptFilter adds a filter function that controls prompt visibility and
+// access. The filter is applied both when listing prompts (prompts/list) and
+// when retrieving a prompt (prompts/get). A prompt that is filtered out cannot
+// be discovered or accessed.
 func WithPromptFilter(
 	promptFilter PromptFilterFunc,
 ) ServerOption {
@@ -1671,6 +1684,31 @@ func (s *MCPServer) handleGetPrompt(
 		}
 	}
 
+	// Enforce prompt filters at get time to prevent access to filtered-out prompts.
+	// Without this check, a client that knows a prompt's name could bypass the
+	// visibility restrictions applied in prompts/list.
+	s.promptFiltersMu.RLock()
+	if len(s.promptFilters) > 0 {
+		s.promptsMu.RLock()
+		prompt, promptExists := s.prompts[request.Params.Name]
+		s.promptsMu.RUnlock()
+		if promptExists {
+			visible := []mcp.Prompt{prompt}
+			for _, filter := range s.promptFilters {
+				visible = filter(ctx, visible)
+			}
+			if len(visible) == 0 {
+				s.promptFiltersMu.RUnlock()
+				return nil, &requestError{
+					id:   id,
+					code: mcp.INVALID_PARAMS,
+					err:  fmt.Errorf("prompt '%s' not found: %w", request.Params.Name, ErrPromptNotFound),
+				}
+			}
+		}
+	}
+	s.promptFiltersMu.RUnlock()
+
 	finalHandler := handler
 
 	s.promptMiddlewareMu.RLock()
@@ -1841,6 +1879,26 @@ func (s *MCPServer) handleToolCall(
 			err:  fmt.Errorf("tool '%s' not found: %w", request.Params.Name, ErrToolNotFound),
 		}
 	}
+
+	// Enforce tool filters at call time to prevent access to filtered-out tools.
+	// Without this check, a client that knows a tool's name could bypass the
+	// visibility restrictions applied in tools/list.
+	s.toolFiltersMu.RLock()
+	if len(s.toolFilters) > 0 {
+		visible := []mcp.Tool{tool.Tool}
+		for _, filter := range s.toolFilters {
+			visible = filter(ctx, visible)
+		}
+		if len(visible) == 0 {
+			s.toolFiltersMu.RUnlock()
+			return nil, &requestError{
+				id:   id,
+				code: mcp.INVALID_PARAMS,
+				err:  fmt.Errorf("tool '%s' not found: %w", request.Params.Name, ErrToolNotFound),
+			}
+		}
+	}
+	s.toolFiltersMu.RUnlock()
 
 	// Validate task support requirements
 	if tool.Tool.Execution != nil && tool.Tool.Execution.TaskSupport == mcp.TaskSupportRequired {

--- a/server/tool_filter_call_test.go
+++ b/server/tool_filter_call_test.go
@@ -1,0 +1,635 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestToolFilterCallTimeEnforcement verifies that tool filters are enforced
+// during tools/call, not just tools/list. This prevents clients from
+// bypassing visibility restrictions by calling a filtered-out tool directly.
+func TestToolFilterCallTimeEnforcement(t *testing.T) {
+	// Filter that only allows tools starting with "allow-"
+	allowPrefixFilter := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		var filtered []mcp.Tool
+		for _, tool := range tools {
+			if strings.HasPrefix(tool.Name, "allow-") {
+				filtered = append(filtered, tool)
+			}
+		}
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+		WithToolFilter(allowPrefixFilter),
+	)
+
+	// Register both allowed and denied tools with real handlers
+	server.AddTool(mcp.NewTool("allow-tool"), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("allowed"), nil
+	})
+	server.AddTool(mcp.NewTool("deny-tool"), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("should not reach"), nil
+	})
+
+	tests := []struct {
+		name       string
+		toolName   string
+		wantError  bool
+		wantResult string
+	}{
+		{
+			name:       "allowed tool can be called",
+			toolName:   "allow-tool",
+			wantError:  false,
+			wantResult: "allowed",
+		},
+		{
+			name:      "filtered-out tool is rejected at call time",
+			toolName:  "deny-tool",
+			wantError: true,
+		},
+		{
+			name:      "non-existent tool is rejected",
+			toolName:  "no-such-tool",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callRequest := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": tt.toolName,
+				},
+			}
+			requestBytes, err := json.Marshal(callRequest)
+			require.NoError(t, err)
+
+			response := server.HandleMessage(t.Context(), requestBytes)
+
+			if tt.wantError {
+				errResp, ok := response.(mcp.JSONRPCError)
+				require.True(t, ok, "Expected JSONRPCError response for tool %q, got %T", tt.toolName, response)
+				assert.Equal(t, mcp.INVALID_PARAMS, errResp.Error.Code)
+				assert.Contains(t, errResp.Error.Message, "not found")
+			} else {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok, "Expected JSONRPCResponse for tool %q, got %T", tt.toolName, response)
+				callToolResult, ok := resp.Result.(*mcp.CallToolResult)
+				require.True(t, ok)
+				require.NotEmpty(t, callToolResult.Content)
+				textContent, ok := callToolResult.Content[0].(mcp.TextContent)
+				require.True(t, ok)
+				assert.Equal(t, tt.wantResult, textContent.Text)
+			}
+		})
+	}
+}
+
+// TestToolFilterCallTimeWithMultipleFilters verifies that multiple chained
+// filters are all enforced at tools/call time, matching tools/list behavior.
+func TestToolFilterCallTimeWithMultipleFilters(t *testing.T) {
+	// First filter: allow tools starting with "a"
+	filterA := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		var filtered []mcp.Tool
+		for _, tool := range tools {
+			if strings.HasPrefix(tool.Name, "a") {
+				filtered = append(filtered, tool)
+			}
+		}
+		return filtered
+	}
+	// Second filter: allow tools containing "keep"
+	filterKeep := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		var filtered []mcp.Tool
+		for _, tool := range tools {
+			if strings.Contains(tool.Name, "keep") {
+				filtered = append(filtered, tool)
+			}
+		}
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+		WithToolFilter(filterA),
+		WithToolFilter(filterKeep),
+	)
+
+	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok:" + request.Params.Name), nil
+	}
+
+	server.AddTool(mcp.NewTool("a-keep-this"), handler)
+	server.AddTool(mcp.NewTool("a-remove-this"), handler)
+	server.AddTool(mcp.NewTool("b-keep-this"), handler)
+
+	tests := []struct {
+		name      string
+		toolName  string
+		wantError bool
+	}{
+		{
+			name:      "passes both filters",
+			toolName:  "a-keep-this",
+			wantError: false,
+		},
+		{
+			name:      "passes first but not second filter",
+			toolName:  "a-remove-this",
+			wantError: true,
+		},
+		{
+			name:      "passes second but not first filter",
+			toolName:  "b-keep-this",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callRequest := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": tt.toolName,
+				},
+			}
+			requestBytes, err := json.Marshal(callRequest)
+			require.NoError(t, err)
+
+			response := server.HandleMessage(t.Context(), requestBytes)
+
+			if tt.wantError {
+				errResp, ok := response.(mcp.JSONRPCError)
+				require.True(t, ok, "Expected error for %q", tt.toolName)
+				assert.Equal(t, mcp.INVALID_PARAMS, errResp.Error.Code)
+			} else {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok, "Expected success for %q", tt.toolName)
+				callToolResult, ok := resp.Result.(*mcp.CallToolResult)
+				require.True(t, ok)
+				require.NotEmpty(t, callToolResult.Content)
+			}
+		})
+	}
+}
+
+// TestToolFilterCallTimeWithSessionTools verifies that tool filters are
+// enforced at call time for session-specific tools too.
+func TestToolFilterCallTimeWithSessionTools(t *testing.T) {
+	allowPrefixFilter := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		var filtered []mcp.Tool
+		for _, tool := range tools {
+			if strings.HasPrefix(tool.Name, "allow-") {
+				filtered = append(filtered, tool)
+			}
+		}
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+		WithToolFilter(allowPrefixFilter),
+	)
+
+	// Create a session with tools
+	session := &sessionTestClientWithTools{
+		sessionID:           "session-1",
+		notificationChannel: make(chan mcp.JSONRPCNotification, 10),
+		initialized:         true,
+		sessionTools: map[string]ServerTool{
+			"allow-session-tool": {
+				Tool: mcp.NewTool("allow-session-tool"),
+				Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("session-allowed"), nil
+				},
+			},
+			"deny-session-tool": {
+				Tool: mcp.NewTool("deny-session-tool"),
+				Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					return mcp.NewToolResultText("should not reach"), nil
+				},
+			},
+		},
+	}
+
+	err := server.RegisterSession(t.Context(), session)
+	require.NoError(t, err)
+
+	sessionCtx := server.WithContext(t.Context(), session)
+
+	tests := []struct {
+		name      string
+		toolName  string
+		wantError bool
+	}{
+		{
+			name:      "allowed session tool can be called",
+			toolName:  "allow-session-tool",
+			wantError: false,
+		},
+		{
+			name:      "filtered-out session tool is rejected",
+			toolName:  "deny-session-tool",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			callRequest := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": tt.toolName,
+				},
+			}
+			requestBytes, err := json.Marshal(callRequest)
+			require.NoError(t, err)
+
+			response := server.HandleMessage(sessionCtx, requestBytes)
+
+			if tt.wantError {
+				errResp, ok := response.(mcp.JSONRPCError)
+				require.True(t, ok, "Expected error for session tool %q", tt.toolName)
+				assert.Equal(t, mcp.INVALID_PARAMS, errResp.Error.Code)
+			} else {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok, "Expected success for session tool %q", tt.toolName)
+				callToolResult, ok := resp.Result.(*mcp.CallToolResult)
+				require.True(t, ok)
+				require.NotEmpty(t, callToolResult.Content)
+			}
+		})
+	}
+}
+
+// TestToolFilterCallTimeConsistencyWithList verifies that tools/list and
+// tools/call agree on which tools are accessible — a tool visible in
+// tools/list must be callable, and a tool hidden by filters must not.
+func TestToolFilterCallTimeConsistencyWithList(t *testing.T) {
+	allowPrefixFilter := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		var filtered []mcp.Tool
+		for _, tool := range tools {
+			if strings.HasPrefix(tool.Name, "visible-") {
+				filtered = append(filtered, tool)
+			}
+		}
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+		WithToolFilter(allowPrefixFilter),
+	)
+
+	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("result:" + request.Params.Name), nil
+	}
+
+	server.AddTool(mcp.NewTool("visible-tool-1"), handler)
+	server.AddTool(mcp.NewTool("visible-tool-2"), handler)
+	server.AddTool(mcp.NewTool("hidden-tool-1"), handler)
+	server.AddTool(mcp.NewTool("hidden-tool-2"), handler)
+
+	ctx := t.Context()
+
+	// Step 1: List tools and collect visible names
+	listResponse := server.HandleMessage(ctx, []byte(`{
+		"jsonrpc": "2.0",
+		"id": 1,
+		"method": "tools/list"
+	}`))
+	listResp, ok := listResponse.(mcp.JSONRPCResponse)
+	require.True(t, ok)
+	listResult, ok := listResp.Result.(mcp.ListToolsResult)
+	require.True(t, ok)
+
+	visibleNames := make(map[string]bool)
+	for _, tool := range listResult.Tools {
+		visibleNames[tool.Name] = true
+	}
+
+	// Step 2: Verify every registered tool name — visible ones should succeed,
+	// hidden ones should fail at call time
+	allToolNames := []string{"visible-tool-1", "visible-tool-2", "hidden-tool-1", "hidden-tool-2"}
+
+	for _, name := range allToolNames {
+		t.Run(name, func(t *testing.T) {
+			callRequest := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      2,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": name,
+				},
+			}
+			requestBytes, err := json.Marshal(callRequest)
+			require.NoError(t, err)
+
+			response := server.HandleMessage(ctx, requestBytes)
+
+			if visibleNames[name] {
+				// Tool was in list — it must be callable
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok, "Visible tool %q should be callable", name)
+				callToolResult, ok := resp.Result.(*mcp.CallToolResult)
+				require.True(t, ok)
+				require.NotEmpty(t, callToolResult.Content)
+			} else {
+				// Tool was NOT in list — it must be rejected
+				errResp, ok := response.(mcp.JSONRPCError)
+				require.True(t, ok, "Hidden tool %q should be rejected at call time", name)
+				assert.Equal(t, mcp.INVALID_PARAMS, errResp.Error.Code)
+			}
+		})
+	}
+}
+
+// TestToolFilterCallTimeNoFilters verifies that when no filters are configured,
+// all tools remain callable (backward compatibility).
+func TestToolFilterCallTimeNoFilters(t *testing.T) {
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+	)
+
+	server.AddTool(mcp.NewTool("any-tool"), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("works"), nil
+	})
+
+	callRequest := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "any-tool",
+		},
+	}
+	requestBytes, err := json.Marshal(callRequest)
+	require.NoError(t, err)
+
+	response := server.HandleMessage(t.Context(), requestBytes)
+	resp, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok, "Expected success with no filters")
+	callToolResult, ok := resp.Result.(*mcp.CallToolResult)
+	require.True(t, ok)
+	require.NotEmpty(t, callToolResult.Content)
+	textContent, ok := callToolResult.Content[0].(mcp.TextContent)
+	require.True(t, ok)
+	assert.Equal(t, "works", textContent.Text)
+}
+
+// TestToolFilterCallTimeErrorType verifies that the error returned for a
+// filtered-out tool contains ErrToolNotFound, allowing callers to use
+// errors.Is for programmatic inspection via hooks.
+func TestToolFilterCallTimeErrorType(t *testing.T) {
+	var capturedErr error
+	hooks := &Hooks{}
+	hooks.AddOnError(func(ctx context.Context, id any, method mcp.MCPMethod, message any, err error) {
+		capturedErr = err
+	})
+
+	denyAllFilter := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		return nil
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+		WithToolFilter(denyAllFilter),
+		WithHooks(hooks),
+	)
+
+	server.AddTool(mcp.NewTool("blocked-tool"), func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("should not reach"), nil
+	})
+
+	callRequest := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "blocked-tool",
+		},
+	}
+	requestBytes, err := json.Marshal(callRequest)
+	require.NoError(t, err)
+
+	response := server.HandleMessage(t.Context(), requestBytes)
+
+	// Verify error response
+	_, ok := response.(mcp.JSONRPCError)
+	require.True(t, ok)
+
+	// Verify the error hook received ErrToolNotFound in the chain
+	require.NotNil(t, capturedErr)
+	assert.True(t, errors.Is(capturedErr, ErrToolNotFound),
+		"Error should wrap ErrToolNotFound, got: %v", capturedErr)
+}
+
+// TestToolFilterCallTimeContextAware verifies that context-aware filters
+// (e.g., based on session identity) work correctly at call time.
+func TestToolFilterCallTimeContextAware(t *testing.T) {
+	// Filter that uses session ID to decide tool access
+	sessionAwareFilter := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		session := ClientSessionFromContext(ctx)
+		if session == nil {
+			return tools // no session = no filtering
+		}
+
+		var filtered []mcp.Tool
+		for _, tool := range tools {
+			// Session "admin-session" gets all tools,
+			// other sessions only get tools starting with "public-"
+			if session.SessionID() == "admin-session" || strings.HasPrefix(tool.Name, "public-") {
+				filtered = append(filtered, tool)
+			}
+		}
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+		WithToolFilter(sessionAwareFilter),
+	)
+
+	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok:" + request.Params.Name), nil
+	}
+
+	server.AddTool(mcp.NewTool("public-tool"), handler)
+	server.AddTool(mcp.NewTool("admin-tool"), handler)
+
+	// Create two sessions
+	adminSession := &sessionTestClientWithTools{
+		sessionID:           "admin-session",
+		notificationChannel: make(chan mcp.JSONRPCNotification, 10),
+		initialized:         true,
+	}
+	userSession := &sessionTestClientWithTools{
+		sessionID:           "user-session",
+		notificationChannel: make(chan mcp.JSONRPCNotification, 10),
+		initialized:         true,
+	}
+
+	err := server.RegisterSession(t.Context(), adminSession)
+	require.NoError(t, err)
+	err = server.RegisterSession(t.Context(), userSession)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		session   ClientSession
+		toolName  string
+		wantError bool
+	}{
+		{
+			name:      "admin can call public tool",
+			session:   adminSession,
+			toolName:  "public-tool",
+			wantError: false,
+		},
+		{
+			name:      "admin can call admin tool",
+			session:   adminSession,
+			toolName:  "admin-tool",
+			wantError: false,
+		},
+		{
+			name:      "user can call public tool",
+			session:   userSession,
+			toolName:  "public-tool",
+			wantError: false,
+		},
+		{
+			name:      "user cannot call admin tool",
+			session:   userSession,
+			toolName:  "admin-tool",
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sessionCtx := server.WithContext(t.Context(), tt.session)
+			callRequest := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/call",
+				"params": map[string]any{
+					"name": tt.toolName,
+				},
+			}
+			requestBytes, err := json.Marshal(callRequest)
+			require.NoError(t, err)
+
+			response := server.HandleMessage(sessionCtx, requestBytes)
+
+			if tt.wantError {
+				errResp, ok := response.(mcp.JSONRPCError)
+				require.True(t, ok, "Expected error for %q with session %q", tt.toolName, tt.session.SessionID())
+				assert.Equal(t, mcp.INVALID_PARAMS, errResp.Error.Code)
+			} else {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok, "Expected success for %q with session %q", tt.toolName, tt.session.SessionID())
+				callToolResult, ok := resp.Result.(*mcp.CallToolResult)
+				require.True(t, ok)
+				require.NotEmpty(t, callToolResult.Content)
+			}
+		})
+	}
+}
+
+// TestPromptFilterGetTimeEnforcement verifies that prompt filters are enforced
+// during prompts/get, not just prompts/list.
+func TestPromptFilterGetTimeEnforcement(t *testing.T) {
+	allowPrefixFilter := func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt {
+		var filtered []mcp.Prompt
+		for _, prompt := range prompts {
+			if strings.HasPrefix(prompt.Name, "allow-") {
+				filtered = append(filtered, prompt)
+			}
+		}
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithPromptCapabilities(true),
+		WithPromptFilter(allowPrefixFilter),
+	)
+
+	handler := func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return &mcp.GetPromptResult{
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: "result:" + request.Params.Name},
+				},
+			},
+		}, nil
+	}
+
+	server.AddPrompt(mcp.Prompt{Name: "allow-prompt"}, handler)
+	server.AddPrompt(mcp.Prompt{Name: "deny-prompt"}, handler)
+
+	tests := []struct {
+		name       string
+		promptName string
+		wantError  bool
+	}{
+		{
+			name:       "allowed prompt can be retrieved",
+			promptName: "allow-prompt",
+			wantError:  false,
+		},
+		{
+			name:       "filtered-out prompt is rejected at get time",
+			promptName: "deny-prompt",
+			wantError:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getRequest := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "prompts/get",
+				"params": map[string]any{
+					"name": tt.promptName,
+				},
+			}
+			requestBytes, err := json.Marshal(getRequest)
+			require.NoError(t, err)
+
+			response := server.HandleMessage(t.Context(), requestBytes)
+
+			if tt.wantError {
+				errResp, ok := response.(mcp.JSONRPCError)
+				require.True(t, ok, "Expected error for prompt %q, got %T", tt.promptName, response)
+				assert.Equal(t, mcp.INVALID_PARAMS, errResp.Error.Code)
+				assert.Contains(t, errResp.Error.Message, "not found")
+			} else {
+				resp, ok := response.(mcp.JSONRPCResponse)
+				require.True(t, ok, "Expected success for prompt %q", tt.promptName)
+				result, ok := resp.Result.(mcp.GetPromptResult)
+				require.True(t, ok)
+				require.NotEmpty(t, result.Messages)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

Tool and prompt filters (`ToolFilterFunc` / `PromptFilterFunc`) are currently only applied during `tools/list` and `prompts/list`. A client that knows a filtered-out tool or prompt name can bypass all filter restrictions by calling `tools/call` or `prompts/get` directly.

This PR enforces the same filter chain at execution time:

- **`handleToolCall`** — After resolving the tool by name, the full `toolFilters` chain runs against it. If all filters eliminate the tool, the server returns `INVALID_PARAMS` with `ErrToolNotFound` — identical to a non-existent tool, preventing both execution and information leakage.

- **`handleGetPrompt`** — Same pattern for prompt filters at `prompts/get` time.

- **Godoc updates** — `ToolFilterFunc`, `PromptFilterFunc`, `WithToolFilter`, and `WithPromptFilter` comments now document that filters act as an access control boundary, not just a visibility hint.

**Before this fix:**
1. Filter hides `admin-reset` from `tools/list` ✅  
2. Client sends `{"method": "tools/call", "params": {"name": "admin-reset"}}`  
3. Tool executes successfully ❌ — filter bypassed  

**After this fix:**
1. Filter hides `admin-reset` from `tools/list` ✅  
2. Client sends `{"method": "tools/call", "params": {"name": "admin-reset"}}`  
3. Server returns `INVALID_PARAMS` — tool not found ✅  

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

### Changes

| File | Change |
|---|---|
| `server/server.go` | Filter enforcement in `handleToolCall` and `handleGetPrompt`; updated godoc on `ToolFilterFunc`, `PromptFilterFunc`, `WithToolFilter`, `WithPromptFilter` |
| `server/tool_filter_call_test.go` | **New** — 8 test functions, 17 sub-tests |

### Test Coverage

| Test | What it verifies |
|---|---|
| `TestToolFilterCallTimeEnforcement` | Allowed tool succeeds, filtered-out tool rejected, non-existent tool rejected |
| `TestToolFilterCallTimeWithMultipleFilters` | Chained filters — tool must pass all filters to be callable |
| `TestToolFilterCallTimeWithSessionTools` | Filter enforcement applies to session-specific tools |
| `TestToolFilterCallTimeConsistencyWithList` | `tools/list` and `tools/call` agree on accessible tools |
| `TestToolFilterCallTimeNoFilters` | Backward compat — no filters = all tools callable (zero overhead) |
| `TestToolFilterCallTimeErrorType` | Error wraps `ErrToolNotFound` (verifiable via `errors.Is` in hooks) |
| `TestToolFilterCallTimeContextAware` | Session-based context-aware filtering (admin vs user access) |
| `TestPromptFilterGetTimeEnforcement` | Same enforcement for prompt filters at `prompts/get` time |

### Backward Compatibility

- **Zero overhead when no filters are configured** — `len(s.toolFilters) > 0` short-circuits before any allocation.
- **No API changes** — existing `ToolFilterFunc` / `PromptFilterFunc` implementations work without modification.
- **Same error shape** — filtered-out tools return `INVALID_PARAMS` / `ErrToolNotFound`, identical to non-existent tools.
- **All existing tests pass** — `go test ./... -race` passes with zero regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced prompt and tool filters at request time so filtered items cannot be retrieved or invoked; requests for hidden items now return a “not found” error.

* **Tests**
  * Added comprehensive tests validating call-time enforcement, multiple chained filters, session/context-aware filtering, list-vs-call consistency, backward compatibility, and error exposure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mark3labs/mcp-go/pull/898?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->