### PR TITLE
oauth: return error instead of (nil, nil) from getServerMetadata (#903)

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -577,6 +577,13 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 	if h.metadataFetchErr != nil {
 		return nil, h.metadataFetchErr
 	}
+	// A "no-op" discovery (e.g. a non-2xx response handled by
+	// fetchMetadataFromURL) leaves serverMetadata nil without recording an
+	// error. Returning (nil, nil) here makes every caller dereference a nil
+	// *AuthServerMetadata and panic, so surface an explicit error instead.
+	if h.serverMetadata == nil {
+		return nil, fmt.Errorf("authorization server metadata unavailable: discovery returned no metadata")
+	}
 	return h.serverMetadata, nil
 }
 

--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -570,6 +570,19 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 		if result.resourceURL != "" {
 			h.resourceURL = result.resourceURL
 		}
+		// Discovery completed without producing metadata or an error (e.g. a
+		// non-2xx response handled by fetchMetadataFromURL). Record an explicit
+		// error — including the discovery target — so callers receive a
+		// consistent cached failure instead of a nil *AuthServerMetadata, which
+		// they would dereference and panic on. Skip when serverMetadata is
+		// already populated: a no-op re-discovery preserves the prior value.
+		if h.serverMetadata == nil && h.metadataFetchErr == nil {
+			if h.config.AuthServerMetadataURL != "" {
+				h.metadataFetchErr = fmt.Errorf("authorization server metadata unavailable: discovery at %q returned no metadata", h.config.AuthServerMetadataURL)
+			} else {
+				h.metadataFetchErr = errors.New("authorization server metadata unavailable: auto-discovery from the server base URL returned no metadata")
+			}
+		}
 	})
 
 	h.metadataMu.Lock()
@@ -577,12 +590,11 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 	if h.metadataFetchErr != nil {
 		return nil, h.metadataFetchErr
 	}
-	// A "no-op" discovery (e.g. a non-2xx response handled by
-	// fetchMetadataFromURL) leaves serverMetadata nil without recording an
-	// error. Returning (nil, nil) here makes every caller dereference a nil
-	// *AuthServerMetadata and panic, so surface an explicit error instead.
+	// Defensive backstop: a concurrent SetProtectedResourceMetadataURL may have
+	// reset state after our once ran. Never return (nil, nil) — every caller
+	// dereferences the returned metadata.
 	if h.serverMetadata == nil {
-		return nil, fmt.Errorf("authorization server metadata unavailable: discovery returned no metadata")
+		return nil, errors.New("authorization server metadata unavailable")
 	}
 	return h.serverMetadata, nil
 }

--- a/client/transport/oauth_nil_metadata_test.go
+++ b/client/transport/oauth_nil_metadata_test.go
@@ -1,0 +1,51 @@
+package transport
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression test for https://github.com/mark3labs/mcp-go/issues/903
+//
+// When metadata discovery hits a non-2xx response, fetchMetadataFromURL returns
+// (nil, nil), which previously left getServerMetadata returning (nil, nil) — no
+// metadata and no error. Callers (RegisterClient, token/auth URL builders) then
+// dereferenced the nil *AuthServerMetadata and panicked, crashing the process.
+// getServerMetadata must return a non-nil error instead of (nil, nil).
+func newOAuthHandlerWithUnavailableMetadata(t *testing.T) *OAuthHandler {
+	t.Helper()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	return NewOAuthHandler(OAuthConfig{
+		ClientID:              "test-client",
+		RedirectURI:           "http://localhost/callback",
+		Scopes:                []string{"mcp.read"},
+		TokenStore:            NewMemoryTokenStore(),
+		AuthServerMetadataURL: server.URL + "/.well-known/oauth-authorization-server",
+	})
+}
+
+func TestOAuthHandler_GetServerMetadata_UnavailableReturnsError(t *testing.T) {
+	handler := newOAuthHandlerWithUnavailableMetadata(t)
+
+	metadata, err := handler.GetServerMetadata(t.Context())
+
+	require.Error(t, err, "expected an error instead of (nil, nil) when discovery returns no metadata")
+	require.Nil(t, metadata)
+}
+
+func TestOAuthHandler_RegisterClient_UnavailableMetadataDoesNotPanic(t *testing.T) {
+	handler := newOAuthHandlerWithUnavailableMetadata(t)
+
+	var err error
+	require.NotPanics(t, func() {
+		err = handler.RegisterClient(t.Context(), "test-client")
+	})
+	require.Error(t, err)
+}


### PR DESCRIPTION
Fixes #903. getServerMetadata returned (nil, nil) on a non-2xx discovery response, so callers (RegisterClient, token/auth URL builders) dereferenced a nil *AuthServerMetadata and panicked. It now returns an explicit error instead; callers already handle the error path. Adds regression tests covering getServerMetadata and RegisterClient.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth authorization handler now returns a clear error when authorization server metadata is unavailable after discovery, avoiding nil responses and preventing downstream failures.
* **Tests**
  * Added regression tests that simulate unavailable metadata to ensure metadata retrieval reports errors and client registration does not panic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->