### PR TITLE
fix(oauth): prevent nil dereference in getServerMetadata

### DIFF
--- a/client/transport/oauth.go
+++ b/client/transport/oauth.go
@@ -577,6 +577,9 @@ func (h *OAuthHandler) getServerMetadata(ctx context.Context) (*AuthServerMetada
 	if h.metadataFetchErr != nil {
 		return nil, h.metadataFetchErr
 	}
+	if h.serverMetadata == nil {
+		return nil, errors.New("server metadata not available")
+	}
 	return h.serverMetadata, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes #903. `getServerMetadata` could return `nil, nil` when the fetch succeeded but returned no metadata, causing callers to panic on nil dereference (e.g. `RegisterClient` accessing `metadata.RegistrationEndpoint`).

## Changes

- `client/transport/oauth.go`: Return `"server metadata not available"` error when `serverMetadata` is nil after a fetch that completed without error

## Test plan

- `go test ./client/transport/ -run "TestOAuth"` — 63 passed

## Risk

- Low. The nil return path is only hit when the metadata discovery succeeds but the response contains no valid metadata, which was already a broken state for all callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved error handling in OAuth authentication to explicitly report failures when server metadata discovery is unable to complete, rather than silently returning no metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->