### PR TITLE
fix: avoid full filter scans on call hot paths

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -75,7 +75,8 @@ type ResourceHandlerMiddleware func(ResourceHandlerFunc) ResourceHandlerFunc
 // ToolFilterFunc is a function that filters tools based on context, typically
 // using session information. Filters are applied both when listing tools
 // (tools/list) and when calling tools (tools/call), so a filtered-out tool
-// cannot be discovered or invoked.
+// cannot be discovered or invoked. During tools/call, filters receive only the
+// requested tool to keep the call-time access check off the full-list hot path.
 type ToolFilterFunc func(ctx context.Context, tools []mcp.Tool) []mcp.Tool
 
 // PromptHandlerMiddleware is a middleware function that wraps a PromptHandlerFunc.
@@ -84,7 +85,9 @@ type PromptHandlerMiddleware func(PromptHandlerFunc) PromptHandlerFunc
 // PromptFilterFunc is a function that filters prompts based on context,
 // typically using session information. Filters are applied both when listing
 // prompts (prompts/list) and when retrieving prompts (prompts/get), so a
-// filtered-out prompt cannot be discovered or accessed.
+// filtered-out prompt cannot be discovered or accessed. During prompts/get,
+// filters receive only the requested prompt to keep the get-time access check
+// off the full-list hot path.
 type PromptFilterFunc func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt
 
 // ServerTool combines a Tool with its ToolHandlerFunc.
@@ -355,7 +358,8 @@ func WithResourceRecovery() ServerOption {
 // The filter is applied both when listing tools (tools/list) and when calling
 // tools (tools/call). A tool that is filtered out cannot be discovered or
 // invoked, ensuring that filters act as an access control boundary rather than
-// just a visibility hint.
+// just a visibility hint. Call-time checks pass only the requested tool to the
+// filter, while list-time checks pass the full candidate list.
 func WithToolFilter(
 	toolFilter ToolFilterFunc,
 ) ServerOption {
@@ -381,7 +385,8 @@ func WithPromptHandlerMiddleware(
 // WithPromptFilter adds a filter function that controls prompt visibility and
 // access. The filter is applied both when listing prompts (prompts/list) and
 // when retrieving a prompt (prompts/get). A prompt that is filtered out cannot
-// be discovered or accessed.
+// be discovered or accessed. Get-time checks pass only the requested prompt to
+// the filter, while list-time checks pass the full candidate list.
 func WithPromptFilter(
 	promptFilter PromptFilterFunc,
 ) ServerOption {
@@ -1651,6 +1656,29 @@ func (s *MCPServer) filteredPrompts(ctx context.Context) []mcp.Prompt {
 	return prompts
 }
 
+func (s *MCPServer) passesPromptFilters(ctx context.Context, prompt mcp.Prompt) bool {
+	s.promptFiltersMu.RLock()
+	defer s.promptFiltersMu.RUnlock()
+	if len(s.promptFilters) == 0 {
+		return true
+	}
+
+	prompts := []mcp.Prompt{prompt}
+	for _, filter := range s.promptFilters {
+		prompts = filter(ctx, prompts)
+		if len(prompts) == 0 {
+			return false
+		}
+	}
+
+	for _, candidate := range prompts {
+		if candidate.Name == prompt.Name {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *MCPServer) handleListPrompts(
 	ctx context.Context,
 	id any,
@@ -1687,6 +1715,7 @@ func (s *MCPServer) handleGetPrompt(
 ) (*mcp.GetPromptResult, *requestError) {
 	s.promptsMu.RLock()
 	handler, ok := s.promptHandlers[request.Params.Name]
+	prompt := s.prompts[request.Params.Name]
 	s.promptsMu.RUnlock()
 
 	if !ok {
@@ -1698,26 +1727,13 @@ func (s *MCPServer) handleGetPrompt(
 	}
 
 	// Enforce prompt filters at get time to prevent access to filtered-out
-	// prompts. Uses the same filteredPrompts helper as prompts/list so that
-	// filters see the identical full candidate set.
-	s.promptFiltersMu.RLock()
-	hasFilters := len(s.promptFilters) > 0
-	s.promptFiltersMu.RUnlock()
-	if hasFilters {
-		visible := s.filteredPrompts(ctx)
-		found := false
-		for _, p := range visible {
-			if p.Name == request.Params.Name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, &requestError{
-				id:   id,
-				code: mcp.INVALID_PARAMS,
-				err:  fmt.Errorf("prompt '%s' not found: %w", request.Params.Name, ErrPromptNotFound),
-			}
+	// prompts. Only the requested prompt is passed through the filter chain so
+	// this access check does not rebuild and filter the full prompt list.
+	if !s.passesPromptFilters(ctx, prompt) {
+		return nil, &requestError{
+			id:   id,
+			code: mcp.INVALID_PARAMS,
+			err:  fmt.Errorf("prompt '%s' not found: %w", request.Params.Name, ErrPromptNotFound),
 		}
 	}
 
@@ -1820,6 +1836,29 @@ func (s *MCPServer) filteredTools(ctx context.Context) []mcp.Tool {
 	return tools
 }
 
+func (s *MCPServer) passesToolFilters(ctx context.Context, tool mcp.Tool) bool {
+	s.toolFiltersMu.RLock()
+	defer s.toolFiltersMu.RUnlock()
+	if len(s.toolFilters) == 0 {
+		return true
+	}
+
+	tools := []mcp.Tool{tool}
+	for _, filter := range s.toolFilters {
+		tools = filter(ctx, tools)
+		if len(tools) == 0 {
+			return false
+		}
+	}
+
+	for _, candidate := range tools {
+		if candidate.Name == tool.Name {
+			return true
+		}
+	}
+	return false
+}
+
 func (s *MCPServer) handleListTools(
 	ctx context.Context,
 	id any,
@@ -1903,26 +1942,13 @@ func (s *MCPServer) handleToolCall(
 	}
 
 	// Enforce tool filters at call time to prevent access to filtered-out
-	// tools. Uses the same filteredTools helper as tools/list so that filters
-	// see the identical full candidate set (global + task + session tools).
-	s.toolFiltersMu.RLock()
-	hasFilters := len(s.toolFilters) > 0
-	s.toolFiltersMu.RUnlock()
-	if hasFilters {
-		visible := s.filteredTools(ctx)
-		found := false
-		for _, t := range visible {
-			if t.Name == request.Params.Name {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return nil, &requestError{
-				id:   id,
-				code: mcp.INVALID_PARAMS,
-				err:  fmt.Errorf("tool '%s' not found: %w", request.Params.Name, ErrToolNotFound),
-			}
+	// tools. Only the requested tool is passed through the filter chain so this
+	// access check does not rebuild and filter the full tool list.
+	if !s.passesToolFilters(ctx, tool.Tool) {
+		return nil, &requestError{
+			id:   id,
+			code: mcp.INVALID_PARAMS,
+			err:  fmt.Errorf("tool '%s' not found: %w", request.Params.Name, ErrToolNotFound),
 		}
 	}
 

--- a/server/tool_filter_call_test.go
+++ b/server/tool_filter_call_test.go
@@ -394,6 +394,56 @@ func TestToolFilterCallTimeNoFilters(t *testing.T) {
 	assert.Equal(t, "works", textContent.Text)
 }
 
+func TestToolFilterCallTimeFiltersOnlyRequestedTool(t *testing.T) {
+	var filterInputs [][]string
+	allowVisibleFilter := func(ctx context.Context, tools []mcp.Tool) []mcp.Tool {
+		names := make([]string, 0, len(tools))
+		filtered := make([]mcp.Tool, 0, len(tools))
+		for _, tool := range tools {
+			names = append(names, tool.Name)
+			if strings.HasPrefix(tool.Name, "visible-") {
+				filtered = append(filtered, tool)
+			}
+		}
+		filterInputs = append(filterInputs, names)
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithToolCapabilities(true),
+		WithToolFilter(allowVisibleFilter),
+	)
+
+	handler := func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("ok:" + request.Params.Name), nil
+	}
+
+	server.AddTool(mcp.NewTool("visible-tool-1"), handler)
+	server.AddTool(mcp.NewTool("visible-tool-2"), handler)
+	server.AddTool(mcp.NewTool("visible-tool-3"), handler)
+	server.AddTool(mcp.NewTool("hidden-tool-1"), handler)
+	server.AddTool(mcp.NewTool("hidden-tool-2"), handler)
+	server.AddTool(mcp.NewTool("hidden-tool-3"), handler)
+
+	callRequest := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name": "visible-tool-3",
+		},
+	}
+	requestBytes, err := json.Marshal(callRequest)
+	require.NoError(t, err)
+
+	response := server.HandleMessage(t.Context(), requestBytes)
+	_, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok, "Expected success for visible tool, got %T", response)
+
+	require.Len(t, filterInputs, 1)
+	assert.Equal(t, []string{"visible-tool-3"}, filterInputs[0])
+}
+
 // TestToolFilterCallTimeErrorType verifies that the error returned for a
 // filtered-out tool contains ErrToolNotFound, allowing callers to use
 // errors.Is for programmatic inspection via hooks.
@@ -552,6 +602,61 @@ func TestToolFilterCallTimeContextAware(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPromptFilterGetTimeFiltersOnlyRequestedPrompt(t *testing.T) {
+	var filterInputs [][]string
+	allowVisibleFilter := func(ctx context.Context, prompts []mcp.Prompt) []mcp.Prompt {
+		names := make([]string, 0, len(prompts))
+		filtered := make([]mcp.Prompt, 0, len(prompts))
+		for _, prompt := range prompts {
+			names = append(names, prompt.Name)
+			if strings.HasPrefix(prompt.Name, "visible-") {
+				filtered = append(filtered, prompt)
+			}
+		}
+		filterInputs = append(filterInputs, names)
+		return filtered
+	}
+
+	server := NewMCPServer("test-server", "1.0.0",
+		WithPromptCapabilities(true),
+		WithPromptFilter(allowVisibleFilter),
+	)
+
+	handler := func(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+		return &mcp.GetPromptResult{
+			Messages: []mcp.PromptMessage{
+				{
+					Role:    mcp.RoleUser,
+					Content: mcp.TextContent{Type: "text", Text: "result:" + request.Params.Name},
+				},
+			},
+		}, nil
+	}
+
+	server.AddPrompt(mcp.Prompt{Name: "visible-prompt-1"}, handler)
+	server.AddPrompt(mcp.Prompt{Name: "visible-prompt-2"}, handler)
+	server.AddPrompt(mcp.Prompt{Name: "hidden-prompt-1"}, handler)
+	server.AddPrompt(mcp.Prompt{Name: "hidden-prompt-2"}, handler)
+
+	getRequest := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "prompts/get",
+		"params": map[string]any{
+			"name": "visible-prompt-2",
+		},
+	}
+	requestBytes, err := json.Marshal(getRequest)
+	require.NoError(t, err)
+
+	response := server.HandleMessage(t.Context(), requestBytes)
+	_, ok := response.(mcp.JSONRPCResponse)
+	require.True(t, ok, "Expected success for visible prompt, got %T", response)
+
+	require.Len(t, filterInputs, 1)
+	assert.Equal(t, []string{"visible-prompt-2"}, filterInputs[0])
 }
 
 // TestPromptFilterGetTimeEnforcement verifies that prompt filters are enforced


### PR DESCRIPTION
## Summary

Fixes #907

`tools/call` and `prompts/get` currently enforce filters by rebuilding the full visible list and running the full filter chain across every registered item. That preserves the call-time access boundary added in #898, but it puts all filters on the per-call hot path.

## Changes

This changes the call/get-time access check to run the existing filter chain over only the already-resolved requested tool or prompt. Listing still filters the full candidate set, while direct calls keep rejecting filtered-out items without scanning unrelated tools or prompts.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Code refactoring (no functional changes)
- [x] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

Added regressions that assert:

- `tools/call` passes only the requested tool through `ToolFilterFunc`.
- `prompts/get` passes only the requested prompt through `PromptFilterFunc`.
- Existing call/get-time rejection behavior remains covered by the surrounding filter tests.

## Verification

```bash
go test ./server -run 'TestToolFilterCallTimeFiltersOnlyRequestedTool|TestPromptFilterGetTimeFiltersOnlyRequestedPrompt' -count=1
go test ./server -run 'TestToolFilter|TestPromptFilter|TestMCPServer_ToolFiltering|TestMCPServer_PromptFiltering|TestMCPServer_MultiplePromptFilters' -count=1
go test ./server -count=1
go test ./... -race
go test ./... -race
git diff --check
```

The second `go test ./... -race` command above was run from the `otel` submodule.

I could not run `golangci-lint run` locally because the binary is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved filter application efficiency by evaluating only the requested item rather than rebuilding the entire filtered list when retrieving prompts or calling tools.
* **Documentation**
  * Clarified that filters function as an access-control boundary, not merely visibility hints.
* **Tests**
  * Added tests verifying that filters are applied only to requested items at tool call and prompt retrieval endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->