### PR TITLE
fix(client): avoid forwarding inbound request headers

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -193,6 +193,16 @@ func (c *Client) sendRequest(
 	return &response.Result, nil
 }
 
+func outboundHeader(header http.Header, requestMethod string) http.Header {
+	// A typed request with Method set was decoded from an inbound JSON-RPC
+	// message. Its Header contains received HTTP metadata, not opt-in outbound
+	// headers for a new client call.
+	if requestMethod != "" {
+		return nil
+	}
+	return header
+}
+
 // Initialize negotiates with the server.
 // Must be called after Start, and before any request methods.
 func (c *Client) Initialize(
@@ -232,7 +242,7 @@ func (c *Client) Initialize(
 		params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
 	}
 
-	response, err := c.sendRequest(ctx, "initialize", params, request.Header)
+	response, err := c.sendRequest(ctx, "initialize", params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -364,7 +374,7 @@ func (c *Client) ReadResource(
 	request mcp.ReadResourceRequest,
 ) (*mcp.ReadResourceResult, error) {
 	request.Params.Meta = c.injectMeta(ctx, request.Params.Meta)
-	response, err := c.sendRequest(ctx, string(mcp.MethodResourcesRead), request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodResourcesRead), request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +387,7 @@ func (c *Client) Subscribe(
 	ctx context.Context,
 	request mcp.SubscribeRequest,
 ) error {
-	_, err := c.sendRequest(ctx, string(mcp.MethodResourcesSubscribe), request.Params, request.Header)
+	_, err := c.sendRequest(ctx, string(mcp.MethodResourcesSubscribe), request.Params, outboundHeader(request.Header, request.Method))
 	return err
 }
 
@@ -386,7 +396,7 @@ func (c *Client) Unsubscribe(
 	ctx context.Context,
 	request mcp.UnsubscribeRequest,
 ) error {
-	_, err := c.sendRequest(ctx, string(mcp.MethodResourcesUnsubscribe), request.Params, request.Header)
+	_, err := c.sendRequest(ctx, string(mcp.MethodResourcesUnsubscribe), request.Params, outboundHeader(request.Header, request.Method))
 	return err
 }
 
@@ -434,7 +444,7 @@ func (c *Client) GetPrompt(
 	request mcp.GetPromptRequest,
 ) (*mcp.GetPromptResult, error) {
 	request.Params.Meta = c.injectMeta(ctx, request.Params.Meta)
-	response, err := c.sendRequest(ctx, string(mcp.MethodPromptsGet), request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodPromptsGet), request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -486,7 +496,7 @@ func (c *Client) CallTool(
 	request mcp.CallToolRequest,
 ) (*mcp.CallToolResult, error) {
 	request.Params.Meta = c.injectMeta(ctx, request.Params.Meta)
-	response, err := c.sendRequest(ctx, string(mcp.MethodToolsCall), request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodToolsCall), request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -499,7 +509,7 @@ func (c *Client) SetLevel(
 	ctx context.Context,
 	request mcp.SetLevelRequest,
 ) error {
-	_, err := c.sendRequest(ctx, "logging/setLevel", request.Params, request.Header)
+	_, err := c.sendRequest(ctx, "logging/setLevel", request.Params, outboundHeader(request.Header, request.Method))
 	return err
 }
 
@@ -508,7 +518,7 @@ func (c *Client) Complete(
 	ctx context.Context,
 	request mcp.CompleteRequest,
 ) (*mcp.CompleteResult, error) {
-	response, err := c.sendRequest(ctx, "completion/complete", request.Params, request.Header)
+	response, err := c.sendRequest(ctx, "completion/complete", request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -708,7 +718,7 @@ func listByPage[T any](
 	header http.Header,
 	method string,
 ) (*T, error) {
-	response, err := client.sendRequest(ctx, method, request.Params, header)
+	response, err := client.sendRequest(ctx, method, request.Params, outboundHeader(header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -756,7 +766,7 @@ func (c *Client) CancelTask(
 	ctx context.Context,
 	request mcp.CancelTaskRequest,
 ) (*mcp.CancelTaskResult, error) {
-	response, err := c.sendRequest(ctx, string(mcp.MethodTasksCancel), request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodTasksCancel), request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -769,7 +779,7 @@ func (c *Client) ListTasks(
 	ctx context.Context,
 	request mcp.ListTasksRequest,
 ) (*mcp.ListTasksResult, error) {
-	response, err := c.sendRequest(ctx, string(mcp.MethodTasksList), request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodTasksList), request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -782,7 +792,7 @@ func (c *Client) TaskResult(
 	ctx context.Context,
 	request mcp.TaskResultRequest,
 ) (*mcp.TaskResultResult, error) {
-	response, err := c.sendRequest(ctx, string(mcp.MethodTasksResult), request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodTasksResult), request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}
@@ -795,7 +805,7 @@ func (c *Client) GetTask(
 	ctx context.Context,
 	request mcp.GetTaskRequest,
 ) (*mcp.GetTaskResult, error) {
-	response, err := c.sendRequest(ctx, string(mcp.MethodTasksGet), request.Params, request.Header)
+	response, err := c.sendRequest(ctx, string(mcp.MethodTasksGet), request.Params, outboundHeader(request.Header, request.Method))
 	if err != nil {
 		return nil, err
 	}

--- a/client/http_test.go
+++ b/client/http_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPClient(t *testing.T) {
@@ -201,6 +203,102 @@ func TestHTTPClient(t *testing.T) {
 		})
 
 	})
+}
+
+func TestHTTPClientDoesNotForwardServerReceivedHeaders(t *testing.T) {
+	backendServer := server.NewMCPServer(
+		"backend",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	var received http.Header
+	backendServer.AddTool(
+		mcp.NewTool("echo"),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			received = request.Header.Clone()
+			return mcp.NewToolResultText("ok"), nil
+		},
+	)
+
+	backendHTTP := server.NewTestStreamableHTTPServer(backendServer)
+	defer backendHTTP.Close()
+
+	backendClient, err := NewStreamableHttpClient(backendHTTP.URL)
+	require.NoError(t, err)
+	defer backendClient.Close()
+	require.NoError(t, backendClient.Start(t.Context()))
+	_, err = backendClient.Initialize(t.Context(), mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    "proxy-client",
+				Version: "1.0.0",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	proxyServer := server.NewMCPServer(
+		"proxy",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+	proxyServer.AddTool(
+		mcp.NewTool("echo"),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return backendClient.CallTool(ctx, request)
+		},
+	)
+	proxyHTTP := server.NewTestStreamableHTTPServer(proxyServer)
+	defer proxyHTTP.Close()
+
+	endClient, err := NewStreamableHttpClient(proxyHTTP.URL)
+	require.NoError(t, err)
+	defer endClient.Close()
+	require.NoError(t, endClient.Start(t.Context()))
+	_, err = endClient.Initialize(t.Context(), mcp.InitializeRequest{
+		Params: mcp.InitializeParams{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo: mcp.Implementation{
+				Name:    "end-client",
+				Version: "1.0.0",
+			},
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = endClient.CallTool(t.Context(), mcp.CallToolRequest{
+		Header: http.Header{
+			"Accept-Encoding": {"gzip, deflate"},
+			"Authorization":   {"Bearer inbound-token"},
+			"Cookie":          {"session=inbound"},
+			"X-Proxy-Auth":    {"proxy-secret"},
+		},
+		Params: mcp.CallToolParams{
+			Name: "echo",
+		},
+	})
+	require.NoError(t, err)
+
+	require.NotContains(t, received.Values("Accept-Encoding"), "gzip, deflate")
+	require.Empty(t, received.Values("Authorization"))
+	require.Empty(t, received.Values("Cookie"))
+	require.Empty(t, received.Values("X-Proxy-Auth"))
+	require.Equal(t, "application/json", received.Get("Content-Type"))
+
+	explicitRequest := mcp.CallToolRequest{
+		Header: http.Header{
+			"X-Backend-Auth": {"allowed"},
+		},
+		Params: mcp.CallToolParams{
+			Name: "echo",
+		},
+	}
+
+	_, err = backendClient.CallTool(t.Context(), explicitRequest)
+	require.NoError(t, err)
+	require.Equal(t, "allowed", received.Get("X-Backend-Auth"))
 }
 
 type SafeMap struct {


### PR DESCRIPTION
## Description

Fixes #905.

When an MCP server handler forwards a received typed request to an upstream `Client`, the request's `Header` field currently contains the inbound HTTP headers that the server populated. The client then treats the same field as per-request outbound headers, so proxy/gateway code can unintentionally forward `Authorization`, `Cookie`, explicit `Accept-Encoding`, and other inbound headers to the backend.

This change keeps explicit client-side per-request headers working, but drops headers from typed requests that were decoded from inbound JSON-RPC messages before making a new client call. The regression test builds a proxy MCP server that forwards a received `CallToolRequest` to a backend client and verifies the inbound headers do not reach the backend, while an explicitly constructed backend request header still does.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

Verification:

- `go test ./client -run TestHTTPClientDoesNotForwardServerReceivedHeaders -count=1 -v`
- `go test ./client ./client/transport ./server -count=1`
- `go test ./... -count=1`
- `go test ./... -race -count=1`
- `(cd otel && go test ./... -count=1)`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HTTP headers received in requests are no longer forwarded on outbound JSON-RPC calls.
* **Tests**
  * Added test coverage for header handling behavior in request operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->