### PR TITLE
fix(tools): omit tool annotations from JSON when unset

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -643,7 +643,9 @@ func (t Tool) MarshalJSON() ([]byte, error) {
 		m["outputSchema"] = t.OutputSchema
 	}
 
-	m["annotations"] = t.Annotations
+	if t.Annotations.HasAny() {
+		m["annotations"] = t.Annotations
+	}
 
 	if t.DeferLoading {
 		m["defer_loading"] = t.DeferLoading
@@ -775,6 +777,15 @@ type ToolAnnotation struct {
 	IdempotentHint *bool `json:"idempotentHint,omitempty"`
 	// If true, tool interacts with external entities
 	OpenWorldHint *bool `json:"openWorldHint,omitempty"`
+}
+
+// HasAny reports whether any annotation field was explicitly set.
+func (a ToolAnnotation) HasAny() bool {
+	return a.Title != "" ||
+		a.ReadOnlyHint != nil ||
+		a.DestructiveHint != nil ||
+		a.IdempotentHint != nil ||
+		a.OpenWorldHint != nil
 }
 
 // ToolOption is a function that configures a Tool.
@@ -941,6 +952,15 @@ func WithOutputSchema[T any]() ToolOption {
 func WithRawOutputSchema(schema json.RawMessage) ToolOption {
 	return func(t *Tool) {
 		t.RawOutputSchema = schema
+	}
+}
+
+// WithoutDefaultAnnotations clears the default annotation hints initialized by
+// NewTool so the annotations field is omitted from JSON unless later options
+// set annotation values explicitly.
+func WithoutDefaultAnnotations() ToolOption {
+	return func(t *Tool) {
+		t.Annotations = ToolAnnotation{}
 	}
 }
 

--- a/mcp/tools_additional_test.go
+++ b/mcp/tools_additional_test.go
@@ -295,61 +295,84 @@ func TestToolAnnotations(t *testing.T) {
 }
 
 func TestToolAnnotationsMarshalJSON(t *testing.T) {
-	t.Run("NewTool includes default annotations", func(t *testing.T) {
-		tool := NewTool("test", WithDescription("desc"))
+	rawSchema := json.RawMessage(`{"type":"object","properties":{}}`)
 
-		data, err := json.Marshal(tool)
-		require.NoError(t, err)
+	tests := []struct {
+		name            string
+		tool            Tool
+		wantAnnotations bool
+		wantContains    string
+		wantNotContains string
+		checkAnnotations func(t *testing.T, annotations map[string]any)
+	}{
+		{
+			name:            "NewTool includes default annotations",
+			tool:            NewTool("test", WithDescription("desc")),
+			wantAnnotations: true,
+			checkAnnotations: func(t *testing.T, annotations map[string]any) {
+				t.Helper()
+				assert.Equal(t, false, annotations["readOnlyHint"])
+				assert.Equal(t, true, annotations["destructiveHint"])
+			},
+		},
+		{
+			name: "WithoutDefaultAnnotations omits annotations field",
+			tool: NewTool("test",
+				WithoutDefaultAnnotations(),
+				WithDescription("desc"),
+			),
+			wantAnnotations: false,
+			wantNotContains: `"annotations"`,
+		},
+		{
+			name: "WithoutDefaultAnnotations with explicit hint includes annotations",
+			tool: NewTool("test",
+				WithoutDefaultAnnotations(),
+				WithReadOnlyHintAnnotation(true),
+			),
+			wantAnnotations: true,
+			checkAnnotations: func(t *testing.T, annotations map[string]any) {
+				t.Helper()
+				assert.Equal(t, true, annotations["readOnlyHint"])
+				assert.NotContains(t, annotations, "destructiveHint")
+			},
+		},
+		{
+			name:            "NewToolWithRawSchema omits annotations when unset",
+			tool:            NewToolWithRawSchema("raw-tool", "Raw tool", rawSchema),
+			wantAnnotations: false,
+			wantNotContains: `"annotations"`,
+		},
+	}
 
-		var parsed map[string]any
-		require.NoError(t, json.Unmarshal(data, &parsed))
-		annotations, ok := parsed["annotations"].(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, false, annotations["readOnlyHint"])
-		assert.Equal(t, true, annotations["destructiveHint"])
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.tool)
+			require.NoError(t, err)
 
-	t.Run("WithoutDefaultAnnotations omits annotations field", func(t *testing.T) {
-		tool := NewTool("test",
-			WithoutDefaultAnnotations(),
-			WithDescription("desc"),
-		)
+			if tt.wantContains != "" {
+				assert.Contains(t, string(data), tt.wantContains)
+			}
+			if tt.wantNotContains != "" {
+				assert.NotContains(t, string(data), tt.wantNotContains)
+			}
 
-		data, err := json.Marshal(tool)
-		require.NoError(t, err)
-		assert.NotContains(t, string(data), `"annotations"`)
+			var parsed map[string]any
+			require.NoError(t, json.Unmarshal(data, &parsed))
 
-		var parsed map[string]any
-		require.NoError(t, json.Unmarshal(data, &parsed))
-		_, hasAnnotations := parsed["annotations"]
-		assert.False(t, hasAnnotations)
-	})
+			annotations, ok := parsed["annotations"].(map[string]any)
+			if tt.wantAnnotations {
+				require.True(t, ok)
+				if tt.checkAnnotations != nil {
+					tt.checkAnnotations(t, annotations)
+				}
+				return
+			}
 
-	t.Run("WithoutDefaultAnnotations with explicit hint includes annotations", func(t *testing.T) {
-		tool := NewTool("test",
-			WithoutDefaultAnnotations(),
-			WithReadOnlyHintAnnotation(true),
-		)
-
-		data, err := json.Marshal(tool)
-		require.NoError(t, err)
-
-		var parsed map[string]any
-		require.NoError(t, json.Unmarshal(data, &parsed))
-		annotations, ok := parsed["annotations"].(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, true, annotations["readOnlyHint"])
-		assert.NotContains(t, annotations, "destructiveHint")
-	})
-
-	t.Run("NewToolWithRawSchema omits annotations when unset", func(t *testing.T) {
-		rawSchema := json.RawMessage(`{"type":"object","properties":{}}`)
-		tool := NewToolWithRawSchema("raw-tool", "Raw tool", rawSchema)
-
-		data, err := json.Marshal(tool)
-		require.NoError(t, err)
-		assert.NotContains(t, string(data), `"annotations"`)
-	})
+			_, hasAnnotations := parsed["annotations"]
+			assert.False(t, hasAnnotations)
+		})
+	}
 
 	t.Run("zero-value ToolAnnotation HasAny is false", func(t *testing.T) {
 		assert.False(t, ToolAnnotation{}.HasAny())

--- a/mcp/tools_additional_test.go
+++ b/mcp/tools_additional_test.go
@@ -294,6 +294,73 @@ func TestToolAnnotations(t *testing.T) {
 	})
 }
 
+func TestToolAnnotationsMarshalJSON(t *testing.T) {
+	t.Run("NewTool includes default annotations", func(t *testing.T) {
+		tool := NewTool("test", WithDescription("desc"))
+
+		data, err := json.Marshal(tool)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		annotations, ok := parsed["annotations"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, false, annotations["readOnlyHint"])
+		assert.Equal(t, true, annotations["destructiveHint"])
+	})
+
+	t.Run("WithoutDefaultAnnotations omits annotations field", func(t *testing.T) {
+		tool := NewTool("test",
+			WithoutDefaultAnnotations(),
+			WithDescription("desc"),
+		)
+
+		data, err := json.Marshal(tool)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"annotations"`)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		_, hasAnnotations := parsed["annotations"]
+		assert.False(t, hasAnnotations)
+	})
+
+	t.Run("WithoutDefaultAnnotations with explicit hint includes annotations", func(t *testing.T) {
+		tool := NewTool("test",
+			WithoutDefaultAnnotations(),
+			WithReadOnlyHintAnnotation(true),
+		)
+
+		data, err := json.Marshal(tool)
+		require.NoError(t, err)
+
+		var parsed map[string]any
+		require.NoError(t, json.Unmarshal(data, &parsed))
+		annotations, ok := parsed["annotations"].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, true, annotations["readOnlyHint"])
+		assert.NotContains(t, annotations, "destructiveHint")
+	})
+
+	t.Run("NewToolWithRawSchema omits annotations when unset", func(t *testing.T) {
+		rawSchema := json.RawMessage(`{"type":"object","properties":{}}`)
+		tool := NewToolWithRawSchema("raw-tool", "Raw tool", rawSchema)
+
+		data, err := json.Marshal(tool)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"annotations"`)
+	})
+
+	t.Run("zero-value ToolAnnotation HasAny is false", func(t *testing.T) {
+		assert.False(t, ToolAnnotation{}.HasAny())
+	})
+
+	t.Run("ToolAnnotation HasAny detects explicit fields", func(t *testing.T) {
+		assert.True(t, ToolAnnotation{Title: "x"}.HasAny())
+		assert.True(t, ToolAnnotation{ReadOnlyHint: ToBoolPtr(false)}.HasAny())
+	})
+}
+
 // Test Tool with both InputSchema and OutputSchema
 
 func TestToolWithBothSchemas(t *testing.T) {


### PR DESCRIPTION
## Summary

Omit the `annotations` field from tool JSON when no annotation values are set, and add `WithoutDefaultAnnotations()` so callers can opt out of `NewTool`'s default hint pointers.

## Motivation

`Tool.MarshalJSON` always included `annotations`, even for tools with no annotation metadata. Clients could not distinguish "explicitly annotated" from "no annotation data available" (see #710).

## Changes

- Add `ToolAnnotation.HasAny()` to detect whether any annotation field is set
- Gate `annotations` in `Tool.MarshalJSON` on `HasAny()`
- Add `WithoutDefaultAnnotations()` `ToolOption` to clear `NewTool` default hints
- Add regression tests for marshal behavior

## Tests

```bash
go test ./mcp/ ./server/ -count=1
```

All tests pass.

## Notes

- `NewTool()` behavior is unchanged: default hint pointers are still serialized for backward compatibility
- Use `NewTool(name, WithoutDefaultAnnotations(), ...)` to omit annotations from `tools/list` output when you have no annotation metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool metadata now omits the `annotations` field in JSON unless annotation hint values are explicitly set, resulting in cleaner output.
  * Added a tool option to start with no default annotation hints, so you can selectively add only the annotation hints you need.
* **Tests**
  * Added coverage to verify correct `annotations` JSON inclusion/omission behavior and helper detection of set annotation values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->