### PR TITLE
fix(server): render readable ErrorKind labels in validation messages

### DIFF
--- a/server/input_validation.go
+++ b/server/input_validation.go
@@ -274,7 +274,7 @@ func formatLeafMessage(verr *jsonschema.ValidationError) string {
 	if location == "" {
 		location = "<root>"
 	}
-	return fmt.Sprintf("%s: %s", location, verr.ErrorKind)
+	return fmt.Sprintf("%s: %+v", location, verr.ErrorKind)
 }
 
 // jsonPointer renders a list of path segments as a RFC 6901 JSON Pointer.

--- a/server/input_validation_test.go
+++ b/server/input_validation_test.go
@@ -339,3 +339,66 @@ func TestInputSchemaValidation_NestedPathInError(t *testing.T) {
 	require.True(t, strings.Contains(tc.Text, "/filter") || strings.Contains(tc.Text, "filter"),
 		"error message should reference the nested path: %s", tc.Text)
 }
+
+// TestInputSchemaValidation_ErrorKindReadable asserts that validation error
+// messages render jsonschema ErrorKind values with named struct fields
+// instead of fmt %s fallback noise like %!s(int=0).
+func TestInputSchemaValidation_ErrorKindReadable(t *testing.T) {
+	srv := NewMCPServer("test", "1.0.0", WithInputSchemaValidation())
+	tool := mcp.Tool{
+		Name: "validated",
+		RawInputSchema: json.RawMessage(`{
+			"type": "object",
+			"properties": {
+				"id": {"type": "number"},
+				"fields": {"type": "object", "minProperties": 1}
+			},
+			"required": ["id", "fields"]
+		}`),
+	}
+	srv.AddTool(tool, okHandler)
+
+	tests := []struct {
+		name          string
+		args          map[string]any
+		wantContains  []string
+		wantNotContains []string
+	}{
+		{
+			name: "minProperties renders Got/Want",
+			args: map[string]any{"id": 23582, "fields": map[string]any{}},
+			wantContains:    []string{"/fields:", "Got:0", "Want:1"},
+			wantNotContains: []string{"%!s"},
+		},
+		{
+			name: "required renders Missing field names",
+			args: map[string]any{"id": 23582},
+			wantContains:    []string{"Missing:[fields]"},
+			wantNotContains: []string{"%!s"},
+		},
+		{
+			name: "type renders Got/Want",
+			args: map[string]any{"id": "abc"},
+			wantContains:    []string{"/id:", "Got:string", "Want:[number]"},
+			wantNotContains: []string{"%!s"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp := callTool(t, srv, tool.Name, tt.args)
+			jr, ok := resp.(mcp.JSONRPCResponse)
+			require.True(t, ok)
+			result, ok := jr.Result.(*mcp.CallToolResult)
+			require.True(t, ok)
+			require.True(t, result.IsError)
+			tc := result.Content[0].(mcp.TextContent)
+			for _, want := range tt.wantContains {
+				require.Contains(t, tc.Text, want, "full message: %s", tc.Text)
+			}
+			for _, omit := range tt.wantNotContains {
+				require.NotContains(t, tc.Text, omit, "full message: %s", tc.Text)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Use `%+v` instead of `%s` when formatting `jsonschema.ValidationError.ErrorKind` values in `formatLeafMessage`, so SEP-1303 input validation errors expose named `Got`/`Want`/`Missing` fields instead of fmt fallback noise like `%!s(int=0)`.

## Motivation

Fixes #914.

`WithInputSchemaValidation()` renders validator output via `formatLeafMessage`. Because `ErrorKind` is a struct (not a `Stringer`), `%s` falls back to `%v` and produces unreadable messages such as `/fields: &{%!s(int=0) %!s(int=1)}`, which defeats the purpose of surfacing validation errors to LLM clients.

## Changes

- `server/input_validation.go`: change `formatLeafMessage` to use `%+v` for `verr.ErrorKind`.
- `server/input_validation_test.go`: add `TestInputSchemaValidation_ErrorKindReadable` covering `minProperties`, `required`, and `type` error kinds from the issue repro.

## Tests

- `go test ./server/ -run TestInputSchemaValidation_ErrorKindReadable -v` — 3 passed
- `go test ./...` — all packages passed

## Notes

- This is a one-line behavioral fix in shared formatting logic; output validation reuses the same helper.
- A future improvement could use upstream `ErrorKind.LocalizedString()` for even friendlier text, but `%+v` fully resolves the reported readability bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the readability of validation error messages when input schema checks fail.
  * Error details now display clearer information instead of confusing formatting artifacts, making it easier to understand what went wrong during tool input validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->