### PR TITLE
fix: deliver server notifications to in-process transport clients

### DIFF
--- a/client/inprocess_test.go
+++ b/client/inprocess_test.go
@@ -2,10 +2,16 @@ package client
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"runtime"
 	"testing"
+	"time"
 
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInProcessMCPClient(t *testing.T) {
@@ -418,4 +424,157 @@ func TestInProcessMCPClient(t *testing.T) {
 			t.Errorf("Expected 1 tool, got %d", len(result.Tools))
 		}
 	})
+}
+
+// TestInProcessMCPClient_Notifications verifies that server-to-client
+// notifications sent during a tool call (e.g. notifications/progress) are
+// actually delivered to the in-process client's registered handler. This is
+// the round-trip regression test for the in-process transport's
+// notification-forwarding goroutine.
+func TestInProcessMCPClient_Notifications(t *testing.T) {
+	mcpServer := server.NewMCPServer(
+		"test-server",
+		"1.0.0",
+		server.WithToolCapabilities(true),
+	)
+
+	mcpServer.AddTool(
+		mcp.NewTool("notify"),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			srv := server.ServerFromContext(ctx)
+			err := srv.SendNotificationToClient(
+				ctx,
+				"notifications/progress",
+				map[string]any{
+					"progress":      10,
+					"total":         10,
+					"progressToken": 0,
+				},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("failed to send notification: %w", err)
+			}
+			return mcp.NewToolResultText("notification sent successfully"), nil
+		},
+	)
+
+	client, err := NewInProcessClient(mcpServer)
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+	defer client.Close()
+
+	received := make(chan mcp.JSONRPCNotification, 1)
+	client.OnNotification(func(notification mcp.JSONRPCNotification) {
+		received <- notification
+	})
+
+	if err := client.Start(t.Context()); err != nil {
+		t.Fatalf("Failed to start client: %v", err)
+	}
+
+	initRequest := mcp.InitializeRequest{}
+	initRequest.Params.ProtocolVersion = mcp.LATEST_PROTOCOL_VERSION
+	initRequest.Params.ClientInfo = mcp.Implementation{
+		Name:    "test-client",
+		Version: "1.0.0",
+	}
+	if _, err := client.Initialize(t.Context(), initRequest); err != nil {
+		t.Fatalf("Failed to initialize: %v", err)
+	}
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "notify"
+	if _, err := client.CallTool(t.Context(), request); err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+
+	select {
+	case notification := <-received:
+		if notification.Method != "notifications/progress" {
+			t.Errorf("Expected notifications/progress, got %s", notification.Method)
+		}
+		progress, ok := notification.Params.AdditionalFields["progress"]
+		if !ok {
+			t.Errorf("Expected progress field in notification params")
+		}
+		if fmt.Sprintf("%v", progress) != "10" {
+			t.Errorf("Expected progress 10, got %v", progress)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Timed out waiting for notification from in-process transport")
+	}
+}
+
+// TestInProcessMCPClient_CloseStopsNotificationForwarding verifies that
+// Close() stops the notification-forwarding goroutine (no leak) and is
+// safe to call more than once.
+func TestInProcessMCPClient_CloseStopsNotificationForwarding(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+
+	const cycles = 5
+	before := runtime.NumGoroutine()
+
+	for range cycles {
+		client, err := NewInProcessClient(mcpServer)
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+
+		if err := client.Start(t.Context()); err != nil {
+			t.Fatalf("Failed to start client: %v", err)
+		}
+
+		if err := client.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+
+		// Closing a second time must not panic and must not double-close
+		// the done channel.
+		if err := client.Close(); err != nil {
+			t.Fatalf("Second Close failed: %v", err)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		runtime.Gosched()
+		return runtime.NumGoroutine()-before <= 1
+	}, 2*time.Second, 20*time.Millisecond, "notification-forwarding goroutine leaked after Close")
+}
+
+// TestInProcessMCPClient_CloseBeforeStart verifies that calling Close()
+// before Start() does not leak the notification-forwarding goroutine. Prior
+// to the fix, Close() called before Start() would find a nil done channel
+// (created lazily in Start()) and no-op, but still consume the sync.Once —
+// so a subsequent Start() would spawn forwardNotifications with no way to
+// ever stop it.
+func TestInProcessMCPClient_CloseBeforeStart(t *testing.T) {
+	mcpServer := server.NewMCPServer("test-server", "1.0.0")
+
+	const cycles = 5
+	before := runtime.NumGoroutine()
+
+	for range cycles {
+		client, err := NewInProcessClient(mcpServer)
+		if err != nil {
+			t.Fatalf("Failed to create client: %v", err)
+		}
+
+		// Close before Start.
+		if err := client.Close(); err != nil {
+			t.Fatalf("Close failed: %v", err)
+		}
+
+		// Start after Close should not spawn a forwarding goroutine that
+		// can never be stopped, and must report the documented
+		// ErrTransportClosed contract.
+		if err := client.Start(t.Context()); !errors.Is(err, transport.ErrTransportClosed) {
+			t.Fatalf("expected ErrTransportClosed from Start after Close, got %v", err)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		runtime.Gosched()
+		return runtime.NumGoroutine()-before <= 1
+	}, 2*time.Second, 20*time.Millisecond, "notification-forwarding goroutine leaked after Close-before-Start")
 }

--- a/client/transport/idempotent_all_transports_test.go
+++ b/client/transport/idempotent_all_transports_test.go
@@ -2,10 +2,14 @@ package transport
 
 import (
 	"context"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/stretchr/testify/require"
 )
 
 // TestSSE_StartIdempotency tests that SSE Start() is idempotent
@@ -108,4 +112,90 @@ func TestInProcessTransport_StartFailureReset(t *testing.T) {
 	if !started {
 		t.Error("Started flag should be true after successful Start()")
 	}
+}
+
+// TestInProcessTransport_ConcurrentStartClose stresses concurrent Start()/Close()
+// calls to guard against the session-registration leak fixed alongside this
+// test: Start() used to re-acquire startedMu a second time (only to assign
+// c.session) without re-checking c.closed, so a Close() that ran between the
+// two lock acquisitions could snapshot session==nil and skip
+// UnregisterSession, while Start() still registered the session -- leaking an
+// entry in the server's session map forever.
+//
+// Start() now performs the closed-check, RegisterSession call, and the
+// c.session/c.started assignment under a single startedMu hold, so Start and
+// Close are mutually exclusive: a concurrent Close either runs entirely
+// before Start's critical section (Start observes c.closed and never
+// registers) or entirely after (Close observes the registered session and
+// unregisters it). Either way registrations and unregistrations stay
+// balanced.
+//
+// This test verifies that invariant under -race across many iterations and
+// checks for goroutine leaks. There is no exported accessor for the live
+// session count on *server.MCPServer (the sessions field is an unexported
+// sync.Map), so instead of asserting on server internals directly, the test
+// uses the exported OnRegisterSession/OnUnregisterSession hooks to count
+// registrations and unregistrations for every transport created across every
+// iteration, then asserts the totals match at the end -- equivalent to
+// asserting zero sessions remain registered, without reaching into
+// unexported state.
+func TestInProcessTransport_ConcurrentStartClose(t *testing.T) {
+	const iterations = 200
+	const startersPerIteration = 4
+
+	var registered, unregistered int64
+
+	baselineGoroutines := runtime.NumGoroutine()
+
+	var outer sync.WaitGroup
+	for i := range iterations {
+		hooks := &server.Hooks{}
+		hooks.AddOnRegisterSession(func(_ context.Context, _ server.ClientSession) {
+			atomic.AddInt64(&registered, 1)
+		})
+		hooks.AddOnUnregisterSession(func(_ context.Context, _ server.ClientSession) {
+			atomic.AddInt64(&unregistered, 1)
+		})
+
+		mcpServer := server.NewMCPServer("test-server", "1.0.0", server.WithHooks(hooks))
+		transport := NewInProcessTransport(mcpServer)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+
+		outer.Add(startersPerIteration + 1)
+		for range startersPerIteration {
+			go func() {
+				defer outer.Done()
+				_ = transport.Start(ctx)
+			}()
+		}
+		go func() {
+			defer outer.Done()
+			_ = transport.Close()
+		}()
+
+		// Bound each iteration so the test can't hang: wait for this
+		// iteration's goroutines before starting the next one.
+		done := make(chan struct{})
+		go func() {
+			outer.Wait()
+			close(done)
+		}()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Fatalf("iteration %d: Start()/Close() goroutines did not complete in time", i)
+		}
+		cancel()
+
+		// Reset the WaitGroup for reuse across iterations.
+		outer = sync.WaitGroup{}
+	}
+
+	require.Equal(t, atomic.LoadInt64(&registered), atomic.LoadInt64(&unregistered),
+		"every registered session must be unregistered; a mismatch indicates the Start()/Close() leak")
+
+	require.Eventually(t, func() bool {
+		return runtime.NumGoroutine() <= baselineGoroutines+2
+	}, 2*time.Second, 50*time.Millisecond, "goroutines leaked after concurrent Start()/Close()")
 }

--- a/client/transport/inprocess.go
+++ b/client/transport/inprocess.go
@@ -21,7 +21,11 @@ type InProcessTransport struct {
 	onNotification func(mcp.JSONRPCNotification)
 	notifyMu       sync.RWMutex
 	started        bool
+	closed         bool
 	startedMu      sync.Mutex
+
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 type InProcessOption func(*InProcessTransport)
@@ -46,7 +50,9 @@ func WithRootsHandler(handler server.RootsHandler) InProcessOption {
 
 func NewInProcessTransport(server *server.MCPServer) *InProcessTransport {
 	return &InProcessTransport{
-		server: server,
+		server:    server,
+		sessionID: server.GenerateInProcessSessionID(),
+		done:      make(chan struct{}),
 	}
 }
 
@@ -54,6 +60,7 @@ func NewInProcessTransportWithOptions(server *server.MCPServer, opts ...InProces
 	t := &InProcessTransport{
 		server:    server,
 		sessionID: server.GenerateInProcessSessionID(),
+		done:      make(chan struct{}),
 	}
 
 	for _, opt := range opts {
@@ -65,24 +72,66 @@ func NewInProcessTransportWithOptions(server *server.MCPServer, opts ...InProces
 
 func (c *InProcessTransport) Start(ctx context.Context) error {
 	c.startedMu.Lock()
+	if c.closed {
+		c.startedMu.Unlock()
+		return ErrTransportClosed
+	}
 	if c.started {
 		c.startedMu.Unlock()
 		return nil
 	}
+
+	// Always create and register a session so server-to-client notifications
+	// (progress, list-changed, resource updates, etc.) have somewhere to land,
+	// in addition to any sampling/elicitation/roots handlers.
+	//
+	// Registration and the c.session/c.started assignments all happen under a
+	// single startedMu hold so that Start and Close are mutually exclusive:
+	// a concurrent Close either runs entirely before this section (observed
+	// via c.closed above, so Start bails out before registering anything) or
+	// entirely after (Close will see c.started and c.session set, and will
+	// unregister the session). There is no window where a session is
+	// registered but Close skips unregistering it. RegisterSession does a
+	// sync.Map store plus runs synchronous OnRegisterSession hooks; neither
+	// re-enters this transport's lock (safe from deadlock); slow user hooks
+	// only extend the lock hold.
+	session := server.NewInProcessSessionWithHandlers(c.sessionID, c.samplingHandler, c.elicitationHandler, c.rootsHandler)
+	if err := c.server.RegisterSession(ctx, session); err != nil {
+		c.startedMu.Unlock()
+		return fmt.Errorf("failed to register session: %w", err)
+	}
+
+	c.session = session
 	c.started = true
 	c.startedMu.Unlock()
 
-	// Create and register session if we have handlers
-	if c.samplingHandler != nil || c.elicitationHandler != nil || c.rootsHandler != nil {
-		c.session = server.NewInProcessSessionWithHandlers(c.sessionID, c.samplingHandler, c.elicitationHandler, c.rootsHandler)
-		if err := c.server.RegisterSession(ctx, c.session); err != nil {
-			c.startedMu.Lock()
-			c.started = false
-			c.startedMu.Unlock()
-			return fmt.Errorf("failed to register session: %w", err)
+	go c.forwardNotifications()
+
+	return nil
+}
+
+// forwardNotifications drains the session's notification channel and
+// forwards each notification to the registered client handler, mirroring
+// the equivalent readResponses notification path in the stdio transport.
+// Runs until Close() closes the done channel.
+func (c *InProcessTransport) forwardNotifications() {
+	notifications := c.session.ClientNotifications()
+	for {
+		select {
+		case <-c.done:
+			return
+		case notification, ok := <-notifications:
+			if !ok {
+				return
+			}
+			c.notifyMu.RLock()
+			handler := c.onNotification
+			c.notifyMu.RUnlock()
+			if handler != nil {
+				handler(notification)
+			}
 		}
 	}
-	return nil
 }
 
 func (c *InProcessTransport) SendRequest(ctx context.Context, request JSONRPCRequest) (*JSONRPCResponse, error) {
@@ -129,8 +178,18 @@ func (c *InProcessTransport) SetNotificationHandler(handler func(notification mc
 }
 
 func (c *InProcessTransport) Close() error {
-	if c.session != nil {
-		c.server.UnregisterSession(context.Background(), c.sessionID)
+	c.startedMu.Lock()
+	c.closed = true
+	session := c.session
+	sessionID := c.sessionID
+	c.startedMu.Unlock()
+
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
+
+	if session != nil {
+		c.server.UnregisterSession(context.Background(), sessionID)
 	}
 	return nil
 }

--- a/server/inprocess_session.go
+++ b/server/inprocess_session.go
@@ -64,6 +64,15 @@ func (s *InProcessSession) NotificationChannel() chan<- mcp.JSONRPCNotification 
 	return s.notifications
 }
 
+// ClientNotifications returns the receive-only endpoint of the session's
+// notification channel. In-process transports use this to drain
+// server-to-client notifications (progress, list-changed, resource
+// updates, etc.) queued via NotificationChannel and forward them to the
+// client's registered notification handler.
+func (s *InProcessSession) ClientNotifications() <-chan mcp.JSONRPCNotification {
+	return s.notifications
+}
+
 func (s *InProcessSession) Initialize() {
 	s.loggingLevel.Store(mcp.LoggingLevelError)
 	s.initialized.Store(true)


### PR DESCRIPTION
## Problem

The in-process transport silently drops server→client notifications.

`SetNotificationHandler` stored the handler on the transport, but nothing ever invoked it. Separately, a session was only created and registered when a sampling/elicitation/roots handler was configured on the client — so a plain `NewInProcessClient` (no such handlers) had no session in context at all. Since `SendNotificationToClient` looks up the session to deliver a notification, it could never reach an in-process client without one of those handlers configured. In practice this meant progress notifications, `list_changed` notifications, and resource update notifications were silently lost for the common case of a bare in-process client.

## Fix

- `InProcessTransport.Start()` now unconditionally creates and registers a session, using `GenerateInProcessSessionID()` for a real session ID (previously this only happened when a sampling/elicitation/roots handler was set).
- Adds a `forwardNotifications` goroutine that drains the session's notification channel and forwards each notification to the client's registered notification handler, mirroring the read-loop forwarding pattern already used by the stdio transport.
- The goroutine is stopped cleanly on `Close()` via `sync.Once`, so it never leaks past shutdown.
- `Start()` and `Close()` are mutually exclusive under a mutex; calling `Start()` after `Close()` returns `ErrTransportClosed` rather than silently registering a new session and spawning a goroutine that could never be stopped. This holds under any interleaving of concurrent `Start`/`Close` calls.
- Adds a read-only `InProcessSession.ClientNotifications()` accessor as the channel `forwardNotifications` drains — no other exported API changes.

## Tests

- `TestInProcessMCPClient_Notifications` — round-trip test asserting a notification/progress event sent during a tool call reaches the in-process client's registered handler.
- `TestInProcessMCPClient_CloseStopsNotificationForwarding` — asserts `Close()` stops the forwarding goroutine (and tolerates being called twice).
- `TestInProcessMCPClient_CloseBeforeStart` — asserts calling `Close()` before `Start()` doesn't leak a goroutine or panic.
- `TestInProcessTransport_ConcurrentStartClose` — exercises concurrent `Start`/`Close` calls under `-race`.

All four pass under `go test -race -count=2 ./client/...`, and the full existing suite (`go test ./...`) remains green.

---

Found this while building an in-process MCP client that needed to receive progress notifications during long-running tool calls — notifications sent via `SendNotificationToClient` were never arriving, and tracing it back led to the two issues above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * In-process sessions now expose a stream of client-facing notifications to support real-time progress updates during tool calls.
* **Bug Fixes**
  * Improved in-process transport shutdown so notification forwarding stops reliably when closing or closing before start.
  * Hardened start/close lifecycle behavior for more stable repeated and concurrent use (including proper handling when already closed).
* **Tests**
  * Added coverage for notification delivery, close behavior, and goroutine-leak prevention under concurrent start/close scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->