### PR TITLE
feat(server): add automatic DNS rebinding protection for localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -730,6 +730,31 @@ Mcp-Session-Id, Last-Event-ID, Authorization` for request headers;
 with `WithCORSAllowCredentials()` echoes the request `Origin` to remain
 spec-compliant.
 
+### DNS rebinding protection for localhost servers
+
+Both HTTP transports automatically protect local servers against
+[DNS rebinding attacks](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise):
+requests arriving over a loopback connection (`127.0.0.1`, `[::1]`) whose
+`Host` header is not a localhost value are rejected with `403 Forbidden`.
+The check is derived from the connection's local address at runtime, so it
+applies whether the server listens on `localhost` or `0.0.0.0`, and never
+affects requests arriving via non-loopback addresses.
+
+If a reverse proxy on the same host forwards requests via localhost while
+preserving the original `Host` header, configure the proxy to rewrite the
+`Host` header to localhost, or opt out explicitly:
+
+```go
+httpServer := server.NewStreamableHTTPServer(mcpServer,
+    // Or server.WithSSEDisableLocalhostProtection(true) on NewSSEServer.
+    server.WithDisableLocalhostProtection(true),
+)
+```
+
+See the [HTTP transport docs](https://mcp-go.dev/transports/http#dns-rebinding-protection)
+for details, including the caveat for the framework-agnostic `Handle` entry
+point.
+
 ### Session Management
 
 MCP-Go provides a robust session management system that allows you to:

--- a/server/http_localhost.go
+++ b/server/http_localhost.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+// isLoopbackHost reports whether addr refers to a loopback interface. addr
+// may be a bare host ("localhost", "127.0.0.1", "::1", "[::1]") or a
+// host:port pair ("localhost:3000", "127.0.0.1:3000", "[::1]:3000").
+//
+// It is used to implement DNS rebinding protection: a request that arrives
+// on a loopback connection must also carry a loopback Host header, otherwise
+// a malicious website could rebind its own domain to 127.0.0.1 and drive a
+// victim's browser to interact with a local MCP server.
+func isLoopbackHost(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		// addr might be a bare host without a port.
+		host = strings.Trim(addr, "[]")
+	}
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip, err := netip.ParseAddr(host)
+	if err != nil {
+		return false
+	}
+	return ip.IsLoopback()
+}
+
+// rejectDNSRebinding applies DNS rebinding protection to r. When the
+// connection's local address (http.LocalAddrContextKey) is a loopback
+// address but the request's Host header is not a loopback value, it writes a
+// 403 Forbidden response and returns true. Otherwise it returns false and
+// writes nothing.
+//
+// Requests arriving via non-loopback addresses are never rejected: DNS
+// rebinding attacks only target servers reachable at localhost from the
+// victim's browser.
+//
+// See https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise
+func rejectDNSRebinding(w http.ResponseWriter, r *http.Request) bool {
+	localAddr, ok := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+	if !ok || localAddr == nil {
+		return false
+	}
+	if isLoopbackHost(localAddr.String()) && !isLoopbackHost(r.Host) {
+		http.Error(w, fmt.Sprintf("Forbidden: invalid Host header %q", r.Host), http.StatusForbidden)
+		return true
+	}
+	return false
+}

--- a/server/http_localhost_test.go
+++ b/server/http_localhost_test.go
@@ -1,0 +1,190 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsLoopbackHost(t *testing.T) {
+	tests := []struct {
+		addr string
+		want bool
+	}{
+		{"localhost", true},
+		{"LocalHost", true},
+		{"localhost:3000", true},
+		{"127.0.0.1", true},
+		{"127.0.0.1:3000", true},
+		{"127.1.2.3:3000", true},
+		{"[::1]", true},
+		{"[::1]:3000", true},
+		{"::1", true},
+		{"", false},
+		{"evil.com", false},
+		{"evil.com:80", false},
+		{"localhost.evil.com", false},
+		{"127.0.0.1.evil.com", false},
+		{"192.168.1.10:8080", false},
+		{"[2001:db8::1]:8080", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.addr, func(t *testing.T) {
+			assert.Equal(t, tt.want, isLoopbackHost(tt.addr), "isLoopbackHost(%q)", tt.addr)
+		})
+	}
+}
+
+// localhostProtectionTests is the shared table for the transport-level DNS
+// rebinding protection tests below.
+var localhostProtectionTests = []struct {
+	name              string
+	hostHeader        string
+	disableProtection bool
+	wantForbidden     bool
+}{
+	{
+		name:       "accepts 127.0.0.1 host header",
+		hostHeader: "127.0.0.1:1234",
+	},
+	{
+		name:       "accepts localhost host header",
+		hostHeader: "localhost:1234",
+	},
+	{
+		name:       "accepts [::1] host header",
+		hostHeader: "[::1]:1234",
+	},
+	{
+		name:          "rejects evil.com",
+		hostHeader:    "evil.com",
+		wantForbidden: true,
+	},
+	{
+		name:          "rejects evil.com:80",
+		hostHeader:    "evil.com:80",
+		wantForbidden: true,
+	},
+	{
+		name:          "rejects localhost.evil.com",
+		hostHeader:    "localhost.evil.com",
+		wantForbidden: true,
+	},
+	{
+		name:              "disabled accepts evil.com",
+		hostHeader:        "evil.com",
+		disableProtection: true,
+	},
+}
+
+// startLoopbackServer serves handler on a real loopback listener so that
+// http.LocalAddrContextKey reflects an actual 127.0.0.1 connection.
+func startLoopbackServer(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	srv := &http.Server{Handler: handler}
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() { _ = srv.Close() })
+	return listener.Addr().String()
+}
+
+// TestStreamableHTTP_LocalhostProtection verifies that DNS rebinding
+// protection is automatically enabled for the streamable HTTP transport when
+// requests arrive over a loopback connection.
+func TestStreamableHTTP_LocalhostProtection(t *testing.T) {
+	for _, tt := range localhostProtectionTests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer := NewMCPServer("test", "1.0.0")
+			httpServer := NewStreamableHTTPServer(mcpServer,
+				WithStateLess(true),
+				WithDisableLocalhostProtection(tt.disableProtection),
+			)
+			addr := startLoopbackServer(t, httpServer)
+
+			body, err := json.Marshal(initRequest)
+			require.NoError(t, err)
+
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/mcp", addr), bytes.NewReader(body))
+			require.NoError(t, err)
+			req.Host = tt.hostHeader
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			if tt.wantForbidden {
+				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+				payload, err := io.ReadAll(resp.Body)
+				require.NoError(t, err)
+				assert.Contains(t, string(payload), "invalid Host header")
+			} else {
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestSSE_LocalhostProtection verifies that DNS rebinding protection is
+// automatically enabled for the SSE transport when requests arrive over a
+// loopback connection.
+func TestSSE_LocalhostProtection(t *testing.T) {
+	for _, tt := range localhostProtectionTests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer := NewMCPServer("test", "1.0.0")
+			sseServer := NewSSEServer(mcpServer,
+				WithSSEDisableLocalhostProtection(tt.disableProtection),
+			)
+			addr := startLoopbackServer(t, sseServer)
+
+			// A POST to the message endpoint without a session is enough to
+			// distinguish the 403 protection response from normal handling
+			// (400 Bad Request for the missing sessionId).
+			req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("http://%s/message", addr), bytes.NewReader(nil))
+			require.NoError(t, err)
+			req.Host = tt.hostHeader
+
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+
+			if tt.wantForbidden {
+				assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+			} else {
+				assert.NotEqual(t, http.StatusForbidden, resp.StatusCode)
+			}
+		})
+	}
+}
+
+// TestStreamableHTTP_LocalhostProtection_NonLoopbackUnaffected verifies that
+// the protection only applies to loopback connections: a handler invoked
+// without a loopback local address must not reject foreign Host headers.
+func TestStreamableHTTP_LocalhostProtection_NonLoopbackUnaffected(t *testing.T) {
+	mcpServer := NewMCPServer("test", "1.0.0")
+	httpServer := NewStreamableHTTPServer(mcpServer, WithStateLess(true))
+
+	// Simulate a request that arrived on a non-loopback interface.
+	body, err := json.Marshal(initRequest)
+	require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodPost, "http://evil.com/mcp", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	localAddr := &net.TCPAddr{IP: net.ParseIP("192.168.1.10"), Port: 8080}
+	req = req.WithContext(context.WithValue(req.Context(), http.LocalAddrContextKey, localAddr))
+
+	rr := httptest.NewRecorder()
+	httpServer.ServeHTTP(rr, req)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}

--- a/server/http_localhost_test.go
+++ b/server/http_localhost_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -88,15 +89,22 @@ var localhostProtectionTests = []struct {
 }
 
 // startLoopbackServer serves handler on a real loopback listener so that
-// http.LocalAddrContextKey reflects an actual 127.0.0.1 connection.
-func startLoopbackServer(t *testing.T, handler http.Handler) string {
+// http.LocalAddrContextKey reflects an actual 127.0.0.1 connection. The
+// server and the returned client both carry explicit timeouts so a stalled
+// handler or connection cannot hang the test run.
+func startLoopbackServer(t *testing.T, handler http.Handler) (addr string, client *http.Client) {
 	t.Helper()
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
-	srv := &http.Server{Handler: handler}
+	srv := &http.Server{
+		Handler:           handler,
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       5 * time.Second,
+		WriteTimeout:      5 * time.Second,
+	}
 	go func() { _ = srv.Serve(listener) }()
 	t.Cleanup(func() { _ = srv.Close() })
-	return listener.Addr().String()
+	return listener.Addr().String(), &http.Client{Timeout: 5 * time.Second}
 }
 
 // TestStreamableHTTP_LocalhostProtection verifies that DNS rebinding
@@ -110,7 +118,7 @@ func TestStreamableHTTP_LocalhostProtection(t *testing.T) {
 				WithStateLess(true),
 				WithDisableLocalhostProtection(tt.disableProtection),
 			)
-			addr := startLoopbackServer(t, httpServer)
+			addr, client := startLoopbackServer(t, httpServer)
 
 			body, err := json.Marshal(initRequest)
 			require.NoError(t, err)
@@ -120,7 +128,7 @@ func TestStreamableHTTP_LocalhostProtection(t *testing.T) {
 			req.Host = tt.hostHeader
 			req.Header.Set("Content-Type", "application/json")
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := client.Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 
@@ -146,7 +154,7 @@ func TestSSE_LocalhostProtection(t *testing.T) {
 			sseServer := NewSSEServer(mcpServer,
 				WithSSEDisableLocalhostProtection(tt.disableProtection),
 			)
-			addr := startLoopbackServer(t, sseServer)
+			addr, client := startLoopbackServer(t, sseServer)
 
 			// A POST to the message endpoint without a session is enough to
 			// distinguish the 403 protection response from normal handling
@@ -155,7 +163,7 @@ func TestSSE_LocalhostProtection(t *testing.T) {
 			require.NoError(t, err)
 			req.Host = tt.hostHeader
 
-			resp, err := http.DefaultClient.Do(req)
+			resp, err := client.Do(req)
 			require.NoError(t, err)
 			defer resp.Body.Close()
 

--- a/server/sse.go
+++ b/server/sse.go
@@ -194,6 +194,11 @@ type SSEServer struct {
 	// WithSSECORS.
 	corsConfig *CORSConfig
 
+	// disableLocalhostProtection, when true, turns off the automatic DNS
+	// rebinding protection applied to requests arriving over loopback
+	// connections. See WithSSEDisableLocalhostProtection.
+	disableLocalhostProtection bool
+
 	mu sync.RWMutex
 }
 
@@ -354,6 +359,30 @@ func WithSSECORS(opts ...CORSOption) SSEOption {
 				opt(s.corsConfig)
 			}
 		}
+	}
+}
+
+// WithSSEDisableLocalhostProtection disables the automatic DNS rebinding
+// protection of the SSE server.
+//
+// By default, requests arriving over a loopback connection (127.0.0.1,
+// [::1]) whose Host header is not a localhost value are rejected with 403
+// Forbidden. This protects local MCP servers against DNS rebinding attacks,
+// where a malicious website rebinds its own domain to 127.0.0.1 to make a
+// victim's browser issue requests against a local server. The protection
+// applies regardless of whether the server listens on localhost specifically
+// or on 0.0.0.0, and never affects requests arriving via non-loopback
+// addresses.
+//
+// Disable it only if you understand the security implications, for example
+// when a reverse proxy on the same host forwards requests via localhost
+// while preserving the original Host header. In that case, prefer
+// configuring the proxy to rewrite the Host header to localhost instead.
+//
+// See https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise
+func WithSSEDisableLocalhostProtection(disable bool) SSEOption {
+	return func(s *SSEServer) {
+		s.disableLocalhostProtection = disable
 	}
 }
 
@@ -851,10 +880,14 @@ func (s *SSEServer) MessageHandler() http.Handler {
 	return s.withCORS(http.HandlerFunc(s.handleMessage))
 }
 
-// withCORS wraps next with CORS preflight and header handling using the
-// SSE server's configured CORSConfig. It is a no-op when CORS is disabled.
+// withCORS wraps next with DNS rebinding protection plus CORS preflight and
+// header handling using the SSE server's configured CORSConfig. The CORS
+// portion is a no-op when CORS is disabled.
 func (s *SSEServer) withCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.disableLocalhostProtection && rejectDNSRebinding(w, r) {
+			return
+		}
 		if s.corsConfig.enabled() {
 			if s.corsConfig.handlePreflight(w, r) {
 				return
@@ -871,7 +904,14 @@ func (s *SSEServer) withCORS(next http.Handler) http.Handler {
 // answered directly and simple cross-origin responses are decorated with the
 // configured Access-Control-* headers before being dispatched to the SSE or
 // message handlers.
+//
+// Requests arriving over a loopback connection with a non-localhost Host
+// header are rejected with 403 Forbidden to protect against DNS rebinding
+// attacks, unless WithSSEDisableLocalhostProtection is set.
 func (s *SSEServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !s.disableLocalhostProtection && rejectDNSRebinding(w, r) {
+		return
+	}
 	if s.corsConfig.enabled() {
 		if s.corsConfig.handlePreflight(w, r) {
 			return

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -111,6 +111,30 @@ func WithDisableStreaming(disable bool) StreamableHTTPOption {
 	}
 }
 
+// WithDisableLocalhostProtection disables the automatic DNS rebinding
+// protection of the streamable HTTP server.
+//
+// By default, requests arriving over a loopback connection (127.0.0.1,
+// [::1]) whose Host header is not a localhost value are rejected with 403
+// Forbidden. This protects local MCP servers against DNS rebinding attacks,
+// where a malicious website rebinds its own domain to 127.0.0.1 to make a
+// victim's browser issue requests against a local server. The protection
+// applies regardless of whether the server listens on localhost specifically
+// or on 0.0.0.0, and never affects requests arriving via non-loopback
+// addresses.
+//
+// Disable it only if you understand the security implications, for example
+// when a reverse proxy on the same host forwards requests via localhost
+// while preserving the original Host header. In that case, prefer
+// configuring the proxy to rewrite the Host header to localhost instead.
+//
+// See https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise
+func WithDisableLocalhostProtection(disable bool) StreamableHTTPOption {
+	return func(s *StreamableHTTPServer) {
+		s.disableLocalhostProtection = disable
+	}
+}
+
 // WithHTTPContextFunc sets a function that will be called to customise the context
 // to the server using the incoming request.
 // This can be used to inject context values from headers, for example.
@@ -257,6 +281,11 @@ type StreamableHTTPServer struct {
 	sessionLogLevels         *sessionLogLevelsStore
 	disableStreaming         bool
 
+	// disableLocalhostProtection, when true, turns off the automatic DNS
+	// rebinding protection applied to requests arriving over loopback
+	// connections. See WithDisableLocalhostProtection.
+	disableLocalhostProtection bool
+
 	tlsCertFile string
 	tlsKeyFile  string
 
@@ -322,9 +351,16 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 // requests are answered directly and simple cross-origin responses are
 // decorated with the configured Access-Control-* headers before dispatch.
 //
+// Requests arriving over a loopback connection with a non-localhost Host
+// header are rejected with 403 Forbidden to protect against DNS rebinding
+// attacks, unless WithDisableLocalhostProtection is set.
+//
 // ServeHTTP is the conventional net/http entry point; for non-net/http HTTP
 // frameworks (fasthttp, fiber, etc.), see Handle.
 func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if !s.disableLocalhostProtection && rejectDNSRebinding(w, r) {
+		return
+	}
 	if s.corsConfig.enabled() {
 		if s.corsConfig.handlePreflight(w, r) {
 			return

--- a/server/streamable_http_handle.go
+++ b/server/streamable_http_handle.go
@@ -175,6 +175,10 @@ func writeHTTPErrorf(w HTTPResponseWriter, code int, format string, args ...any)
 //
 //   - WithStreamableHTTPCORS is NOT applied. Frameworks should use their
 //     native CORS middleware.
+//   - DNS rebinding protection is NOT applied, because Handle has no access
+//     to the connection's local address. Adapters for localhost-reachable
+//     servers should validate the Host header themselves (reject non-loopback
+//     Host values on loopback connections with 403 Forbidden).
 //   - WithProtectedResourceMetadata is NOT applied. The caller should mount
 //     the metadata route separately if needed (see ProtectedResourceMetadataHandler).
 //   - WithHTTPContextFunc is honored for backwards compatibility; it receives

--- a/www/docs/pages/transports/http.mdx
+++ b/www/docs/pages/transports/http.mdx
@@ -759,6 +759,50 @@ The auto-mount options (`WithProtectedResourceMetadata` /
 CORS is enabled with `Access-Control-Allow-Origin: *` so browser-based MCP
 clients can perform discovery cross-origin.
 
+### DNS Rebinding Protection
+
+Local MCP servers are a prime target for [DNS rebinding attacks](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise):
+a malicious website rebinds its own domain to `127.0.0.1`, letting the
+victim's browser issue what it considers same-origin requests against a
+server running on the victim's machine. CORS does not stop this — after
+rebinding, the browser sees a same-origin request and applies no
+cross-origin restrictions.
+
+Both HTTP transports therefore validate the `Host` header automatically.
+When a request arrives over a loopback connection (`127.0.0.1`, `[::1]`)
+but its `Host` header is not a localhost value (`localhost`, a `127.0.0.0/8`
+address, or `[::1]`, with or without a port), the request is rejected with
+`403 Forbidden`.
+
+The protection is enabled by default and requires no configuration:
+
+- It is detected at runtime from the connection's local address
+  (`http.LocalAddrContextKey`), so it applies whether the server listens on
+  `localhost` or `0.0.0.0`.
+- Requests arriving via non-loopback addresses (external traffic) are
+  never affected.
+
+**Reverse proxies:** if a proxy (nginx, Envoy, ...) on the same host
+forwards requests to the MCP server via localhost while preserving the
+original `Host` header, those requests would be rejected. Prefer
+configuring the proxy to rewrite the `Host` header to localhost;
+alternatively, opt out explicitly:
+
+```go
+httpServer := server.NewStreamableHTTPServer(mcpServer,
+    // Only disable this if you understand the security implications.
+    server.WithDisableLocalhostProtection(true),
+)
+```
+
+Use `server.WithSSEDisableLocalhostProtection(true)` for the
+[SSE transport](/transports/sse#sse-server-options).
+
+The protection applies to `ServeHTTP` (and the SSE handlers) only. The
+framework-agnostic [`Handle`](#embedding-in-non-nethttp-frameworks) entry
+point has no access to the connection's local address, so adapters must
+enforce the check themselves — see [Behavior Notes](#behavior-notes).
+
 ### Cross-Origin Resource Sharing (CORS)
 
 The MCP endpoints themselves are **not** CORS-enabled by default — every
@@ -1146,6 +1190,12 @@ func mcpHandler(ctx *fasthttp.RequestCtx) {
 
 - **`WithStreamableHTTPCORS` is not applied** when entering through
   `Handle`. Use the framework's native CORS middleware.
+- **DNS rebinding protection is not applied** when entering through
+  `Handle`, because it has no access to the connection's local address.
+  Adapters for localhost-reachable servers should reject requests that
+  arrive on a loopback connection with a non-loopback `Host` header,
+  answering `403 Forbidden`. See
+  [DNS Rebinding Protection](#dns-rebinding-protection) above.
 - **`WithProtectedResourceMetadata` is not applied** when entering through
   `Handle`. Mount the metadata route separately using
   `NewProtectedResourceMetadataHandler`. See

--- a/www/docs/pages/transports/sse.mdx
+++ b/www/docs/pages/transports/sse.mdx
@@ -304,6 +304,17 @@ compatibility, while the message endpoint emits no CORS headers.
 See the [Streamable HTTP CORS docs](/transports/http#cross-origin-resource-sharing-cors)
 for the full list of `CORSOption` helpers shared between both transports.
 
+The SSE server also ships with automatic
+[DNS rebinding protection](/transports/http#dns-rebinding-protection):
+requests arriving over a loopback connection (`127.0.0.1`, `[::1]`) whose
+`Host` header is not a localhost value are rejected with `403 Forbidden`.
+This is enabled by default and covers `ServeHTTP` as well as the
+`SSEHandler()`/`MessageHandler()` sub-handlers. Use
+`server.WithSSEDisableLocalhostProtection(true)` to opt out, for example
+behind a same-host reverse proxy that preserves the original `Host` header
+(prefer configuring the proxy to rewrite the `Host` header to localhost
+instead).
+
 **Resulting endpoints:**
 - SSE stream: `http://localhost:8080/api/mcp/sse`
 - Message endpoint: `http://localhost:8080/api/mcp/message`


### PR DESCRIPTION
## Description

Adds automatic DNS rebinding protection to both HTTP transports (streamable HTTP and SSE). Requests that arrive over a loopback connection (`127.0.0.1`, `[::1]`) but carry a non-localhost `Host` header are now rejected with `403 Forbidden`.

This closes a real gap for local MCP servers: a malicious website can rebind its own domain to `127.0.0.1` and drive a victim's browser to interact with a local server. CORS does not help here — after rebinding, the browser considers the request same-origin. Only server-side `Host` header validation stops the attack, as called out in the [MCP security best practices](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise).

The design ports [modelcontextprotocol/go-sdk#760](https://github.com/modelcontextprotocol/go-sdk/pull/760) and is **secure by default**:

- The connection's local address is detected at runtime via `http.LocalAddrContextKey`, so protection applies whether the server listens on `localhost` or `0.0.0.0` — no code changes or opt-in needed for existing servers.
- Requests arriving via non-loopback addresses (external traffic) are never affected.
- Opt-out is explicit, for reverse proxies on the same host that forward via localhost while preserving the original `Host` header:

```go
// Streamable HTTP
httpServer := server.NewStreamableHTTPServer(mcpServer,
    server.WithDisableLocalhostProtection(true),
)

// SSE
sseServer := server.NewSSEServer(mcpServer,
    server.WithSSEDisableLocalhostProtection(true),
)
```

For SSE, the check covers `ServeHTTP` as well as the `SSEHandler()`/`MessageHandler()` sub-handlers (dynamic base path mode). The framework-agnostic `Handle` entry point has no access to the connection's local address, so its docs now instruct fasthttp/fiber adapters to enforce the check themselves (same pattern as the existing CORS caveat).

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Security Best Practices — Local MCP Server Compromise](https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise)
- [x] Implementation follows the specification exactly

## Additional Information

**Added:**

- `server/http_localhost.go` — `isLoopbackHost` helper and `rejectDNSRebinding` check shared by both transports
- `server/http_localhost_test.go` — table-driven tests over real loopback listeners (so `http.LocalAddrContextKey` is genuinely populated), covering accept/reject cases for both transports, the opt-out, and non-loopback connections being unaffected

**Modified:**

- `server/streamable_http.go` — check at the top of `ServeHTTP`; new `WithDisableLocalhostProtection` option
- `server/sse.go` — check in `ServeHTTP` and the `withCORS` wrapper; new `WithSSEDisableLocalhostProtection` option
- `server/streamable_http_handle.go` — documented that `Handle` cannot apply the protection and what adapters must do
- `README.md`, `www/docs/pages/transports/http.mdx`, `www/docs/pages/transports/sse.mdx` — documentation for the new behavior and opt-outs

**Backwards compatibility:** no public API changes or removals. The new default only affects loopback connections whose `Host` header is not a localhost value — i.e. exactly the DNS rebinding attack pattern. Legitimate localhost clients (which send `Host: localhost:...` / `127.0.0.1:...`) are unaffected; the full test suite passes unchanged with `-race`. Same-host reverse proxies that preserve a foreign `Host` header need either the opt-out or a `Host` rewrite (documented).

**Verification:** `go test ./... -race` passes, `golangci-lint run` reports 0 issues, `npx vocs build` succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DNS rebinding protection for HTTP and SSE servers, rejecting loopback-origin requests when the `Host` header isn’t a localhost value.
  * Added configuration options to disable this protection (HTTP and SSE have separate opt-outs).
* **Bug Fixes**
  * Loopback requests now consistently return **403 Forbidden** with an “invalid Host header” response body when `Host` doesn’t match localhost.
  * Protection is enforced on `ServeHTTP`-based paths, not on the transport-agnostic `Handle` path.
* **Documentation**
  * Updated HTTP and SSE transport docs and README with behavior details, reverse-proxy guidance, and opt-out instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->