### PR TITLE
fix(server): label client JSON-RPC errors by method in streamable HTTP

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -995,7 +995,10 @@ func (s *StreamableHTTPServer) handleSamplingResponse(w HTTPResponseWriter, r *H
 		if err := json.Unmarshal(responseMessage.Error, &jsonrpcError); err != nil {
 			response.err = fmt.Errorf("failed to parse error: %v", err)
 		} else {
-			response.err = fmt.Errorf("sampling error %d: %s", jsonrpcError.Code, jsonrpcError.Message)
+			// Defer building the final error to deliverSamplingResponse, which
+			// knows which method (sampling/createMessage, elicitation/create, or
+			// roots/list) this response corresponds to.
+			response.clientError = &clientJSONRPCError{code: jsonrpcError.Code, message: jsonrpcError.Message}
 		}
 	} else if responseMessage.Result != nil {
 		// Store the result to be unmarshaled later
@@ -1032,17 +1035,30 @@ func (s *StreamableHTTPServer) deliverSamplingResponse(w HTTPResponseWriter, ses
 		return fmt.Errorf("invalid session type for session %s", sessionID)
 	}
 
-	// Look up the dedicated response channel for this specific request
-	responseChannelInterface, exists := session.samplingRequests.Load(response.requestID)
+	// Look up the dedicated pending request for this specific request ID.
+	pendingInterface, exists := session.samplingRequests.Load(response.requestID)
 	if !exists {
 		writeHTTPError(w, "No pending sampling request found for the given request ID", http.StatusBadRequest)
 		return fmt.Errorf("no pending request found for session %s, request %d", sessionID, response.requestID)
 	}
 
-	responseChan, ok := responseChannelInterface.(chan samplingResponseItem)
+	pending, ok := pendingInterface.(pendingClientRequest)
 	if !ok {
 		writeHTTPError(w, "Failed to deliver response", http.StatusInternalServerError)
-		return fmt.Errorf("invalid response channel type for session %s, request %d", sessionID, response.requestID)
+		return fmt.Errorf("invalid pending request type for session %s, request %d", sessionID, response.requestID)
+	}
+	responseChan := pending.response
+
+	// If the client returned a JSON-RPC error, label it with the method that
+	// actually failed. This shared path serves sampling/createMessage,
+	// elicitation/create and roots/list, so a generic "sampling error" prefix
+	// would misattribute elicitation and roots failures (see #817).
+	if response.clientError != nil {
+		method := pending.method
+		if method == "" {
+			method = mcp.MethodSamplingCreateMessage
+		}
+		response.err = fmt.Errorf("%s error %d: %s", method, response.clientError.code, response.clientError.message)
 	}
 
 	// Attempt to deliver the response with timeout to prevent indefinite blocking
@@ -1310,6 +1326,26 @@ type samplingResponseItem struct {
 	requestID int64
 	result    json.RawMessage
 	err       error
+	// clientError is set when the client returned a JSON-RPC error object.
+	// deliverSamplingResponse turns it into err, labeled with the pending
+	// request's method (sampling/createMessage, elicitation/create, roots/list).
+	clientError *clientJSONRPCError
+}
+
+// clientJSONRPCError holds a JSON-RPC error returned by the client in response
+// to a server-initiated request (sampling, elicitation, or roots).
+type clientJSONRPCError struct {
+	code    int
+	message string
+}
+
+// pendingClientRequest tracks a server-initiated request that is awaiting a
+// client response. Recording the method alongside the response channel lets
+// deliverSamplingResponse attribute a client-returned JSON-RPC error to the
+// method that actually failed instead of always reporting "sampling".
+type pendingClientRequest struct {
+	method   mcp.MCPMethod
+	response chan samplingResponseItem
 }
 
 // Elicitation support types for HTTP transport
@@ -1446,7 +1482,10 @@ func (s *streamableHttpSession) RequestSampling(ctx context.Context, request mcp
 	}
 
 	// Store the pending request
-	s.samplingRequests.Store(requestID, responseChan)
+	s.samplingRequests.Store(requestID, pendingClientRequest{
+		method:   mcp.MethodSamplingCreateMessage,
+		response: responseChan,
+	})
 	defer s.samplingRequests.Delete(requestID)
 
 	// Send the sampling request via the channel (non-blocking)
@@ -1503,7 +1542,10 @@ func (s *streamableHttpSession) ListRoots(ctx context.Context, request mcp.ListR
 	}
 
 	// Store the pending request
-	s.samplingRequests.Store(requestID, responseChan)
+	s.samplingRequests.Store(requestID, pendingClientRequest{
+		method:   mcp.MethodListRoots,
+		response: responseChan,
+	})
 	defer s.samplingRequests.Delete(requestID)
 
 	// Send the list roots request via the channel (non-blocking)
@@ -1548,7 +1590,10 @@ func (s *streamableHttpSession) RequestElicitation(ctx context.Context, request 
 	}
 
 	// Store the pending request
-	s.samplingRequests.Store(requestID, responseChan)
+	s.samplingRequests.Store(requestID, pendingClientRequest{
+		method:   mcp.MethodElicitationCreate,
+		response: responseChan,
+	})
 	defer s.samplingRequests.Delete(requestID)
 
 	// Send the sampling request via the channel (non-blocking)

--- a/server/streamable_http_sampling_error_label_test.go
+++ b/server/streamable_http_sampling_error_label_test.go
@@ -1,0 +1,89 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestStreamableHTTPServer_ClientErrorLabeledByMethod verifies that a JSON-RPC
+// error returned by the client is surfaced with the method that actually
+// failed. handleSamplingResponse is the shared response path for
+// sampling/createMessage, elicitation/create and roots/list, so a generic
+// "sampling error" prefix previously misattributed elicitation and roots
+// failures (see #817).
+func TestStreamableHTTPServer_ClientErrorLabeledByMethod(t *testing.T) {
+	cases := []struct {
+		name    string
+		method  mcp.MCPMethod
+		wantErr string
+	}{
+		{"sampling", mcp.MethodSamplingCreateMessage, "sampling/createMessage error -32601: Method not found"},
+		{"elicitation", mcp.MethodElicitationCreate, "elicitation/create error -32601: Method not found"},
+		{"roots", mcp.MethodListRoots, "roots/list error -32601: Method not found"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mcpServer := NewMCPServer("test-server", "1.0.0")
+			httpServer := NewStreamableHTTPServer(mcpServer, WithStateLess(true)) // any session ID validates
+
+			const sessionID = "test-session"
+			session := newStreamableHttpSession(sessionID, nil, nil, nil, nil)
+			httpServer.activeSessions.Store(sessionID, session)
+
+			const requestID int64 = 1
+			respChan := make(chan samplingResponseItem, 1)
+			session.samplingRequests.Store(requestID, pendingClientRequest{
+				method:   tc.method,
+				response: respChan,
+			})
+
+			// Mirror the anonymous struct that handleSamplingResponse accepts.
+			responseMessage := struct {
+				ID     json.RawMessage `json:"id"`
+				Result json.RawMessage `json:"result,omitempty"`
+				Error  json.RawMessage `json:"error,omitempty"`
+				Method mcp.MCPMethod   `json:"method,omitempty"`
+			}{
+				ID:    json.RawMessage("1"),
+				Error: json.RawMessage(`{"code":-32601,"message":"Method not found"}`),
+			}
+
+			header := http.Header{}
+			header.Set(HeaderKeySessionID, sessionID)
+			r := &HTTPRequest{
+				Method:  http.MethodPost,
+				URL:     &url.URL{Path: "/mcp"},
+				Header:  header,
+				Context: t.Context(),
+			}
+			w := newBufferingHTTPResponseWriter()
+
+			if err := httpServer.handleSamplingResponse(w, r, responseMessage); err != nil {
+				t.Fatalf("handleSamplingResponse returned error: %v", err)
+			}
+
+			select {
+			case resp := <-respChan:
+				if resp.err == nil {
+					t.Fatalf("expected a delivered error, got nil")
+				}
+				if got := resp.err.Error(); got != tc.wantErr {
+					t.Errorf("error = %q, want %q", got, tc.wantErr)
+				}
+				if tc.method != mcp.MethodSamplingCreateMessage &&
+					strings.HasPrefix(resp.err.Error(), "sampling error") {
+					t.Errorf("%s failure was mislabeled as sampling: %q", tc.method, resp.err.Error())
+				}
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for the delivered response")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description

`handleSamplingResponse` in `server/streamable_http.go` is the shared response path for **sampling/createMessage**, **elicitation/create**, and **roots/list**. When the client returns a JSON-RPC error, it was always wrapped as:

```go
response.err = fmt.Errorf("sampling error %d: %s", jsonrpcError.Code, jsonrpcError.Message)
```

So an `elicitation/create` failure surfaced to the server as `sampling error -32601: Method not found`, even though sampling never ran. Callers that need to tell "client doesn't support elicitation" from "sampling failed" had to string-match the wrapped message, which is fragile.

Fixes #817.

## Changes

- Track the method of each pending server-initiated request alongside its response channel (`pendingClientRequest{method, response}`) instead of storing a bare channel in `session.samplingRequests`.
- Carry the client's JSON-RPC error through to `deliverSamplingResponse` (via `samplingResponseItem.clientError`) and build the final error there, where the method is known.
- Errors are now labeled `"<method> error <code>: <msg>"`, e.g. `elicitation/create error -32601: Method not found` / `roots/list error -32601: Method not found` / `sampling/createMessage error -32601: Method not found`.

This is the "minimal" option suggested in #817. The numeric JSON-RPC code is preserved in the message, so existing code-based workarounds keep working. The stdio transport already routes elicitation through a separate handler, so this only affects the streamable HTTP path.

## Tests

- Added `TestStreamableHTTPServer_ClientErrorLabeledByMethod` (table-driven over sampling / elicitation / roots) asserting the method-labeled message and that elicitation/roots are no longer mislabeled as `sampling error`.
- `go test ./server/ ./mcp/` passes; `go build ./...`, `go vet ./server/`, and `gofmt` are clean.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] I have updated the documentation accordingly (n/a — internal behavior)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Client-side JSON-RPC errors are now shown with the correct method label, making failures easier to understand.
  * Error messages for sampling, elicitation, and roots requests are no longer grouped under a generic label.
  * Missing or malformed pending request data now returns clearer HTTP errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->