### PR TITLE
fix(client): accept Content-Type parameters on GET listening stream

### DIFF
--- a/client/transport/streamable_http.go
+++ b/client/transport/streamable_http.go
@@ -999,10 +999,11 @@ func (c *StreamableHTTP) createGETConnectionToServer(ctx context.Context) error 
 		return fmt.Errorf("request failed with status %d: %s", resp.StatusCode, body)
 	}
 
-	// handle SSE response
-	contentType := resp.Header.Get("Content-Type")
-	if contentType != "text/event-stream" {
-		return fmt.Errorf("unexpected content type: %s", contentType)
+	// handle SSE response. Parse the media type to tolerate parameters such as
+	// "text/event-stream; charset=utf-8" (same handling as SendRequest).
+	mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+	if mediaType != "text/event-stream" {
+		return fmt.Errorf("unexpected content type: %s", resp.Header.Get("Content-Type"))
 	}
 
 	// When ignoreResponse is true, the function will never return expect context is done.

--- a/client/transport/streamable_http_test.go
+++ b/client/transport/streamable_http_test.go
@@ -895,6 +895,111 @@ func TestContinuousListeningMethodNotAllowed(t *testing.T) {
 	}
 }
 
+// TestContinuousListeningContentTypeWithCharset verifies that the GET
+// listening stream accepts a Content-Type carrying media-type parameters
+// (e.g. "text/event-stream; charset=utf-8"). Servers built on frameworks
+// that append a charset to text/* responses (such as the Python MCP SDK,
+// via Starlette) send exactly this header, and the stream must still be
+// treated as SSE rather than rejected as an unexpected content type.
+func TestContinuousListeningContentTypeWithCharset(t *testing.T) {
+	origRetryInterval := retryInterval
+	retryInterval = 10 * time.Millisecond
+	defer func() { retryInterval = origRetryInterval }()
+
+	var mu sync.Mutex
+	var sessionID string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPost:
+			var request map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			sessionID = "charset-test-session"
+			mu.Unlock()
+			w.Header().Set("Mcp-Session-Id", sessionID)
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			if err := json.NewEncoder(w).Encode(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      request["id"],
+				"result":  "initialized",
+			}); err != nil {
+				http.Error(w, "Failed to encode response", http.StatusInternalServerError)
+			}
+		case http.MethodGet:
+			mu.Lock()
+			expected := sessionID
+			mu.Unlock()
+			if recvSessionID := r.Header.Get("Mcp-Session-Id"); recvSessionID != expected {
+				http.Error(w, "Invalid session ID", http.StatusNotFound)
+				return
+			}
+			// Include a charset parameter, as Starlette-based servers do.
+			w.Header().Set("Content-Type", "text/event-stream; charset=utf-8")
+			w.WriteHeader(http.StatusOK)
+			flusher, ok := w.(http.Flusher)
+			if !ok {
+				http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+				return
+			}
+			notification := map[string]any{
+				"jsonrpc": "2.0",
+				"method":  "test/notification",
+				"params":  map[string]any{"message": "Hello from server"},
+			}
+			notificationData, _ := json.Marshal(notification)
+			fmt.Fprintf(w, "event: message\ndata: %s\n\n", notificationData)
+			flusher.Flush()
+			<-r.Context().Done()
+		}
+	}))
+
+	trans, err := NewStreamableHTTP(server.URL, WithContinuousListening())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		trans.Close()
+		server.Close()
+	}()
+
+	notificationReceived := make(chan struct{}, 1)
+	trans.SetNotificationHandler(func(notification mcp.JSONRPCNotification) {
+		select {
+		case notificationReceived <- struct{}{}:
+		default:
+		}
+	})
+
+	if err := trans.Start(t.Context()); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	initRequest := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(0)),
+		Method:  "initialize",
+	}
+	if _, err := trans.SendRequest(ctx, initRequest); err != nil {
+		t.Fatal(err)
+	}
+
+	// The notification only arrives if the GET stream was accepted despite
+	// the charset parameter in the Content-Type header.
+	select {
+	case <-notificationReceived:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Timed out waiting for notification: GET stream with " +
+			"\"text/event-stream; charset=utf-8\" was not accepted")
+	}
+}
+
 func TestContinuousListeningSessionTerminated(t *testing.T) {
 	// Use a short retry interval so we can verify no retries happen quickly.
 	origRetryInterval := retryInterval


### PR DESCRIPTION
## Description

The continuous-listening GET stream (`createGETConnectionToServer`) validates the
response `Content-Type` with plain string equality:

```go
contentType := resp.Header.Get("Content-Type")
if contentType != "text/event-stream" {
    return fmt.Errorf("unexpected content type: %s", contentType)
}
```

Any header carrying media-type parameters is rejected. This is not a theoretical
case: servers built on Starlette (including the official Python MCP SDK, which
serves its GET stream through sse-starlette) append a charset to every `text/*`
response, so they send `text/event-stream; charset=utf-8`. RFC 9110 §8.3 allows
parameters on media types, and the MCP spec mandates UTF-8 anyway.

The practical impact when a `WithContinuousListening()` client talks to such a
server:

- `listenForever` gets an error that matches neither `ErrGetMethodNotAllowed`
  nor `ErrSessionTerminated`, so it logs `failed to listen to server. retry in
  1 second` and re-issues the GET every second, forever.
- Server-to-client notifications (`notifications/tools/list_changed` etc.) are
  silently never delivered.

The POST path in the same file already handles this correctly via
`mime.ParseMediaType` (added in #210), and the server side got the equivalent
fix in #478 (closes #501). The GET listening path was the remaining spot with a
raw string comparison. This PR applies the same treatment there:

```go
mediaType, _, _ := mime.ParseMediaType(resp.Header.Get("Content-Type"))
if mediaType != "text/event-stream" {
    return fmt.Errorf("unexpected content type: %s", resp.Header.Get("Content-Type"))
}
```

Also adds `TestContinuousListeningContentTypeWithCharset`, which spins up an
httptest server whose GET handler responds with
`text/event-stream; charset=utf-8` and asserts a notification is actually
delivered. The test fails on `main` (times out after 1s-interval retries) and
passes with this change.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly (no doc surface for this)

## Additional Information

Repro without this patch: connect an mcp-go client with
`WithContinuousListening()` to any Python MCP SDK streamable-HTTP server and
watch the client log `failed to listen to server. retry in 1 second` in a loop
while `tools/list_changed` notifications never arrive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with server-sent event streams that include additional parameters in the `Content-Type` header, such as `charset=utf-8`.
  * Continuous listening now accepts valid SSE responses with parameterized media types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->