### PR TITLE
fix(streamable_http): close active sessions before Shutdown

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -458,6 +458,8 @@ func (s *StreamableHTTPServer) Shutdown(ctx context.Context) error {
 		s.sweeperCancel()
 	}
 
+	s.CloseSessions()
+
 	// shutdown the server if needed (may use as a http.Handler)
 	s.mu.RLock()
 	srv := s.httpServer
@@ -466,6 +468,35 @@ func (s *StreamableHTTPServer) Shutdown(ctx context.Context) error {
 		return srv.Shutdown(ctx)
 	}
 	return nil
+}
+
+// CloseSessions terminates all active streamable HTTP listening sessions
+// without stopping the HTTP server. This unblocks long-lived GET handlers so
+// Shutdown can complete while clients are still connected.
+func (s *StreamableHTTPServer) CloseSessions() {
+	sessionIDs := make([]string, 0)
+	s.activeSessions.Range(func(key, value any) bool {
+		sessionID, ok := key.(string)
+		if !ok {
+			return true
+		}
+		if session, ok := value.(*streamableHttpSession); ok {
+			session.closeDone()
+		}
+		sessionIDs = append(sessionIDs, sessionID)
+		return true
+	})
+
+	mgr := s.sessionIdManager
+	if mgr == nil {
+		mgr = s.sessionIdManagerResolver.ResolveSessionIdManager(nil)
+	}
+
+	ctx := context.Background()
+	for _, sessionID := range sessionIDs {
+		_, _ = mgr.Terminate(sessionID)
+		s.cleanupSessionState(ctx, sessionID)
+	}
 }
 
 // --- internal methods ---
@@ -912,6 +943,8 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 			s.touchSession(sessionID)
 		case <-ctx.Done():
 			return
+		case <-session.done:
+			return
 		}
 	}
 }
@@ -1332,6 +1365,8 @@ type rootsRequestItem struct {
 type streamableHttpSession struct {
 	clientInfoStore // provides Get/SetClientInfo and Get/SetClientCapabilities via method promotion
 
+	done                chan struct{}
+	doneOnce            sync.Once
 	sessionID           string
 	notificationChannel chan mcp.JSONRPCNotification // server -> client notifications
 	tools               *sessionToolsStore
@@ -1351,6 +1386,7 @@ type streamableHttpSession struct {
 
 func newStreamableHttpSession(sessionID string, toolStore *sessionToolsStore, resourcesStore *sessionResourcesStore, templatesStore *sessionResourceTemplatesStore, levels *sessionLogLevelsStore) *streamableHttpSession {
 	s := &streamableHttpSession{
+		done:                   make(chan struct{}),
 		sessionID:              sessionID,
 		notificationChannel:    make(chan mcp.JSONRPCNotification, 100),
 		tools:                  toolStore,
@@ -1362,6 +1398,14 @@ func newStreamableHttpSession(sessionID string, toolStore *sessionToolsStore, re
 		rootsRequestChan:       make(chan rootsRequestItem, 10),
 	}
 	return s
+}
+
+// closeDone safely closes the session's done channel exactly once,
+// allowing long-lived GET handlers to exit during server shutdown.
+func (s *streamableHttpSession) closeDone() {
+	s.doneOnce.Do(func() {
+		close(s.done)
+	})
 }
 
 func (s *streamableHttpSession) SessionID() string {

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -458,22 +458,41 @@ func (s *StreamableHTTPServer) Shutdown(ctx context.Context) error {
 		s.sweeperCancel()
 	}
 
-	s.CloseSessions()
+	s.CloseSessions(ctx)
 
 	// shutdown the server if needed (may use as a http.Handler)
 	s.mu.RLock()
 	srv := s.httpServer
 	s.mu.RUnlock()
-	if srv != nil {
-		return srv.Shutdown(ctx)
+	if srv == nil {
+		return nil
 	}
-	return nil
+
+	shutdownDone := make(chan error, 1)
+	go func() {
+		shutdownDone <- srv.Shutdown(ctx)
+	}()
+
+	drainTicker := time.NewTicker(5 * time.Millisecond)
+	defer drainTicker.Stop()
+
+	for {
+		select {
+		case err := <-shutdownDone:
+			return err
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-drainTicker.C:
+			// Drain sessions registered after the initial CloseSessions snapshot.
+			s.CloseSessions(ctx)
+		}
+	}
 }
 
 // CloseSessions terminates all active streamable HTTP listening sessions
 // without stopping the HTTP server. This unblocks long-lived GET handlers so
 // Shutdown can complete while clients are still connected.
-func (s *StreamableHTTPServer) CloseSessions() {
+func (s *StreamableHTTPServer) CloseSessions(ctx context.Context) {
 	sessionIDs := make([]string, 0)
 	s.activeSessions.Range(func(key, value any) bool {
 		sessionID, ok := key.(string)
@@ -492,9 +511,10 @@ func (s *StreamableHTTPServer) CloseSessions() {
 		mgr = s.sessionIdManagerResolver.ResolveSessionIdManager(nil)
 	}
 
-	ctx := context.Background()
 	for _, sessionID := range sessionIDs {
-		_, _ = mgr.Terminate(sessionID)
+		if _, err := mgr.Terminate(sessionID); err != nil {
+			s.logger.Warn("failed to terminate session during CloseSessions", "sessionID", sessionID, "err", err)
+		}
 		s.cleanupSessionState(ctx, sessionID)
 	}
 }

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -3082,7 +3082,9 @@ func TestStreamableHTTP_CloseSessions(t *testing.T) {
 	})
 	require.Equal(t, 0, sessionCount)
 
-	resp2, err := http.Get(ts.URL)
+	req2, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	resp2, err := http.DefaultClient.Do(req2)
 	require.NoError(t, err)
 	defer resp2.Body.Close()
 	require.Equal(t, http.StatusOK, resp2.StatusCode)

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -3006,7 +3006,7 @@ func TestStreamableHTTP_ShutdownWithActiveConnection(t *testing.T) {
 		serveDone <- customServer.Serve(listener)
 	}()
 	t.Cleanup(func() {
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		defer cancel()
 		_ = httpServer.Shutdown(shutdownCtx)
 		select {

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2984,3 +2984,78 @@ func TestStreamableHTTP_SamplingResponseErrors(t *testing.T) {
 		assert.Contains(t, string(body), "No pending sampling request")
 	})
 }
+
+func TestStreamableHTTP_ShutdownWithActiveConnection(t *testing.T) {
+	mcpServer := NewMCPServer("test", "1.0.0")
+	httpServer := NewStreamableHTTPServer(mcpServer, WithStateful(true))
+
+	ts := httptest.NewServer(httpServer)
+	defer ts.Close()
+
+	ctx := t.Context()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	sessionCount := 0
+	httpServer.activeSessions.Range(func(_, _ any) bool {
+		sessionCount++
+		return true
+	})
+	require.Greater(t, sessionCount, 0)
+
+	shutdownDone := make(chan error, 1)
+	shutdownCtx, shutdownCancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer shutdownCancel()
+	go func() {
+		shutdownDone <- httpServer.Shutdown(shutdownCtx)
+	}()
+
+	select {
+	case err := <-shutdownDone:
+		if shutdownCtx.Err() == context.DeadlineExceeded {
+			t.Fatalf("Shutdown deadlocked (timed out): %v", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("Shutdown did not return in time (likely deadlocked)")
+	}
+}
+
+func TestStreamableHTTP_CloseSessions(t *testing.T) {
+	mcpServer := NewMCPServer("test", "1.0.0")
+	httpServer := NewStreamableHTTPServer(mcpServer, WithStateful(true))
+
+	ts := httptest.NewServer(httpServer)
+	defer ts.Close()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	sessionCount := 0
+	httpServer.activeSessions.Range(func(_, _ any) bool {
+		sessionCount++
+		return true
+	})
+	require.Greater(t, sessionCount, 0)
+
+	httpServer.CloseSessions()
+
+	sessionCount = 0
+	httpServer.activeSessions.Range(func(_, _ any) bool {
+		sessionCount++
+		return true
+	})
+	require.Equal(t, 0, sessionCount)
+
+	resp2, err := http.Get(ts.URL)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	require.Equal(t, http.StatusOK, resp2.StatusCode)
+}

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -5,8 +5,10 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -2987,13 +2989,39 @@ func TestStreamableHTTP_SamplingResponseErrors(t *testing.T) {
 
 func TestStreamableHTTP_ShutdownWithActiveConnection(t *testing.T) {
 	mcpServer := NewMCPServer("test", "1.0.0")
-	httpServer := NewStreamableHTTPServer(mcpServer, WithStateful(true))
+	mux := http.NewServeMux()
+	customServer := &http.Server{Handler: mux}
+	httpServer := NewStreamableHTTPServer(
+		mcpServer,
+		WithStateful(true),
+		WithStreamableHTTPServer(customServer),
+	)
+	mux.Handle(httpServer.endpointPath, httpServer)
 
-	ts := httptest.NewServer(httpServer)
-	defer ts.Close()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	serveDone := make(chan error, 1)
+	go func() {
+		serveDone <- customServer.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = httpServer.Shutdown(shutdownCtx)
+		select {
+		case err := <-serveDone:
+			if err != nil && !errors.Is(err, http.ErrServerClosed) {
+				t.Logf("Serve returned: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+		}
+	})
+
+	baseURL := "http://" + listener.Addr().String() + httpServer.endpointPath
 
 	ctx := t.Context()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL, nil)
 	require.NoError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
@@ -3045,7 +3073,7 @@ func TestStreamableHTTP_CloseSessions(t *testing.T) {
 	})
 	require.Greater(t, sessionCount, 0)
 
-	httpServer.CloseSessions()
+	httpServer.CloseSessions(t.Context())
 
 	sessionCount = 0
 	httpServer.activeSessions.Range(func(_, _ any) bool {


### PR DESCRIPTION
## Summary

Close active streamable HTTP listening sessions before calling `http.Server.Shutdown`, so graceful shutdown does not hang while clients remain connected.

## Motivation

Fixes #922. `StreamableHTTPServer.Shutdown()` could block indefinitely when long-lived GET handlers were still open, because `http.Server.Shutdown` waits for active handlers to finish.

## Changes

- Add a per-session `done` signal to `streamableHttpSession` with `closeDone()`
- Have `handleGet` return when the session is closed
- Add `CloseSessions()` to terminate active listeners and clean up session state
- Call `CloseSessions()` from `Shutdown()` before stopping the HTTP server
- Add regression tests for shutdown with an active GET connection and for `CloseSessions()`

## Tests

- `go test ./server -run 'TestStreamableHTTP_ShutdownWithActiveConnection|TestStreamableHTTP_CloseSessions' -count=1` — PASS
- `go test ./server -count=1` — PASS

## Notes

Mirrors the existing SSE server shutdown pattern (`CloseSessions` + `Shutdown`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new method to explicitly close all active streaming HTTP GET sessions.
* **Bug Fixes**
  * Improved server shutdown reliability by ensuring active sessions are terminated before completing shutdown.
  * Ensured long-lived streaming requests stop promptly during shutdown.
* **Tests**
  * Added regression tests to prevent shutdown timeouts when active connections exist.
  * Added coverage verifying session cleanup works and the server can continue to handle requests afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->