### PR TITLE
feat(server): add streamable HTTP stream resumability via pluggable EventStore

### DIFF
--- a/e2e/resumability_http_test.go
+++ b/e2e/resumability_http_test.go
@@ -67,6 +67,10 @@ func (r *recordingStore) ReplayEventsAfter(ctx context.Context, sessionID, lastE
 	return r.inner.ReplayEventsAfter(ctx, sessionID, lastEventID, send)
 }
 
+func (r *recordingStore) PurgeSession(ctx context.Context, sessionID string) error {
+	return r.inner.PurgeSession(ctx, sessionID)
+}
+
 // waitTotalStored blocks until at least n events have been recorded in total.
 func (r *recordingStore) waitTotalStored(t *testing.T, n int) {
 	t.Helper()
@@ -293,7 +297,7 @@ func openGET(t *testing.T, ts *httptest.Server, sessionID, lastEventID string) (
 // startToolCall POSTs a tools/call for the emitter tool and returns a channel
 // yielding the response once its headers arrive (i.e. once the response
 // upgrades to SSE or completes).
-func startToolCall(t *testing.T, ts *httptest.Server, sessionID string, requestID int) (<-chan *http.Response, context.CancelFunc) {
+func startToolCall(t *testing.T, ts *httptest.Server, sessionID string, requestID int) (<-chan postResult, context.CancelFunc) {
 	t.Helper()
 	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
@@ -303,23 +307,28 @@ func startToolCall(t *testing.T, ts *httptest.Server, sessionID string, requestI
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set(sessionHeader, sessionID)
 
-	ch := make(chan *http.Response, 1)
+	ch := make(chan postResult, 1)
 	go func() {
 		resp, err := http.DefaultClient.Do(req)
-		if err != nil {
-			return
-		}
-		ch <- resp
+		ch <- postResult{resp: resp, err: err}
 	}()
 	return ch, cancel
 }
 
-func waitResponse(t *testing.T, ch <-chan *http.Response) *http.Response {
+// postResult carries the outcome of an asynchronous POST: the response once
+// its headers arrived, or the request error.
+type postResult struct {
+	resp *http.Response
+	err  error
+}
+
+func waitResponse(t *testing.T, ch <-chan postResult) *http.Response {
 	t.Helper()
 	select {
-	case resp := <-ch:
-		t.Cleanup(func() { _ = resp.Body.Close() })
-		return resp
+	case r := <-ch:
+		require.NoError(t, r.err, "tools/call request failed")
+		t.Cleanup(func() { _ = r.resp.Body.Close() })
+		return r.resp
 	case <-time.After(waitTimeout):
 		t.Fatal("timed out waiting for HTTP response headers")
 		return nil
@@ -559,6 +568,40 @@ func TestResumability_UnknownLastEventID(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp2.StatusCode)
 }
 
+// Terminating a session purges its recorded events: an event id that resumed
+// fine while the session lived is rejected after DELETE.
+func TestResumability_TerminatedSessionCannotResume(t *testing.T) {
+	mcpServer, ts, _ := startServer(t, server.NewInMemoryEventStore())
+	sid := initSession(t, ts)
+
+	resp, cancelGET := openGET(t, ts, sid, "")
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	br := bufio.NewReader(resp.Body)
+
+	sendNotification(t, mcpServer, sid, "n1")
+	sendNotification(t, mcpServer, sid, "n2")
+	ev := requireEvent(t, br)
+	require.NotEmpty(t, ev.id)
+	cancelGET()
+
+	// While the session lives, ev.id resumes and redelivers n2.
+	resumed, cancelResumed := openGET(t, ts, sid, ev.id)
+	require.Equal(t, http.StatusOK, resumed.StatusCode)
+	require.Equal(t, "n2", notificationData(t, requireEvent(t, bufio.NewReader(resumed.Body)).data))
+	cancelResumed()
+
+	req, err := http.NewRequest(http.MethodDelete, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set(sessionHeader, sid)
+	delResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer delResp.Body.Close()
+	require.Equal(t, http.StatusOK, delResp.StatusCode)
+
+	rejected, _ := openGET(t, ts, sid, ev.id)
+	assert.Equal(t, http.StatusBadRequest, rejected.StatusCode)
+}
+
 // An event id recorded for one session cannot be used to resume from another
 // session.
 func TestResumability_CrossSessionRejected(t *testing.T) {
@@ -701,9 +744,11 @@ func (f *fakeStore) StoreEvent(_ context.Context, sessionID, streamID string, me
 	return id, nil
 }
 
+func (f *fakeStore) PurgeSession(context.Context, string) error { return nil }
+
 func (f *fakeStore) ReplayEventsAfter(_ context.Context, _ string, lastEventID string, send func(eventID string, message json.RawMessage) error) (string, error) {
 	if lastEventID != "custom~1*id" {
-		return "", fmt.Errorf("unknown event id %q", lastEventID)
+		return "", fmt.Errorf("%w: %q", server.ErrUnknownEventID, lastEventID)
 	}
 	f.mu.Lock()
 	events := make([]sseEvent, len(f.replayEvents))

--- a/e2e/resumability_http_test.go
+++ b/e2e/resumability_http_test.go
@@ -1,0 +1,726 @@
+package e2e
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+const sessionHeader = "Mcp-Session-Id"
+
+const waitTimeout = 15 * time.Second
+
+// ---------------------------------------------------------------------------
+// Store instrumentation
+// ---------------------------------------------------------------------------
+
+type storeCall struct {
+	sessionID string
+	streamID  string
+	message   json.RawMessage
+	eventID   string
+}
+
+// recordingStore wraps the in-memory store and tracks every recorded event,
+// so tests can wait for messages produced while no client is connected
+// without polling or timing assumptions.
+type recordingStore struct {
+	inner  server.EventStore
+	mu     sync.Mutex
+	calls  []storeCall
+	stored chan struct{}
+}
+
+func newRecordingStore() *recordingStore {
+	return &recordingStore{
+		inner:  server.NewInMemoryEventStore(),
+		stored: make(chan struct{}, 4096),
+	}
+}
+
+func (r *recordingStore) StoreEvent(ctx context.Context, sessionID, streamID string, message json.RawMessage) (string, error) {
+	id, err := r.inner.StoreEvent(ctx, sessionID, streamID, message)
+	msg := make(json.RawMessage, len(message))
+	copy(msg, message)
+	r.mu.Lock()
+	r.calls = append(r.calls, storeCall{sessionID: sessionID, streamID: streamID, message: msg, eventID: id})
+	r.mu.Unlock()
+	r.stored <- struct{}{}
+	return id, err
+}
+
+func (r *recordingStore) ReplayEventsAfter(ctx context.Context, sessionID, lastEventID string, send func(eventID string, message json.RawMessage) error) (string, error) {
+	return r.inner.ReplayEventsAfter(ctx, sessionID, lastEventID, send)
+}
+
+// waitTotalStored blocks until at least n events have been recorded in total.
+func (r *recordingStore) waitTotalStored(t *testing.T, n int) {
+	t.Helper()
+	deadline := time.After(waitTimeout)
+	for {
+		r.mu.Lock()
+		count := len(r.calls)
+		r.mu.Unlock()
+		if count >= n {
+			return
+		}
+		select {
+		case <-r.stored:
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d events to be recorded, have %d", n, count)
+		}
+	}
+}
+
+func (r *recordingStore) snapshot() []storeCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]storeCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// SSE wire helpers
+// ---------------------------------------------------------------------------
+
+type sseEvent struct {
+	id   string
+	data json.RawMessage
+}
+
+// readSSEEvent reads the next SSE event from br. It accepts both "field:value"
+// and "field: value" forms and returns io.EOF once the stream ends.
+func readSSEEvent(br *bufio.Reader) (sseEvent, error) {
+	var ev sseEvent
+	seen := false
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return sseEvent{}, err
+		}
+		line = strings.TrimRight(line, "\r\n")
+		if line == "" {
+			if seen {
+				return ev, nil
+			}
+			continue
+		}
+		field, value, _ := strings.Cut(line, ":")
+		value = strings.TrimPrefix(value, " ")
+		switch field {
+		case "id":
+			ev.id = value
+			seen = true
+		case "data":
+			ev.data = json.RawMessage(value)
+			seen = true
+		case "event":
+			seen = true
+		}
+	}
+}
+
+// requireEvent reads one SSE event, failing the test on error or timeout.
+func requireEvent(t *testing.T, br *bufio.Reader) sseEvent {
+	t.Helper()
+	type result struct {
+		ev  sseEvent
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ev, err := readSSEEvent(br)
+		ch <- result{ev, err}
+	}()
+	select {
+	case r := <-ch:
+		require.NoError(t, r.err, "reading SSE event")
+		return r.ev
+	case <-time.After(waitTimeout):
+		t.Fatal("timed out waiting for an SSE event")
+		return sseEvent{}
+	}
+}
+
+// requireEOF asserts that the stream ends without any further events.
+func requireEOF(t *testing.T, br *bufio.Reader) {
+	t.Helper()
+	type result struct {
+		ev  sseEvent
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		ev, err := readSSEEvent(br)
+		ch <- result{ev, err}
+	}()
+	select {
+	case r := <-ch:
+		require.ErrorIs(t, r.err, io.EOF, "expected end of stream, got event %q / error %v", string(r.ev.data), r.err)
+	case <-time.After(waitTimeout):
+		t.Fatal("timed out waiting for the stream to end")
+	}
+}
+
+// notificationData extracts params.data from a notifications/message payload.
+func notificationData(t *testing.T, raw json.RawMessage) string {
+	t.Helper()
+	var n struct {
+		Method string `json:"method"`
+		Params struct {
+			Data string `json:"data"`
+		} `json:"params"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &n))
+	require.Equal(t, "notifications/message", n.Method)
+	return n.Params.Data
+}
+
+// toolResponse parses a JSON-RPC tools/call response payload.
+func toolResponse(t *testing.T, raw json.RawMessage) (int, string) {
+	t.Helper()
+	var rpc struct {
+		ID     int `json:"id"`
+		Result struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+		} `json:"result"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &rpc))
+	require.NotEmpty(t, rpc.Result.Content, "expected tool result content in %s", string(raw))
+	return rpc.ID, rpc.Result.Content[0].Text
+}
+
+// ---------------------------------------------------------------------------
+// Server and HTTP helpers
+// ---------------------------------------------------------------------------
+
+// startServer builds an MCP server with two tools: "emitter", which sends a
+// notifications/message per command received on the returned channel until
+// told to return, and "quiet", which returns immediately without streaming.
+func startServer(t *testing.T, store server.EventStore) (*server.MCPServer, *httptest.Server, chan string) {
+	t.Helper()
+	mcpServer := server.NewMCPServer("resumability-test-server", "1.0.0")
+
+	cmds := make(chan string, 32)
+	closeCmds := sync.OnceFunc(func() { close(cmds) })
+
+	mcpServer.AddTool(mcp.NewTool("emitter"), func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		for cmd := range cmds {
+			if cmd == "return" {
+				break
+			}
+			if err := mcpServer.SendNotificationToClient(ctx, "notifications/message", map[string]any{"data": cmd}); err != nil {
+				return nil, fmt.Errorf("send notification: %w", err)
+			}
+		}
+		return mcp.NewToolResultText("done"), nil
+	})
+	mcpServer.AddTool(mcp.NewTool("quiet"), func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		return mcp.NewToolResultText("quiet-done"), nil
+	})
+
+	var opts []server.StreamableHTTPOption
+	if store != nil {
+		opts = append(opts, server.WithEventStore(store))
+	}
+	ts := server.NewTestStreamableHTTPServer(mcpServer, opts...)
+	t.Cleanup(ts.Close)
+	// Unblock any emitter call still waiting for commands, so shutting the
+	// test server down cannot hang on an in-flight request.
+	t.Cleanup(closeCmds)
+	return mcpServer, ts, cmds
+}
+
+func initSession(t *testing.T, ts *httptest.Server) string {
+	t.Helper()
+	initBody := fmt.Sprintf(
+		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":%q,"clientInfo":{"name":"resume-test","version":"1.0.0"},"capabilities":{}}}`,
+		mcp.LATEST_PROTOCOL_VERSION,
+	)
+	resp, err := http.Post(ts.URL, "application/json", strings.NewReader(initBody))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	sessionID := resp.Header.Get(sessionHeader)
+	require.NotEmpty(t, sessionID, "initialize response must carry a session ID")
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(sessionHeader, sessionID)
+	resp2, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	require.Equal(t, http.StatusAccepted, resp2.StatusCode)
+	return sessionID
+}
+
+// openGET opens a listening (or, with lastEventID, resuming) GET stream.
+func openGET(t *testing.T, ts *httptest.Server, sessionID, lastEventID string) (*http.Response, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set(sessionHeader, sessionID)
+	if lastEventID != "" {
+		req.Header.Set("Last-Event-ID", lastEventID)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp, cancel
+}
+
+// startToolCall POSTs a tools/call for the emitter tool and returns a channel
+// yielding the response once its headers arrive (i.e. once the response
+// upgrades to SSE or completes).
+func startToolCall(t *testing.T, ts *httptest.Server, sessionID string, requestID int) (<-chan *http.Response, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+	body := fmt.Sprintf(`{"jsonrpc":"2.0","id":%d,"method":"tools/call","params":{"name":"emitter","arguments":{}}}`, requestID)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.URL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(sessionHeader, sessionID)
+
+	ch := make(chan *http.Response, 1)
+	go func() {
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return
+		}
+		ch <- resp
+	}()
+	return ch, cancel
+}
+
+func waitResponse(t *testing.T, ch <-chan *http.Response) *http.Response {
+	t.Helper()
+	select {
+	case resp := <-ch:
+		t.Cleanup(func() { _ = resp.Body.Close() })
+		return resp
+	case <-time.After(waitTimeout):
+		t.Fatal("timed out waiting for HTTP response headers")
+		return nil
+	}
+}
+
+func sendNotification(t *testing.T, s *server.MCPServer, sessionID, data string) {
+	t.Helper()
+	require.NoError(t, s.SendNotificationToSpecificClient(sessionID, "notifications/message", map[string]any{"data": data}))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// Without an event store configured, behavior is unchanged: SSE events carry
+// no id fields, on either the listening stream or an upgraded POST response.
+func TestResumability_NoEventStoreNoIDs(t *testing.T) {
+	mcpServer, ts, cmds := startServer(t, nil)
+
+	// Listening stream, on its own session.
+	sidA := initSession(t, ts)
+	resp, _ := openGET(t, ts, sidA, "")
+	br := bufio.NewReader(resp.Body)
+	sendNotification(t, mcpServer, sidA, "n1")
+	ev := requireEvent(t, br)
+	assert.Empty(t, ev.id, "events must not carry ids without an event store")
+	assert.Equal(t, "n1", notificationData(t, ev.data))
+
+	// Upgraded POST response, on a separate session so notification routing
+	// is unambiguous.
+	sidB := initSession(t, ts)
+	respCh, _ := startToolCall(t, ts, sidB, 7)
+	cmds <- "p1"
+	postResp := waitResponse(t, respCh)
+	pbr := bufio.NewReader(postResp.Body)
+	evP := requireEvent(t, pbr)
+	assert.Empty(t, evP.id)
+	assert.Equal(t, "p1", notificationData(t, evP.data))
+	cmds <- "return"
+	evR := requireEvent(t, pbr)
+	assert.Empty(t, evR.id)
+	id, text := toolResponse(t, evR.data)
+	assert.Equal(t, 7, id)
+	assert.Equal(t, "done", text)
+}
+
+// With a store, live events on the listening stream carry unique, non-empty
+// ids and arrive in order.
+func TestResumability_ListeningStreamEventIDs(t *testing.T) {
+	store := newRecordingStore()
+	mcpServer, ts, _ := startServer(t, store)
+	sid := initSession(t, ts)
+
+	resp, _ := openGET(t, ts, sid, "")
+	br := bufio.NewReader(resp.Body)
+
+	seen := map[string]bool{}
+	for i, want := range []string{"n1", "n2", "n3"} {
+		sendNotification(t, mcpServer, sid, want)
+		ev := requireEvent(t, br)
+		require.NotEmpty(t, ev.id, "event %d must carry an id", i+1)
+		require.False(t, seen[ev.id], "event ids must be unique, got %q twice", ev.id)
+		seen[ev.id] = true
+		assert.Equal(t, want, notificationData(t, ev.data))
+	}
+}
+
+// Notifications produced while the listening client is disconnected are
+// recorded and replayed, in order and with their original ids, and the
+// resumed connection then continues receiving live.
+func TestResumability_ListeningStreamResume(t *testing.T) {
+	store := newRecordingStore()
+	mcpServer, ts, _ := startServer(t, store)
+	sid := initSession(t, ts)
+
+	resp1, cancel1 := openGET(t, ts, sid, "")
+	br1 := bufio.NewReader(resp1.Body)
+	sendNotification(t, mcpServer, sid, "n1")
+	sendNotification(t, mcpServer, sid, "n2")
+	_ = requireEvent(t, br1)
+	ev2 := requireEvent(t, br1)
+	require.NotEmpty(t, ev2.id)
+
+	// Drop the connection, then produce messages while nobody is listening.
+	cancel1()
+	sendNotification(t, mcpServer, sid, "n3")
+	sendNotification(t, mcpServer, sid, "n4")
+	store.waitTotalStored(t, 4)
+
+	// Resume after n2: exactly n3 and n4 come back, then delivery goes live.
+	resp2, cancel2 := openGET(t, ts, sid, ev2.id)
+	br2 := bufio.NewReader(resp2.Body)
+	ev3 := requireEvent(t, br2)
+	assert.Equal(t, "n3", notificationData(t, ev3.data))
+	require.NotEmpty(t, ev3.id)
+	ev4 := requireEvent(t, br2)
+	assert.Equal(t, "n4", notificationData(t, ev4.data))
+	require.NotEmpty(t, ev4.id)
+
+	sendNotification(t, mcpServer, sid, "n5")
+	ev5 := requireEvent(t, br2)
+	assert.Equal(t, "n5", notificationData(t, ev5.data))
+
+	// Resuming again replays with the ids the events were originally
+	// assigned.
+	cancel2()
+	store.waitTotalStored(t, 5)
+	resp3, _ := openGET(t, ts, sid, ev3.id)
+	br3 := bufio.NewReader(resp3.Body)
+	ev4again := requireEvent(t, br3)
+	assert.Equal(t, "n4", notificationData(t, ev4again.data))
+	assert.Equal(t, ev4.id, ev4again.id, "replayed events keep their original ids")
+	ev5again := requireEvent(t, br3)
+	assert.Equal(t, "n5", notificationData(t, ev5again.data))
+	assert.Equal(t, ev5.id, ev5again.id)
+}
+
+// When a POST connection breaks while its request is executing, the
+// notifications the handler goes on to emit and its response are recorded;
+// resuming from the last event the client saw redelivers them and the stream
+// closes once the response has been delivered.
+func TestResumability_InterruptedRequestCaptured(t *testing.T) {
+	store := newRecordingStore()
+	_, ts, cmds := startServer(t, store)
+	sid := initSession(t, ts)
+
+	respCh, cancelPost := startToolCall(t, ts, sid, 42)
+	cmds <- "p1"
+	postResp := waitResponse(t, respCh)
+	br := bufio.NewReader(postResp.Body)
+	evP1 := requireEvent(t, br)
+	require.NotEmpty(t, evP1.id)
+	require.Equal(t, "p1", notificationData(t, evP1.data))
+
+	// Kill the connection mid-request, then let the handler finish its work.
+	cancelPost()
+	cmds <- "p2"
+	cmds <- "p3"
+	cmds <- "return"
+	store.waitTotalStored(t, 4) // p1, p2, p3, response
+
+	resp2, _ := openGET(t, ts, sid, evP1.id)
+	br2 := bufio.NewReader(resp2.Body)
+	evP2 := requireEvent(t, br2)
+	assert.Equal(t, "p2", notificationData(t, evP2.data))
+	evP3 := requireEvent(t, br2)
+	assert.Equal(t, "p3", notificationData(t, evP3.data))
+	evR := requireEvent(t, br2)
+	id, text := toolResponse(t, evR.data)
+	assert.Equal(t, 42, id)
+	assert.Equal(t, "done", text)
+
+	// The request's response has been delivered; the resumed stream ends.
+	requireEOF(t, br2)
+}
+
+// Replay never mixes streams: resuming from an event of one request stream
+// redelivers only that stream's messages, and ids are unique across all of a
+// session's streams.
+func TestResumability_StreamIsolationAndUniqueIDs(t *testing.T) {
+	store := newRecordingStore()
+	_, ts, cmds := startServer(t, store)
+	sid := initSession(t, ts)
+
+	// Request A: one live notification, then interrupted; finishes detached.
+	respChA, cancelA := startToolCall(t, ts, sid, 1)
+	cmds <- "a1"
+	respA := waitResponse(t, respChA)
+	brA := bufio.NewReader(respA.Body)
+	evA1 := requireEvent(t, brA)
+	require.Equal(t, "a1", notificationData(t, evA1.data))
+	cancelA()
+	cmds <- "a2"
+	cmds <- "return"
+	store.waitTotalStored(t, 3) // a1, a2, response A
+
+	// Request B: runs to completion normally after A is done.
+	respChB, _ := startToolCall(t, ts, sid, 2)
+	cmds <- "b1"
+	respB := waitResponse(t, respChB)
+	brB := bufio.NewReader(respB.Body)
+	evB1 := requireEvent(t, brB)
+	require.Equal(t, "b1", notificationData(t, evB1.data))
+	cmds <- "return"
+	evBR := requireEvent(t, brB)
+	idB, _ := toolResponse(t, evBR.data)
+	require.Equal(t, 2, idB)
+	store.waitTotalStored(t, 5)
+
+	// Resuming from a1 yields a2 and A's response, and nothing of B's.
+	resp, _ := openGET(t, ts, sid, evA1.id)
+	br := bufio.NewReader(resp.Body)
+	evA2 := requireEvent(t, br)
+	assert.Equal(t, "a2", notificationData(t, evA2.data))
+	evAR := requireEvent(t, br)
+	idA, textA := toolResponse(t, evAR.data)
+	assert.Equal(t, 1, idA)
+	assert.Equal(t, "done", textA)
+	requireEOF(t, br)
+
+	// Resuming from b1 yields only B's response.
+	resp2, _ := openGET(t, ts, sid, evB1.id)
+	br2 := bufio.NewReader(resp2.Body)
+	evBR2 := requireEvent(t, br2)
+	idB2, _ := toolResponse(t, evBR2.data)
+	assert.Equal(t, 2, idB2)
+	assert.Equal(t, evBR.id, evBR2.id, "replayed events keep their original ids")
+	requireEOF(t, br2)
+
+	// All ids observed in the session are distinct.
+	ids := []string{evA1.id, evA2.id, evAR.id, evB1.id, evBR.id}
+	seen := map[string]bool{}
+	for _, id := range ids {
+		require.NotEmpty(t, id)
+		require.False(t, seen[id], "event id %q is not unique within the session", id)
+		seen[id] = true
+	}
+}
+
+// A Last-Event-ID the store has never issued is rejected with 400, whether
+// or not the session has recorded events.
+func TestResumability_UnknownLastEventID(t *testing.T) {
+	store := newRecordingStore()
+	mcpServer, ts, _ := startServer(t, store)
+	sid := initSession(t, ts)
+
+	resp, _ := openGET(t, ts, sid, "no-such-event")
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	// Record something, then still reject an unknown id.
+	respGET, _ := openGET(t, ts, sid, "")
+	sendNotification(t, mcpServer, sid, "n1")
+	_ = requireEvent(t, bufio.NewReader(respGET.Body))
+
+	resp2, _ := openGET(t, ts, sid, "still-not-an-id")
+	assert.Equal(t, http.StatusBadRequest, resp2.StatusCode)
+}
+
+// An event id recorded for one session cannot be used to resume from another
+// session.
+func TestResumability_CrossSessionRejected(t *testing.T) {
+	store := newRecordingStore()
+	mcpServer, ts, _ := startServer(t, store)
+
+	sidA := initSession(t, ts)
+	respA, _ := openGET(t, ts, sidA, "")
+	brA := bufio.NewReader(respA.Body)
+	sendNotification(t, mcpServer, sidA, "a1")
+	evA := requireEvent(t, brA)
+	require.NotEmpty(t, evA.id)
+
+	sidB := initSession(t, ts)
+	respB, _ := openGET(t, ts, sidB, "")
+	brB := bufio.NewReader(respB.Body)
+	sendNotification(t, mcpServer, sidB, "b1")
+	_ = requireEvent(t, brB)
+
+	resp, _ := openGET(t, ts, sidB, evA.id)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode, "another session's event id must not resume this session")
+}
+
+// The event store is genuinely pluggable: ids the store issues are used
+// verbatim however they look, StoreEvent receives a consistent stream
+// identifier and the exact delivered payload, replayed events are whatever
+// the store sends, and a store error on resume maps to 400.
+func TestResumability_CustomStore(t *testing.T) {
+	fake := &fakeStore{
+		replayEvents: []sseEvent{
+			{id: "made-up/2", data: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/message","params":{"data":"fabricated-1"}}`)},
+			{id: "made-up/3", data: json.RawMessage(`{"jsonrpc":"2.0","method":"notifications/message","params":{"data":"fabricated-2"}}`)},
+		},
+	}
+	mcpServer, ts, _ := startServer(t, fake)
+	sid := initSession(t, ts)
+
+	resp, _ := openGET(t, ts, sid, "")
+	br := bufio.NewReader(resp.Body)
+	sendNotification(t, mcpServer, sid, "n1")
+	ev1 := requireEvent(t, br)
+	assert.Equal(t, "custom~1*id", ev1.id, "store-issued ids must be used verbatim")
+	sendNotification(t, mcpServer, sid, "n2")
+	ev2 := requireEvent(t, br)
+	assert.Equal(t, "custom~2*id", ev2.id)
+
+	calls := fake.snapshot()
+	require.Len(t, calls, 2)
+	assert.Equal(t, sid, calls[0].sessionID)
+	assert.Equal(t, calls[0].streamID, calls[1].streamID, "one stream must keep one stream id")
+	assert.NotEmpty(t, calls[0].streamID)
+	assert.JSONEq(t, string(ev1.data), string(calls[0].message), "the recorded message must be the delivered message")
+
+	// Replay comes straight from the store.
+	resp2, _ := openGET(t, ts, sid, "custom~1*id")
+	br2 := bufio.NewReader(resp2.Body)
+	evR1 := requireEvent(t, br2)
+	assert.Equal(t, "made-up/2", evR1.id)
+	assert.Equal(t, "fabricated-1", notificationData(t, evR1.data))
+	evR2 := requireEvent(t, br2)
+	assert.Equal(t, "made-up/3", evR2.id)
+	assert.Equal(t, "fabricated-2", notificationData(t, evR2.data))
+	requireEOF(t, br2)
+
+	// A store that cannot resolve the id means 400.
+	resp3, _ := openGET(t, ts, sid, "unresolvable")
+	assert.Equal(t, http.StatusBadRequest, resp3.StatusCode)
+}
+
+// Responses returned as plain JSON are not part of any stream and are not
+// recorded.
+func TestResumability_PlainJSONNotRecorded(t *testing.T) {
+	store := newRecordingStore()
+	_, ts, _ := startServer(t, store)
+	sid := initSession(t, ts)
+
+	req, err := http.NewRequest(http.MethodPost, ts.URL, strings.NewReader(`{"jsonrpc":"2.0","id":9,"method":"tools/call","params":{"name":"quiet","arguments":{}}}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(sessionHeader, sid)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Contains(t, resp.Header.Get("Content-Type"), "application/json")
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	id, text := toolResponse(t, body)
+	assert.Equal(t, 9, id)
+	assert.Equal(t, "quiet-done", text)
+
+	assert.Empty(t, store.snapshot(), "plain JSON responses must not be recorded")
+}
+
+// A reconnect for a stream supersedes an earlier connection still attached to
+// it: the old connection is closed and delivery continues on the new one.
+func TestResumability_ReconnectSupersedes(t *testing.T) {
+	store := newRecordingStore()
+	mcpServer, ts, _ := startServer(t, store)
+	sid := initSession(t, ts)
+
+	resp1, _ := openGET(t, ts, sid, "")
+	br1 := bufio.NewReader(resp1.Body)
+	sendNotification(t, mcpServer, sid, "n1")
+	ev1 := requireEvent(t, br1)
+	require.NotEmpty(t, ev1.id)
+
+	// Resume the same stream while the first connection is still open.
+	resp2, _ := openGET(t, ts, sid, ev1.id)
+	br2 := bufio.NewReader(resp2.Body)
+
+	// The superseded connection ends...
+	requireEOF(t, br1)
+
+	// ...and new messages arrive on the replacement.
+	sendNotification(t, mcpServer, sid, "n2")
+	ev2 := requireEvent(t, br2)
+	assert.Equal(t, "n2", notificationData(t, ev2.data))
+}
+
+// ---------------------------------------------------------------------------
+// fakeStore
+// ---------------------------------------------------------------------------
+
+// fakeStore issues deliberately odd event ids and serves replay entirely from
+// canned data, to verify the server treats stores as the source of truth.
+type fakeStore struct {
+	mu           sync.Mutex
+	calls        []storeCall
+	replayEvents []sseEvent
+}
+
+func (f *fakeStore) StoreEvent(_ context.Context, sessionID, streamID string, message json.RawMessage) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	msg := make(json.RawMessage, len(message))
+	copy(msg, message)
+	id := fmt.Sprintf("custom~%d*id", len(f.calls)+1)
+	f.calls = append(f.calls, storeCall{sessionID: sessionID, streamID: streamID, message: msg, eventID: id})
+	return id, nil
+}
+
+func (f *fakeStore) ReplayEventsAfter(_ context.Context, _ string, lastEventID string, send func(eventID string, message json.RawMessage) error) (string, error) {
+	if lastEventID != "custom~1*id" {
+		return "", fmt.Errorf("unknown event id %q", lastEventID)
+	}
+	f.mu.Lock()
+	events := make([]sseEvent, len(f.replayEvents))
+	copy(events, f.replayEvents)
+	f.mu.Unlock()
+	for _, ev := range events {
+		if err := send(ev.id, ev.data); err != nil {
+			return "", err
+		}
+	}
+	return "stream-the-server-never-issued", nil
+}
+
+func (f *fakeStore) snapshot() []storeCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]storeCall, len(f.calls))
+	copy(out, f.calls)
+	return out
+}

--- a/server/event_store.go
+++ b/server/event_store.go
@@ -1,0 +1,116 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"sync"
+)
+
+// EventStore records the JSON-RPC messages delivered on a session's SSE
+// streams so that a client can resume a broken stream and be redelivered the
+// messages it missed, per the "Resumability and Redelivery" section of the
+// MCP Streamable HTTP transport specification.
+//
+// The transport treats event IDs as opaque strings: any non-empty value is
+// acceptable, as long as IDs are unique within a session across all of its
+// streams. Implementations must be safe for concurrent use.
+type EventStore interface {
+	// StoreEvent records message as the next event on the given stream and
+	// returns the event ID assigned to it. The returned ID is attached to the
+	// SSE event delivered to the client.
+	StoreEvent(ctx context.Context, sessionID, streamID string, message json.RawMessage) (string, error)
+
+	// ReplayEventsAfter invokes send, in insertion order, for every event
+	// stored after lastEventID on the same stream as lastEventID, and returns
+	// the ID of that stream. It returns an error if lastEventID is not known
+	// for the given session, or if send returns an error.
+	ReplayEventsAfter(ctx context.Context, sessionID, lastEventID string, send func(eventID string, message json.RawMessage) error) (string, error)
+}
+
+// InMemoryEventStore is an EventStore that keeps events in process memory.
+// It is suitable for single-process deployments; multi-node deployments
+// should implement EventStore on top of shared storage instead.
+//
+// Events are retained for the lifetime of the store.
+type InMemoryEventStore struct {
+	mu       sync.RWMutex
+	seq      int64
+	sessions map[string]*sessionEventLog
+}
+
+// sessionEventLog holds the events recorded for one session, grouped by
+// stream, plus an index from event ID to its position for replay lookups.
+type sessionEventLog struct {
+	streams map[string][]storedEvent
+	index   map[string]storedEventRef
+}
+
+type storedEvent struct {
+	id      string
+	message json.RawMessage
+}
+
+type storedEventRef struct {
+	streamID string
+	pos      int
+}
+
+// NewInMemoryEventStore creates an empty in-memory event store.
+func NewInMemoryEventStore() *InMemoryEventStore {
+	return &InMemoryEventStore{sessions: make(map[string]*sessionEventLog)}
+}
+
+func (s *InMemoryEventStore) StoreEvent(_ context.Context, sessionID, streamID string, message json.RawMessage) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	log := s.sessions[sessionID]
+	if log == nil {
+		log = &sessionEventLog{
+			streams: make(map[string][]storedEvent),
+			index:   make(map[string]storedEventRef),
+		}
+		s.sessions[sessionID] = log
+	}
+
+	// IDs only need to be unique within a session, but a store-wide sequence
+	// costs nothing extra and keeps IDs from one session meaningless in
+	// another.
+	s.seq++
+	id := strconv.FormatInt(s.seq, 10)
+
+	// Copy the message: callers may reuse the backing buffer after we return.
+	msg := make(json.RawMessage, len(message))
+	copy(msg, message)
+
+	log.index[id] = storedEventRef{streamID: streamID, pos: len(log.streams[streamID])}
+	log.streams[streamID] = append(log.streams[streamID], storedEvent{id: id, message: msg})
+	return id, nil
+}
+
+func (s *InMemoryEventStore) ReplayEventsAfter(_ context.Context, sessionID, lastEventID string, send func(eventID string, message json.RawMessage) error) (string, error) {
+	s.mu.RLock()
+	log := s.sessions[sessionID]
+	if log == nil {
+		s.mu.RUnlock()
+		return "", fmt.Errorf("unknown event ID: %s", lastEventID)
+	}
+	ref, ok := log.index[lastEventID]
+	if !ok {
+		s.mu.RUnlock()
+		return "", fmt.Errorf("unknown event ID: %s", lastEventID)
+	}
+	events := log.streams[ref.streamID][ref.pos+1:]
+	tail := make([]storedEvent, len(events))
+	copy(tail, events)
+	s.mu.RUnlock()
+
+	for _, ev := range tail {
+		if err := send(ev.id, ev.message); err != nil {
+			return "", err
+		}
+	}
+	return ref.streamID, nil
+}

--- a/server/event_store.go
+++ b/server/event_store.go
@@ -3,19 +3,25 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
 )
+
+// ErrUnknownEventID indicates that a lastEventID passed to
+// EventStore.ReplayEventsAfter is not known for the given session.
+var ErrUnknownEventID = errors.New("unknown event ID")
 
 // EventStore records the JSON-RPC messages delivered on a session's SSE
 // streams so that a client can resume a broken stream and be redelivered the
 // messages it missed, per the "Resumability and Redelivery" section of the
 // MCP Streamable HTTP transport specification.
 //
-// The transport treats event IDs as opaque strings: any non-empty value is
-// acceptable, as long as IDs are unique within a session across all of its
-// streams. Implementations must be safe for concurrent use.
+// The transport treats event IDs as opaque strings: any non-empty value that
+// contains no carriage returns or newlines is acceptable, as long as IDs are
+// unique within a session across all of its streams. Implementations must be
+// safe for concurrent use.
 type EventStore interface {
 	// StoreEvent records message as the next event on the given stream and
 	// returns the event ID assigned to it. The returned ID is attached to the
@@ -24,16 +30,23 @@ type EventStore interface {
 
 	// ReplayEventsAfter invokes send, in insertion order, for every event
 	// stored after lastEventID on the same stream as lastEventID, and returns
-	// the ID of that stream. It returns an error if lastEventID is not known
-	// for the given session, or if send returns an error.
+	// the ID of that stream. It returns an error wrapping ErrUnknownEventID if
+	// lastEventID is not known for the given session, or the error returned by
+	// send if send fails.
 	ReplayEventsAfter(ctx context.Context, sessionID, lastEventID string, send func(eventID string, message json.RawMessage) error) (string, error)
+
+	// PurgeSession removes every event recorded for the given session. It is
+	// called when the session terminates (an explicit DELETE or an idle
+	// sweep), after which none of the session's event IDs can be resumed from.
+	PurgeSession(ctx context.Context, sessionID string) error
 }
 
 // InMemoryEventStore is an EventStore that keeps events in process memory.
 // It is suitable for single-process deployments; multi-node deployments
 // should implement EventStore on top of shared storage instead.
 //
-// Events are retained for the lifetime of the store.
+// A session's events are retained until PurgeSession is called for it, which
+// the streamable HTTP server does when the session terminates.
 type InMemoryEventStore struct {
 	mu       sync.RWMutex
 	seq      int64
@@ -62,6 +75,8 @@ func NewInMemoryEventStore() *InMemoryEventStore {
 	return &InMemoryEventStore{sessions: make(map[string]*sessionEventLog)}
 }
 
+// StoreEvent records message as the next event on the given stream and
+// returns the store-wide sequence number assigned to it as the event ID.
 func (s *InMemoryEventStore) StoreEvent(_ context.Context, sessionID, streamID string, message json.RawMessage) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -90,17 +105,21 @@ func (s *InMemoryEventStore) StoreEvent(_ context.Context, sessionID, streamID s
 	return id, nil
 }
 
+// ReplayEventsAfter invokes send for every event stored after lastEventID on
+// the stream that produced it, in insertion order, and returns that stream's
+// ID. It returns an error wrapping ErrUnknownEventID if lastEventID was never
+// issued for the given session or the session's events have been purged.
 func (s *InMemoryEventStore) ReplayEventsAfter(_ context.Context, sessionID, lastEventID string, send func(eventID string, message json.RawMessage) error) (string, error) {
 	s.mu.RLock()
 	log := s.sessions[sessionID]
 	if log == nil {
 		s.mu.RUnlock()
-		return "", fmt.Errorf("unknown event ID: %s", lastEventID)
+		return "", fmt.Errorf("%w: %s", ErrUnknownEventID, lastEventID)
 	}
 	ref, ok := log.index[lastEventID]
 	if !ok {
 		s.mu.RUnlock()
-		return "", fmt.Errorf("unknown event ID: %s", lastEventID)
+		return "", fmt.Errorf("%w: %s", ErrUnknownEventID, lastEventID)
 	}
 	events := log.streams[ref.streamID][ref.pos+1:]
 	tail := make([]storedEvent, len(events))
@@ -113,4 +132,12 @@ func (s *InMemoryEventStore) ReplayEventsAfter(_ context.Context, sessionID, las
 		}
 	}
 	return ref.streamID, nil
+}
+
+// PurgeSession removes every event recorded for the given session.
+func (s *InMemoryEventStore) PurgeSession(_ context.Context, sessionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.sessions, sessionID)
+	return nil
 }

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -101,6 +101,25 @@ func WithHeartbeatInterval(interval time.Duration) StreamableHTTPOption {
 	}
 }
 
+// WithEventStore enables stream resumability, per the "Resumability and
+// Redelivery" section of the MCP Streamable HTTP transport specification.
+//
+// Every JSON-RPC message delivered on an SSE stream is recorded in store
+// before it is sent and carries the store-issued event ID in the SSE id
+// field. A client whose connection broke can then reconnect with a GET
+// carrying the standard Last-Event-ID header to be redelivered everything it
+// missed on that stream and keep receiving from it.
+//
+// With an event store configured, session transport state survives client
+// disconnects so that messages produced while no client is connected can
+// still be recorded. It is reclaimed when the session is terminated (DELETE)
+// or, with WithSessionIdleTTL configured, when the session idles out.
+func WithEventStore(store EventStore) StreamableHTTPOption {
+	return func(s *StreamableHTTPServer) {
+		s.eventStore = store
+	}
+}
+
 // WithDisableStreaming prevents the server from responding to GET requests with
 // a streaming response. Instead, it will respond with a 405 Method Not Allowed status.
 // This can be useful in scenarios where streaming is not desired or supported.
@@ -259,8 +278,8 @@ func WithStreamableHTTPCORS(opts ...CORSOption) StreamableHTTPOption {
 // not trigger the session registration. So the methods like `SendNotificationToSpecificClient`
 // or `hooks.onRegisterSession` will not be triggered for POST messages.
 //
-// The current implementation does not support the following features from the specification:
-//   - Stream Resumability
+// Stream resumability (redelivery of the messages a client missed while its
+// SSE connection was broken) is opt-in via WithEventStore.
 type StreamableHTTPServer struct {
 	server                   *MCPServer
 	sessionTools             *sessionToolsStore
@@ -268,6 +287,11 @@ type StreamableHTTPServer struct {
 	sessionResourceTemplates *sessionResourceTemplatesStore
 	sessionRequestIDs        sync.Map // sessionId --> last requestID(*atomic.Int64)
 	activeSessions           sync.Map // sessionId --> *streamableHttpSession (for sampling responses)
+
+	eventStore         EventStore
+	resumableStreams   sync.Map // streamID --> *resumableStream
+	listeningStreams   sync.Map // sessionID --> *resumableStream (the standalone listening stream)
+	listeningPumpStops sync.Map // sessionID --> chan struct{} (stops the session's pump)
 
 	httpServer *http.Server
 	mu         sync.RWMutex
@@ -598,7 +622,17 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 	// application/json response (the upgrade simply won't fire).
 	canStream := w.CanStream()
 
+	// Request stream for resumability, created lazily when the first SSE
+	// message for this request is delivered. Guarded by mu. Stored events
+	// must outlive the request context, which ends with the connection.
+	var rst *resumableStream
+	storeCtx := context.WithoutCancel(ctx)
+
+	// forwarderExited lets the response path wait until the forwarder can no
+	// longer be holding an undelivered notification.
+	forwarderExited := make(chan struct{})
 	go func() {
+		defer close(forwarderExited)
 		defer func() {
 			if r := recover(); r != nil {
 				s.logger.Error("panic in notification forwarder", "panic", r)
@@ -613,6 +647,23 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 					// if the done chan is closed, as the request is terminated, just return
 					select {
 					case <-done:
+						// The notification is already off the channel; with an
+						// event store it must still be recorded.
+						if s.eventStore != nil && canStream {
+							if rst == nil {
+								rst = s.newResumableStream(sessionID, w)
+							}
+							if ctx.Err() != nil {
+								rst.clearPostWriter()
+							} else if !upgradedHeader {
+								w.Header().Set("Content-Type", "text/event-stream")
+								w.Header().Set("Connection", "keep-alive")
+								w.Header().Set("Cache-Control", "no-cache")
+								w.WriteHeader(http.StatusOK)
+								upgradedHeader = true
+							}
+							rst.deliver(storeCtx, nt, false)
+						}
 						return
 					default:
 					}
@@ -623,6 +674,23 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 						return
 					}
 					defer w.Flush()
+
+					if s.eventStore != nil {
+						if rst == nil {
+							rst = s.newResumableStream(sessionID, w)
+						}
+						if ctx.Err() != nil {
+							rst.clearPostWriter()
+						} else if !upgradedHeader {
+							w.Header().Set("Content-Type", "text/event-stream")
+							w.Header().Set("Connection", "keep-alive")
+							w.Header().Set("Cache-Control", "no-cache")
+							w.WriteHeader(http.StatusOK)
+							upgradedHeader = true
+						}
+						rst.deliver(storeCtx, nt, false)
+						return
+					}
 
 					// if there's notifications, upgradedHeader to SSE response
 					if !upgradedHeader {
@@ -661,6 +729,14 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 	}
 
 	// Write response
+	//
+	// With an event store, stop the forwarder before draining so that exactly
+	// one consumer records whatever notifications remain, preserving their
+	// order ahead of the response.
+	if s.eventStore != nil {
+		close(done)
+		<-forwarderExited
+	}
 	mu.Lock()
 
 drainLoop:
@@ -668,6 +744,23 @@ drainLoop:
 		select {
 		case nt := <-session.notificationChannel:
 			if !canStream {
+				continue
+			}
+			if s.eventStore != nil {
+				if rst == nil {
+					rst = s.newResumableStream(sessionID, w)
+				}
+				if ctx.Err() != nil {
+					rst.clearPostWriter()
+				} else if !upgradedHeader {
+					w.Header().Set("Content-Type", "text/event-stream")
+					w.Header().Set("Connection", "keep-alive")
+					w.Header().Set("Cache-Control", "no-cache")
+					w.WriteHeader(http.StatusOK)
+					upgradedHeader = true
+				}
+				rst.deliver(storeCtx, nt, false)
+				w.Flush()
 				continue
 			}
 			if !upgradedHeader {
@@ -687,16 +780,40 @@ drainLoop:
 	}
 
 	// close the done chan before unlocking to signal the goroutine to stop
-	close(done)
+	if s.eventStore == nil {
+		close(done)
+	}
 	mu.Unlock()
 	if ctx.Err() != nil {
+		// The connection is gone, but with an event store the response of an
+		// interrupted SSE request is still recorded so that a resuming client
+		// can be redelivered it.
+		if s.eventStore != nil && (rst != nil || (session.upgradeToSSE.Load() && canStream)) {
+			if rst == nil {
+				rst = s.newResumableStream(sessionID, w)
+			}
+			rst.clearPostWriter()
+			rst.deliver(storeCtx, response, true)
+		}
 		return
 	}
 	// If client-server communication already upgraded to SSE stream
 	// Also check upgradedHeader: a notification during HandleMessage processing
 	// may have already written SSE headers on this response, so we must continue
 	// in SSE mode to avoid writing JSON on top of SSE data.
-	if (session.upgradeToSSE.Load() && canStream) || upgradedHeader {
+	if s.eventStore != nil && (rst != nil || (session.upgradeToSSE.Load() && canStream)) {
+		if rst == nil {
+			rst = s.newResumableStream(sessionID, w)
+		}
+		if !upgradedHeader {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.WriteHeader(http.StatusOK)
+			upgradedHeader = true
+		}
+		rst.deliver(storeCtx, response, true)
+	} else if (session.upgradeToSSE.Load() && canStream) || upgradedHeader {
 		if !upgradedHeader {
 			w.Header().Set("Content-Type", "text/event-stream")
 			w.Header().Set("Connection", "keep-alive")
@@ -753,6 +870,15 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 		return
 	}
 
+	// A GET carrying Last-Event-ID resumes a previously broken SSE stream
+	// rather than opening a fresh listening stream.
+	if s.eventStore != nil {
+		if lastEventID := r.header().Get("Last-Event-ID"); lastEventID != "" {
+			s.handleResumeGet(w, r, lastEventID)
+			return
+		}
+	}
+
 	sessionID := r.header().Get(HeaderKeySessionID)
 	// The MCP specification doesn't require validating session ID for GET requests.
 	// If no session ID is provided by the client, generate one using the configured SessionIdManager
@@ -776,12 +902,22 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 			writeHTTPErrorf(w, http.StatusBadRequest, "Session registration failed: %v", err)
 			return
 		}
-		defer s.server.UnregisterSession(r.ctx(), sessionID)
-		defer s.activeSessions.Delete(sessionID)
-		defer s.sessionRequestIDs.Delete(sessionID)
+		if s.eventStore == nil {
+			defer s.server.UnregisterSession(r.ctx(), sessionID)
+			defer s.activeSessions.Delete(sessionID)
+			defer s.sessionRequestIDs.Delete(sessionID)
+		}
+		// With an event store, the session outlives the connection so that
+		// messages produced while the client is away are recorded for
+		// replay; it is cleaned up on DELETE or by the idle sweeper.
 	}
 
 	s.touchSession(sessionID)
+
+	if s.eventStore != nil {
+		s.serveListeningStream(w, r, sessionID, session)
+		return
+	}
 
 	// Set the client context before handling the message
 	w.Header().Set("Content-Type", "text/event-stream")
@@ -1088,6 +1224,9 @@ func (s *StreamableHTTPServer) touchSession(sessionID string) {
 
 // cleanupSessionState removes all per-session transport state for the given session ID.
 func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionID string) {
+	if s.eventStore != nil {
+		s.cleanupResumableState(sessionID)
+	}
 	// Unregister first to stop notification routing before deleting data.
 	s.server.UnregisterSession(ctx, sessionID)
 	s.activeSessions.Delete(sessionID)

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -112,8 +112,9 @@ func WithHeartbeatInterval(interval time.Duration) StreamableHTTPOption {
 //
 // With an event store configured, session transport state survives client
 // disconnects so that messages produced while no client is connected can
-// still be recorded. It is reclaimed when the session is terminated (DELETE)
-// or, with WithSessionIdleTTL configured, when the session idles out.
+// still be recorded. It is reclaimed, and the session's events are purged
+// from the store, when the session is terminated (DELETE) or, with
+// WithSessionIdleTTL configured, when the session idles out.
 func WithEventStore(store EventStore) StreamableHTTPOption {
 	return func(s *StreamableHTTPServer) {
 		s.eventStore = store
@@ -628,6 +629,25 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 	var rst *resumableStream
 	storeCtx := context.WithoutCancel(ctx)
 
+	// deliverResumable records msg on the request's resumable stream (creating
+	// it on first use), upgrading the response to SSE first while the
+	// connection is still usable. Callers must hold mu.
+	deliverResumable := func(msg any, last bool) {
+		if rst == nil {
+			rst = s.newResumableStream(sessionID, w)
+		}
+		if ctx.Err() != nil {
+			rst.clearPostWriter()
+		} else if !upgradedHeader {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.Header().Set("Connection", "keep-alive")
+			w.Header().Set("Cache-Control", "no-cache")
+			w.WriteHeader(http.StatusOK)
+			upgradedHeader = true
+		}
+		rst.deliver(storeCtx, msg, last)
+	}
+
 	// forwarderExited lets the response path wait until the forwarder can no
 	// longer be holding an undelivered notification.
 	forwarderExited := make(chan struct{})
@@ -650,19 +670,7 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 						// The notification is already off the channel; with an
 						// event store it must still be recorded.
 						if s.eventStore != nil && canStream {
-							if rst == nil {
-								rst = s.newResumableStream(sessionID, w)
-							}
-							if ctx.Err() != nil {
-								rst.clearPostWriter()
-							} else if !upgradedHeader {
-								w.Header().Set("Content-Type", "text/event-stream")
-								w.Header().Set("Connection", "keep-alive")
-								w.Header().Set("Cache-Control", "no-cache")
-								w.WriteHeader(http.StatusOK)
-								upgradedHeader = true
-							}
-							rst.deliver(storeCtx, nt, false)
+							deliverResumable(nt, false)
 						}
 						return
 					default:
@@ -676,19 +684,7 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 					defer w.Flush()
 
 					if s.eventStore != nil {
-						if rst == nil {
-							rst = s.newResumableStream(sessionID, w)
-						}
-						if ctx.Err() != nil {
-							rst.clearPostWriter()
-						} else if !upgradedHeader {
-							w.Header().Set("Content-Type", "text/event-stream")
-							w.Header().Set("Connection", "keep-alive")
-							w.Header().Set("Cache-Control", "no-cache")
-							w.WriteHeader(http.StatusOK)
-							upgradedHeader = true
-						}
-						rst.deliver(storeCtx, nt, false)
+						deliverResumable(nt, false)
 						return
 					}
 
@@ -747,19 +743,7 @@ drainLoop:
 				continue
 			}
 			if s.eventStore != nil {
-				if rst == nil {
-					rst = s.newResumableStream(sessionID, w)
-				}
-				if ctx.Err() != nil {
-					rst.clearPostWriter()
-				} else if !upgradedHeader {
-					w.Header().Set("Content-Type", "text/event-stream")
-					w.Header().Set("Connection", "keep-alive")
-					w.Header().Set("Cache-Control", "no-cache")
-					w.WriteHeader(http.StatusOK)
-					upgradedHeader = true
-				}
-				rst.deliver(storeCtx, nt, false)
+				deliverResumable(nt, false)
 				w.Flush()
 				continue
 			}
@@ -789,11 +773,9 @@ drainLoop:
 		// interrupted SSE request is still recorded so that a resuming client
 		// can be redelivered it.
 		if s.eventStore != nil && (rst != nil || (session.upgradeToSSE.Load() && canStream)) {
-			if rst == nil {
-				rst = s.newResumableStream(sessionID, w)
-			}
-			rst.clearPostWriter()
-			rst.deliver(storeCtx, response, true)
+			mu.Lock()
+			deliverResumable(response, true)
+			mu.Unlock()
 		}
 		return
 	}
@@ -802,17 +784,9 @@ drainLoop:
 	// may have already written SSE headers on this response, so we must continue
 	// in SSE mode to avoid writing JSON on top of SSE data.
 	if s.eventStore != nil && (rst != nil || (session.upgradeToSSE.Load() && canStream)) {
-		if rst == nil {
-			rst = s.newResumableStream(sessionID, w)
-		}
-		if !upgradedHeader {
-			w.Header().Set("Content-Type", "text/event-stream")
-			w.Header().Set("Connection", "keep-alive")
-			w.Header().Set("Cache-Control", "no-cache")
-			w.WriteHeader(http.StatusOK)
-			upgradedHeader = true
-		}
-		rst.deliver(storeCtx, response, true)
+		mu.Lock()
+		deliverResumable(response, true)
+		mu.Unlock()
 	} else if (session.upgradeToSSE.Load() && canStream) || upgradedHeader {
 		if !upgradedHeader {
 			w.Header().Set("Content-Type", "text/event-stream")
@@ -1225,7 +1199,7 @@ func (s *StreamableHTTPServer) touchSession(sessionID string) {
 // cleanupSessionState removes all per-session transport state for the given session ID.
 func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionID string) {
 	if s.eventStore != nil {
-		s.cleanupResumableState(sessionID)
+		s.cleanupResumableState(ctx, sessionID)
 	}
 	// Unregister first to stop notification routing before deleting data.
 	s.server.UnregisterSession(ctx, sessionID)

--- a/server/streamable_http_handle.go
+++ b/server/streamable_http_handle.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
 )
 
 // HTTPRequest is a transport-agnostic view of an incoming MCP HTTP request.
@@ -135,6 +136,13 @@ func (a *httpResponseWriterAdapter) Flush() {
 	if a.flusher != nil {
 		a.flusher.Flush()
 	}
+}
+
+// SetWriteDeadline sets a deadline for future writes via
+// http.ResponseController, bounding how long a stalled client can block the
+// server. A zero time clears the deadline.
+func (a *httpResponseWriterAdapter) SetWriteDeadline(t time.Time) error {
+	return http.NewResponseController(a.w).SetWriteDeadline(t)
 }
 
 func (a *httpResponseWriterAdapter) CanStream() bool { return a.flusher != nil }

--- a/server/streamable_http_resume.go
+++ b/server/streamable_http_resume.go
@@ -3,9 +3,11 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -14,15 +16,23 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+// replayWriteTimeout bounds how long a resume replay may block writing to a
+// slow client while the stream's lock is held.
+const replayWriteTimeout = 30 * time.Second
+
 // resumableStream tracks one SSE stream whose events are recorded in the
 // configured EventStore. A stream outlives any single HTTP connection: while
 // no connection is attached, deliveries are recorded only, and a later GET
 // carrying Last-Event-ID replays the missed events and takes the stream over.
 //
-// All delivery for a stream is serialized through mu, which is what makes
-// resumption gap-free: a connection attaching under mu first replays from the
-// store and then installs itself, so an event is either included in the
-// replay or delivered live, never both and never neither.
+// Recording is serialized through mu, and a connection attaching under mu
+// first replays from the store and then installs itself, so an event reaches
+// the attaching connection either through the replay or live afterwards,
+// never both and never neither. Writes to an attached connection happen
+// outside mu so that a stalled client can never block stream takeover or
+// session cleanup; they cannot reorder because each stream has a single
+// producer (the session's listening pump, or the originating POST handler
+// under its own mutex).
 type resumableStream struct {
 	server    *StreamableHTTPServer
 	sessionID string
@@ -88,8 +98,6 @@ func (st *resumableStream) deliver(ctx context.Context, message any, last bool) 
 	}
 
 	st.mu.Lock()
-	defer st.mu.Unlock()
-
 	eventID, err := st.server.eventStore.StoreEvent(ctx, st.sessionID, st.id, data)
 	if err != nil {
 		// Recording failed; deliver live without an ID rather than dropping.
@@ -99,20 +107,47 @@ func (st *resumableStream) deliver(ctx context.Context, message any, last bool) 
 	if last {
 		st.closed = true
 	}
+	conn, postW := st.conn, st.postW
+	st.mu.Unlock()
 
 	switch {
-	case st.conn != nil:
+	case conn != nil:
 		select {
-		case st.conn.sink <- resumableEvent{eventID: eventID, message: data, last: last}:
-		case <-st.conn.gone:
+		case conn.sink <- resumableEvent{eventID: eventID, message: data, last: last}:
+		case <-conn.gone:
+			// The connection died or was superseded while we were blocked; the
+			// event is recorded and reaches the client on resume (or already
+			// reached the successor through its replay).
 		}
-	case st.postW != nil:
-		if err := writeSSEEventRaw(st.postW, eventID, data); err != nil {
+	case postW != nil:
+		if err := writeSSEEventRaw(postW, eventID, data); err != nil {
 			st.server.logger.Error("Failed to write SSE event", "err", err)
-			st.postW = nil
+			st.clearPostWriterIf(postW)
 			return
 		}
-		st.postW.Flush()
+		postW.Flush()
+	}
+}
+
+// deliverTransient writes message to the attached connection without
+// recording it. Keepalive pings use this: they check connection liveness
+// rather than carry session history, so they get no event ID (the client's
+// Last-Event-ID does not advance) and are dropped while nothing is attached.
+func (st *resumableStream) deliverTransient(message any) {
+	data, err := json.Marshal(message)
+	if err != nil {
+		st.server.logger.Error("Failed to marshal SSE event", "err", err)
+		return
+	}
+	st.mu.Lock()
+	conn := st.conn
+	st.mu.Unlock()
+	if conn == nil {
+		return
+	}
+	select {
+	case conn.sink <- resumableEvent{message: data}:
+	case <-conn.gone:
 	}
 }
 
@@ -122,6 +157,16 @@ func (st *resumableStream) clearPostWriter() {
 	st.mu.Lock()
 	defer st.mu.Unlock()
 	st.postW = nil
+}
+
+// clearPostWriterIf stops direct writes to w if it is still the stream's
+// originating POST writer.
+func (st *resumableStream) clearPostWriterIf(w HTTPResponseWriter) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.postW == w {
+		st.postW = nil
+	}
 }
 
 // detachLocked supersedes whatever is currently attached. Callers must hold mu.
@@ -158,13 +203,16 @@ func (st *resumableStream) attach() *resumableConn {
 // connection as the stream's live writer. Replay happens under mu, so no
 // event can be recorded while the store is scanned: an event is either part
 // of the replay or delivered live afterwards, never both and never neither.
-// It returns nil if the stream is complete (or replay failed) and there is
-// nothing further to serve. SSE response headers must already be written.
+// A write deadline (where the transport supports one) bounds how long a slow
+// client can hold the lock during replay. It returns nil if the stream is
+// complete (or replay failed) and there is nothing further to serve. SSE
+// response headers must already be written.
 func (st *resumableStream) replayAndAttach(w HTTPResponseWriter, r *HTTPRequest, lastEventID string) *resumableConn {
 	conn := newResumableConn()
 
 	st.mu.Lock()
 	st.detachLocked()
+	restoreDeadline := setWriteDeadline(w, replayWriteTimeout)
 	_, err := st.server.eventStore.ReplayEventsAfter(r.ctx(), st.sessionID, lastEventID, func(eventID string, message json.RawMessage) error {
 		if err := writeSSEEventRaw(w, eventID, message); err != nil {
 			return err
@@ -172,6 +220,7 @@ func (st *resumableStream) replayAndAttach(w HTTPResponseWriter, r *HTTPRequest,
 		w.Flush()
 		return nil
 	})
+	restoreDeadline()
 	if err != nil {
 		st.mu.Unlock()
 		st.server.logger.Error("Failed to replay SSE events", "err", err, "stream", st.id)
@@ -327,7 +376,12 @@ func (s *StreamableHTTPServer) handleResumeGet(w HTTPResponseWriter, r *HTTPRequ
 	// stores pay two reads per resume.
 	streamID, err := s.eventStore.ReplayEventsAfter(r.ctx(), sessionID, lastEventID, func(string, json.RawMessage) error { return nil })
 	if err != nil {
-		writeHTTPError(w, "Unknown Last-Event-ID", http.StatusBadRequest)
+		if errors.Is(err, ErrUnknownEventID) {
+			writeHTTPError(w, "Unknown Last-Event-ID", http.StatusBadRequest)
+		} else {
+			s.logger.Error("Failed to resume stream", "err", err, "session", sessionID)
+			writeHTTPError(w, "Failed to resume stream", http.StatusInternalServerError)
+		}
 		return
 	}
 	s.touchSession(sessionID)
@@ -349,6 +403,7 @@ func (s *StreamableHTTPServer) handleResumeGet(w HTTPResponseWriter, r *HTTPRequ
 	if st == nil {
 		// The stream is no longer tracked (e.g. its session state was cleaned
 		// up); replay what the store has and finish.
+		restoreDeadline := setWriteDeadline(w, replayWriteTimeout)
 		_, err := s.eventStore.ReplayEventsAfter(r.ctx(), sessionID, lastEventID, func(eventID string, message json.RawMessage) error {
 			if err := writeSSEEventRaw(w, eventID, message); err != nil {
 				return err
@@ -356,6 +411,7 @@ func (s *StreamableHTTPServer) handleResumeGet(w HTTPResponseWriter, r *HTTPRequ
 			w.Flush()
 			return nil
 		})
+		restoreDeadline()
 		if err != nil {
 			s.logger.Error("Failed to replay SSE events", "err", err, "stream", streamID)
 		}
@@ -372,7 +428,8 @@ func (s *StreamableHTTPServer) handleResumeGet(w HTTPResponseWriter, r *HTTPRequ
 }
 
 // startConnHeartbeat delivers periodic ping requests to the stream for as
-// long as ctx (the attached connection's context) lasts.
+// long as ctx (the attached connection's context) lasts. Pings are transient:
+// they are never recorded for replay.
 func (s *StreamableHTTPServer) startConnHeartbeat(ctx context.Context, st *resumableStream, sessionID string) {
 	go func() {
 		defer func() {
@@ -385,13 +442,13 @@ func (s *StreamableHTTPServer) startConnHeartbeat(ctx context.Context, st *resum
 		for {
 			select {
 			case <-ticker.C:
-				st.deliver(context.Background(), mcp.JSONRPCRequest{
+				st.deliverTransient(mcp.JSONRPCRequest{
 					JSONRPC: "2.0",
 					ID:      mcp.NewRequestId(s.nextRequestID(sessionID)),
 					Request: mcp.Request{
 						Method: string(mcp.MethodPing),
 					},
-				}, false)
+				})
 			case <-ctx.Done():
 				return
 			}
@@ -399,9 +456,10 @@ func (s *StreamableHTTPServer) startConnHeartbeat(ctx context.Context, st *resum
 	}()
 }
 
-// cleanupResumableState tears down the session's streams and pump. Any
-// connection still attached to one of its streams is closed.
-func (s *StreamableHTTPServer) cleanupResumableState(sessionID string) {
+// cleanupResumableState tears down the session's streams and pump and purges
+// the session's events from the store, so none of its event IDs can be
+// resumed from. Any connection still attached to one of its streams is closed.
+func (s *StreamableHTTPServer) cleanupResumableState(ctx context.Context, sessionID string) {
 	if stop, ok := s.listeningPumpStops.LoadAndDelete(sessionID); ok {
 		close(stop.(chan struct{}))
 	}
@@ -416,12 +474,37 @@ func (s *StreamableHTTPServer) cleanupResumableState(sessionID string) {
 		}
 		return true
 	})
+	if err := s.eventStore.PurgeSession(ctx, sessionID); err != nil {
+		s.logger.Error("Failed to purge session events", "err", err, "session", sessionID)
+	}
+}
+
+// setWriteDeadline applies a write deadline to w when the underlying
+// transport supports one (net/http does, via http.ResponseController) and
+// returns a func that clears it again. Writers without deadline support,
+// e.g. adapters for other frameworks, are left untouched.
+func setWriteDeadline(w HTTPResponseWriter, d time.Duration) (restore func()) {
+	dw, ok := w.(interface{ SetWriteDeadline(time.Time) error })
+	if !ok {
+		return func() {}
+	}
+	if err := dw.SetWriteDeadline(time.Now().Add(d)); err != nil {
+		return func() {}
+	}
+	return func() {
+		_ = dw.SetWriteDeadline(time.Time{})
+	}
 }
 
 // writeSSEEventRaw writes an already-marshaled message as an SSE event,
-// prefixed with an id field when eventID is non-empty.
+// prefixed with an id field when eventID is non-empty. IDs containing line
+// breaks are rejected: interpolating one into the id field would corrupt the
+// SSE framing.
 func writeSSEEventRaw(w io.Writer, eventID string, data json.RawMessage) error {
 	if eventID != "" {
+		if strings.ContainsAny(eventID, "\r\n") {
+			return fmt.Errorf("invalid SSE event id %q: contains line breaks", eventID)
+		}
 		if _, err := fmt.Fprintf(w, "id: %s\n", eventID); err != nil {
 			return fmt.Errorf("failed to write SSE event id: %w", err)
 		}

--- a/server/streamable_http_resume.go
+++ b/server/streamable_http_resume.go
@@ -1,0 +1,433 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// resumableStream tracks one SSE stream whose events are recorded in the
+// configured EventStore. A stream outlives any single HTTP connection: while
+// no connection is attached, deliveries are recorded only, and a later GET
+// carrying Last-Event-ID replays the missed events and takes the stream over.
+//
+// All delivery for a stream is serialized through mu, which is what makes
+// resumption gap-free: a connection attaching under mu first replays from the
+// store and then installs itself, so an event is either included in the
+// replay or delivered live, never both and never neither.
+type resumableStream struct {
+	server    *StreamableHTTPServer
+	sessionID string
+	id        string
+
+	mu sync.Mutex
+	// conn is the currently attached connection, nil while detached.
+	conn *resumableConn
+	// postW is the originating POST response writer for request streams,
+	// written to directly (under the POST handler's own serialization) until
+	// it fails, the request context ends, or a resumed connection takes over.
+	postW HTTPResponseWriter
+	// closed is set once the stream's final message (a request stream's
+	// response) has been recorded; a stream resumed after that point is
+	// replayed and closed.
+	closed bool
+}
+
+// resumableConn is one attached connection's write side. Events are handed to
+// sink and written by the owning handler goroutine; gone is closed (exactly
+// once) when the connection detaches, dies, or is superseded.
+type resumableConn struct {
+	sink      chan resumableEvent
+	gone      chan struct{}
+	closeGone func()
+}
+
+type resumableEvent struct {
+	eventID string
+	message json.RawMessage
+	// last closes the connection after the event is written.
+	last bool
+}
+
+func newResumableConn() *resumableConn {
+	gone := make(chan struct{})
+	return &resumableConn{
+		sink:      make(chan resumableEvent, 16),
+		gone:      gone,
+		closeGone: sync.OnceFunc(func() { close(gone) }),
+	}
+}
+
+func (s *StreamableHTTPServer) newResumableStream(sessionID string, postW HTTPResponseWriter) *resumableStream {
+	st := &resumableStream{
+		server:    s,
+		sessionID: sessionID,
+		id:        uuid.NewString(),
+		postW:     postW,
+	}
+	s.resumableStreams.Store(st.id, st)
+	return st
+}
+
+// deliver records message on the stream and forwards it to whatever is
+// currently attached, if anything. Delivery failures detach the writer; the
+// message stays recorded and is redelivered on resume.
+func (st *resumableStream) deliver(ctx context.Context, message any, last bool) {
+	data, err := json.Marshal(message)
+	if err != nil {
+		st.server.logger.Error("Failed to marshal SSE event for recording", "err", err)
+		return
+	}
+
+	st.mu.Lock()
+	defer st.mu.Unlock()
+
+	eventID, err := st.server.eventStore.StoreEvent(ctx, st.sessionID, st.id, data)
+	if err != nil {
+		// Recording failed; deliver live without an ID rather than dropping.
+		st.server.logger.Error("Failed to store SSE event", "err", err, "stream", st.id)
+		eventID = ""
+	}
+	if last {
+		st.closed = true
+	}
+
+	switch {
+	case st.conn != nil:
+		select {
+		case st.conn.sink <- resumableEvent{eventID: eventID, message: data, last: last}:
+		case <-st.conn.gone:
+		}
+	case st.postW != nil:
+		if err := writeSSEEventRaw(st.postW, eventID, data); err != nil {
+			st.server.logger.Error("Failed to write SSE event", "err", err)
+			st.postW = nil
+			return
+		}
+		st.postW.Flush()
+	}
+}
+
+// clearPostWriter stops direct writes to the originating POST response, e.g.
+// once its request context has ended.
+func (st *resumableStream) clearPostWriter() {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	st.postW = nil
+}
+
+// detachLocked supersedes whatever is currently attached. Callers must hold mu.
+func (st *resumableStream) detachLocked() {
+	if st.conn != nil {
+		st.conn.closeGone()
+		st.conn = nil
+	}
+	st.postW = nil
+}
+
+// detachIf detaches conn if it is still the attached connection.
+func (st *resumableStream) detachIf(conn *resumableConn) {
+	st.mu.Lock()
+	defer st.mu.Unlock()
+	if st.conn == conn {
+		st.conn = nil
+	}
+}
+
+// attach installs a fresh connection as the stream's live writer, superseding
+// whatever was attached before. Events delivered from this point on queue on
+// the connection's sink until serve starts writing them.
+func (st *resumableStream) attach() *resumableConn {
+	conn := newResumableConn()
+	st.mu.Lock()
+	st.detachLocked()
+	st.conn = conn
+	st.mu.Unlock()
+	return conn
+}
+
+// replayAndAttach replays events after lastEventID to w and attaches the
+// connection as the stream's live writer. Replay happens under mu, so no
+// event can be recorded while the store is scanned: an event is either part
+// of the replay or delivered live afterwards, never both and never neither.
+// It returns nil if the stream is complete (or replay failed) and there is
+// nothing further to serve. SSE response headers must already be written.
+func (st *resumableStream) replayAndAttach(w HTTPResponseWriter, r *HTTPRequest, lastEventID string) *resumableConn {
+	conn := newResumableConn()
+
+	st.mu.Lock()
+	st.detachLocked()
+	_, err := st.server.eventStore.ReplayEventsAfter(r.ctx(), st.sessionID, lastEventID, func(eventID string, message json.RawMessage) error {
+		if err := writeSSEEventRaw(w, eventID, message); err != nil {
+			return err
+		}
+		w.Flush()
+		return nil
+	})
+	if err != nil {
+		st.mu.Unlock()
+		st.server.logger.Error("Failed to replay SSE events", "err", err, "stream", st.id)
+		return nil
+	}
+	if st.closed {
+		// The stream's final message was part of the replay; nothing further
+		// will be delivered.
+		st.mu.Unlock()
+		return nil
+	}
+	st.conn = conn
+	st.mu.Unlock()
+	return conn
+}
+
+// serve writes the attached connection's events to w until the client
+// disconnects, the stream completes, or another connection takes over.
+func (st *resumableStream) serve(w HTTPResponseWriter, r *HTTPRequest, conn *resumableConn) {
+	ctx := r.ctx()
+	for {
+		select {
+		case ev := <-conn.sink:
+			if err := writeSSEEventRaw(w, ev.eventID, ev.message); err != nil {
+				st.server.logger.Error("Failed to write SSE event", "err", err)
+				conn.closeGone()
+				st.detachIf(conn)
+				return
+			}
+			w.Flush()
+			st.server.touchSession(st.sessionID)
+			if ev.last {
+				conn.closeGone()
+				st.detachIf(conn)
+				return
+			}
+		case <-conn.gone:
+			// Superseded by a newer connection for this stream.
+			return
+		case <-ctx.Done():
+			conn.closeGone()
+			st.detachIf(conn)
+			return
+		}
+	}
+}
+
+// ensureListeningStream returns the session's standalone listening stream,
+// creating it, along with the pump that feeds it, on first use.
+func (s *StreamableHTTPServer) ensureListeningStream(sessionID string, session *streamableHttpSession) *resumableStream {
+	if v, ok := s.listeningStreams.Load(sessionID); ok {
+		return v.(*resumableStream)
+	}
+	st := &resumableStream{
+		server:    s,
+		sessionID: sessionID,
+		id:        uuid.NewString(),
+	}
+	actual, loaded := s.listeningStreams.LoadOrStore(sessionID, st)
+	if loaded {
+		return actual.(*resumableStream)
+	}
+	s.resumableStreams.Store(st.id, st)
+	stop := make(chan struct{})
+	s.listeningPumpStops.Store(sessionID, stop)
+	s.startListeningPump(session, st, stop)
+	return st
+}
+
+// startListeningPump moves messages bound for the session's listening stream
+// into it for recording and delivery. Unlike the connection-scoped forwarding
+// used without an event store, the pump is session-scoped: it keeps running
+// while no client is connected, so messages produced in the meantime are
+// recorded and can be replayed.
+func (s *StreamableHTTPServer) startListeningPump(session *streamableHttpSession, st *resumableStream, stop <-chan struct{}) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Error("panic in listening stream pump", "panic", r)
+			}
+		}()
+		ctx := context.Background()
+		for {
+			select {
+			case nt := <-session.notificationChannel:
+				st.deliver(ctx, nt, false)
+			case samplingReq := <-session.samplingRequestChan:
+				st.deliver(ctx, mcp.JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(samplingReq.requestID),
+					Request: mcp.Request{
+						Method: string(mcp.MethodSamplingCreateMessage),
+					},
+					Params: samplingReq.request.CreateMessageParams,
+				}, false)
+			case elicitationReq := <-session.elicitationRequestChan:
+				st.deliver(ctx, mcp.JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(elicitationReq.requestID),
+					Request: mcp.Request{
+						Method: string(mcp.MethodElicitationCreate),
+					},
+					Params: elicitationReq.request.Params,
+				}, false)
+			case rootsReq := <-session.rootsRequestChan:
+				st.deliver(ctx, mcp.JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(rootsReq.requestID),
+					Request: mcp.Request{
+						Method: string(mcp.MethodListRoots),
+					},
+				}, false)
+			case <-stop:
+				return
+			}
+		}
+	}()
+}
+
+// serveListeningStream handles a GET without Last-Event-ID when an event
+// store is configured: it attaches the connection to the session's listening
+// stream, superseding any previous one.
+func (s *StreamableHTTPServer) serveListeningStream(w HTTPResponseWriter, r *HTTPRequest, sessionID string, session *streamableHttpSession) {
+	st := s.ensureListeningStream(sessionID, session)
+
+	// Attach before writing headers: anything delivered from now on queues on
+	// the connection and is written once serve starts, so a message can't
+	// slip through unseen between the response starting and the attach.
+	conn := st.attach()
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	w.Flush()
+
+	if s.listenHeartbeatInterval > 0 {
+		s.startConnHeartbeat(r.ctx(), st, sessionID)
+	}
+
+	st.serve(w, r, conn)
+}
+
+// handleResumeGet handles a GET carrying Last-Event-ID: it replays the
+// events recorded after that ID on the stream that produced it and, if the
+// stream is still live, continues delivering from there.
+func (s *StreamableHTTPServer) handleResumeGet(w HTTPResponseWriter, r *HTTPRequest, lastEventID string) {
+	sessionID := r.header().Get(HeaderKeySessionID)
+
+	// Probe the store to locate the stream (and reject IDs this session does
+	// not own) before writing any response bytes. The events themselves are
+	// replayed by a second, authoritative scan once the stream is locked, so
+	// stores pay two reads per resume.
+	streamID, err := s.eventStore.ReplayEventsAfter(r.ctx(), sessionID, lastEventID, func(string, json.RawMessage) error { return nil })
+	if err != nil {
+		writeHTTPError(w, "Unknown Last-Event-ID", http.StatusBadRequest)
+		return
+	}
+	s.touchSession(sessionID)
+
+	var st *resumableStream
+	if v, ok := s.resumableStreams.Load(streamID); ok {
+		st = v.(*resumableStream)
+		if st.sessionID != sessionID {
+			st = nil
+		}
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+	w.Flush()
+
+	if st == nil {
+		// The stream is no longer tracked (e.g. its session state was cleaned
+		// up); replay what the store has and finish.
+		_, err := s.eventStore.ReplayEventsAfter(r.ctx(), sessionID, lastEventID, func(eventID string, message json.RawMessage) error {
+			if err := writeSSEEventRaw(w, eventID, message); err != nil {
+				return err
+			}
+			w.Flush()
+			return nil
+		})
+		if err != nil {
+			s.logger.Error("Failed to replay SSE events", "err", err, "stream", streamID)
+		}
+		return
+	}
+
+	if s.listenHeartbeatInterval > 0 {
+		s.startConnHeartbeat(r.ctx(), st, sessionID)
+	}
+
+	if conn := st.replayAndAttach(w, r, lastEventID); conn != nil {
+		st.serve(w, r, conn)
+	}
+}
+
+// startConnHeartbeat delivers periodic ping requests to the stream for as
+// long as ctx (the attached connection's context) lasts.
+func (s *StreamableHTTPServer) startConnHeartbeat(ctx context.Context, st *resumableStream, sessionID string) {
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				s.logger.Error("panic in heartbeat goroutine", "panic", r)
+			}
+		}()
+		ticker := time.NewTicker(s.listenHeartbeatInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				st.deliver(context.Background(), mcp.JSONRPCRequest{
+					JSONRPC: "2.0",
+					ID:      mcp.NewRequestId(s.nextRequestID(sessionID)),
+					Request: mcp.Request{
+						Method: string(mcp.MethodPing),
+					},
+				}, false)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+// cleanupResumableState tears down the session's streams and pump. Any
+// connection still attached to one of its streams is closed.
+func (s *StreamableHTTPServer) cleanupResumableState(sessionID string) {
+	if stop, ok := s.listeningPumpStops.LoadAndDelete(sessionID); ok {
+		close(stop.(chan struct{}))
+	}
+	s.listeningStreams.Delete(sessionID)
+	s.resumableStreams.Range(func(key, value any) bool {
+		st := value.(*resumableStream)
+		if st.sessionID == sessionID {
+			st.mu.Lock()
+			st.detachLocked()
+			st.mu.Unlock()
+			s.resumableStreams.Delete(key)
+		}
+		return true
+	})
+}
+
+// writeSSEEventRaw writes an already-marshaled message as an SSE event,
+// prefixed with an id field when eventID is non-empty.
+func writeSSEEventRaw(w io.Writer, eventID string, data json.RawMessage) error {
+	if eventID != "" {
+		if _, err := fmt.Fprintf(w, "id: %s\n", eventID); err != nil {
+			return fmt.Errorf("failed to write SSE event id: %w", err)
+		}
+	}
+	if _, err := fmt.Fprintf(w, "event: message\ndata: %s\n\n", data); err != nil {
+		return fmt.Errorf("failed to write SSE event: %w", err)
+	}
+	return nil
+}

--- a/www/docs/pages/transports/http.mdx
+++ b/www/docs/pages/transports/http.mdx
@@ -502,7 +502,7 @@ httpServer := server.NewStreamableHTTPServer(s,
 
 With a store configured, each SSE event carries an `id` field issued by the store. To resume, a client reconnects with a `GET` request carrying the standard `Last-Event-ID` header (alongside its `Mcp-Session-Id`); the server replays the messages recorded after that event on the same stream, then continues live delivery. This also covers messages produced while nobody was connected: a tool call whose POST connection broke keeps recording its notifications and final response, all of which are redelivered on resume. Unknown event IDs, or event IDs belonging to a different session, are rejected with `400 Bad Request`.
 
-`NewInMemoryEventStore` keeps events in process memory and retains them for the lifetime of the store, which suits single-process deployments. For multi-node deployments or bounded retention, implement the two-method `EventStore` interface against shared storage (Redis, a database, etc.) and pass it to `WithEventStore`.
+`NewInMemoryEventStore` keeps events in process memory, which suits single-process deployments. A session's events are purged when the session terminates — an explicit `DELETE` or, with `WithSessionIdleTTL` configured, an idle sweep — after which its event IDs can no longer be resumed from. For multi-node deployments, implement the `EventStore` interface against shared storage (Redis, a database, etc.) and pass it to `WithEventStore`.
 
 ### Stateful vs Stateless
 

--- a/www/docs/pages/transports/http.mdx
+++ b/www/docs/pages/transports/http.mdx
@@ -490,6 +490,20 @@ httpServer := server.NewStreamableHTTPServer(s,
 
 The sweeper runs in the background and removes per-session state for sessions that haven't received any requests within the TTL. It also invalidates swept session IDs so they cannot be reused. A zero or negative TTL disables the sweeper (default behavior). The sweeper is automatically stopped on `Shutdown()`.
 
+### Stream Resumability
+
+By default, messages sent while a client's SSE connection is down are lost. Configure an `EventStore` with `WithEventStore` to record every message delivered on a session's SSE streams so clients can resume after a broken connection:
+
+```go
+httpServer := server.NewStreamableHTTPServer(s,
+    server.WithEventStore(server.NewInMemoryEventStore()),
+)
+```
+
+With a store configured, each SSE event carries an `id` field issued by the store. To resume, a client reconnects with a `GET` request carrying the standard `Last-Event-ID` header (alongside its `Mcp-Session-Id`); the server replays the messages recorded after that event on the same stream, then continues live delivery. This also covers messages produced while nobody was connected: a tool call whose POST connection broke keeps recording its notifications and final response, all of which are redelivered on resume. Unknown event IDs, or event IDs belonging to a different session, are rejected with `400 Bad Request`.
+
+`NewInMemoryEventStore` keeps events in process memory and retains them for the lifetime of the store, which suits single-process deployments. For multi-node deployments or bounded retention, implement the two-method `EventStore` interface against shared storage (Redis, a database, etc.) and pass it to `WithEventStore`.
+
 ### Stateful vs Stateless
 
 #### Stateless Design (Recommended)


### PR DESCRIPTION
## Description

Implements server-side stream resumability for the streamable HTTP transport, which the
server's docs currently list as unsupported. Recording is opt-in via a new `WithEventStore`
option: every JSON-RPC message delivered on a session's SSE streams (POST responses that
upgraded to SSE, and the standalone GET listening stream) is recorded before it is written
and carries the store-issued SSE `id`. A client that loses its connection resumes with a
GET carrying `Last-Event-ID`: the server replays that stream's recorded events after the
given id, in order with their original ids, then continues live delivery on the same
connection.

Notable behavior:

- Messages produced while no client is attached are still recorded — a tool call whose
  POST connection broke keeps recording its notifications and final response, all
  redelivered on resume.
- A resumed connection supersedes any connection still attached to the stream.
- Unknown or cross-session `Last-Event-ID` values get `400 Bad Request`.
- Store-before-write plus per-stream delivery locking makes the replay→live handoff
  exactly-once (no gaps, no duplicates).
- With no store configured, behavior is unchanged (no `id` fields, no recording).

`EventStore` is a two-method interface (`StoreEvent` / `ReplayEventsAfter`) so events can
live in shared storage for multi-node deployments; `NewInMemoryEventStore()` ships as the
single-process reference implementation. Event ids are opaque to the transport; retention
policy is the store's concern (matching the TypeScript SDK's EventStore design).

Scope: server side only. Client-side auto-resume (prior attempt in #380) would layer on
top of this and is left for a follow-up.

Tests: 13 e2e tests covering replay ordering and boundaries, capture-while-disconnected
(including the interrupted-POST response), per-stream isolation under concurrent tool
calls, listening-stream resume, supersede semantics, custom-store id opacity, invalid-id
handling, and no-store baseline. `go test ./... -race` and `golangci-lint run` are clean.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## MCP Spec Compliance

- [x] This PR implements a feature defined in the MCP specification
- [x] Link to relevant spec section: [Resumability and Redelivery](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery)
- [x] Implementation follows the specification exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional HTTP/SSE stream resumability via configurable event storage.
  * SSE messages and final tool responses can be replayed after reconnect using `Last-Event-ID` (with the session ID) for gap-free continuation.
  * Server rejects unknown, cross-session, or previously terminated event IDs with `400 Bad Request`.
  * Resuming one stream doesn’t replay messages from other streams; interrupted tool-call requests continue correctly.
* **Documentation**
  * Added a “Stream Resumability” section to HTTP transport Session Management docs.
* **Tests**
  * Added extensive end-to-end coverage for resumability scenarios.
* **Chores**
  * Improved write behavior by adding response write deadlines when streaming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->