### PR TITLE
fix(server): return 200 for HEAD requests instead of 404

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -404,6 +404,8 @@ func (s *StreamableHTTPServer) ServeHTTP(w http.ResponseWriter, r *http.Request)
 		s.handleGet(hw, hr)
 	case http.MethodDelete:
 		s.handleDelete(hw, hr)
+	case http.MethodHead:
+		w.WriteHeader(http.StatusOK)
 	default:
 		http.NotFound(w, r)
 	}

--- a/server/streamable_http_handle.go
+++ b/server/streamable_http_handle.go
@@ -199,6 +199,8 @@ func (s *StreamableHTTPServer) Handle(w HTTPResponseWriter, r *HTTPRequest) {
 		s.handleGet(w, r)
 	case http.MethodDelete:
 		s.handleDelete(w, r)
+	case http.MethodHead:
+		w.WriteHeader(http.StatusOK)
 	default:
 		writeHTTPError(w, "404 page not found", http.StatusNotFound)
 	}

--- a/server/streamable_http_handle_test.go
+++ b/server/streamable_http_handle_test.go
@@ -203,6 +203,25 @@ func TestStreamableHTTPServer_Handle_UnknownMethod(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.status)
 }
 
+func TestStreamableHTTPServer_Handle_HeadReturns200(t *testing.T) {
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	srv := NewStreamableHTTPServer(mcpServer)
+
+	w := newBufferingHTTPResponseWriter()
+	r := &HTTPRequest{
+		Method:  http.MethodHead,
+		URL:     &url.URL{Path: "/mcp"},
+		Header:  http.Header{},
+		Context: t.Context(),
+	}
+
+	srv.Handle(w, r)
+
+	assert.Equal(t, http.StatusOK, w.status)
+	assert.True(t, w.wrote)
+	assert.Empty(t, w.body)
+}
+
 func TestStreamableHTTPServer_Handle_FlushableWriterMatchesServeHTTP(t *testing.T) {
 	// A streamable HTTPResponseWriter going through Handle should produce
 	// the same JSON body as net/http's default writer going through ServeHTTP

--- a/server/streamable_http_test.go
+++ b/server/streamable_http_test.go
@@ -2523,6 +2523,20 @@ func TestStreamableHTTP_Delete(t *testing.T) {
 	assert.Equal(t, sessionID, hookSession.SessionID())
 }
 
+func TestStreamableHTTP_HeadReturns200(t *testing.T) {
+	mcpServer := NewMCPServer("test-mcp-server", "1.0")
+	sseServer := NewStreamableHTTPServer(mcpServer)
+	testServer := httptest.NewServer(sseServer)
+	defer testServer.Close()
+
+	req, _ := http.NewRequest(http.MethodHead, testServer.URL, nil)
+	resp, err := testServer.Client().Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
 func TestStreamableHTTP_DrainNotifications(t *testing.T) {
 	t.Run("drain pending notifications after response is computed", func(t *testing.T) {
 		mcpServer := NewMCPServer("test-mcp-server", "1.0")


### PR DESCRIPTION
## Description

`StreamableHTTPServer.ServeHTTP` and `Handle` only switch on POST/GET/DELETE.
All other HTTP methods fall through to the `default` branch which calls
`http.NotFound`, returning 404.

Many MCP clients and health-checkers send a HEAD request to probe endpoint
availability before issuing POST. They currently receive 404 and assume the
endpoint is down.

Add `case http.MethodHead` to both method switches, returning 200 with an
empty body.

### Real-world impact

In our production MCP gateway (Gin + `gin.WrapH`), health-checkers and
MCP clients routinely send `HEAD /mcp` to probe endpoint availability.
These requests pass through the framework router into `ServeHTTP`, hit
the `default` branch, and return 404 — causing monitors to flag the
endpoint as down.

Access log sample:

```json
{"method":"HEAD","path":"/mcp","status":404,"latency_ms":0}
```

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

Affected files:

- `server/streamable_http.go` — HEAD case in `ServeHTTP`
- `server/streamable_http_handle.go` — HEAD case in `Handle`
- `server/streamable_http_test.go` — test via `httptest.NewServer`
- `server/streamable_http_handle_test.go` — test via `Handle` directly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `HEAD` requests to the streamable HTTP endpoint returning `404 Not Found`.
  * `HEAD` requests now return `200 OK` with an empty response body.
* **Tests**
  * Added coverage to confirm `HEAD` responses return `200 OK` and do not include a response body.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->