### PR TITLE
fix(mcp): unmarshal embedded resource contents

### DIFF
--- a/mcp/errors.go
+++ b/mcp/errors.go
@@ -28,6 +28,12 @@ var (
 
 	// ErrResourceNotFound indicates a requested resource was not found (code: RESOURCE_NOT_FOUND).
 	ErrResourceNotFound = errors.New("resource not found")
+
+	// ErrEmbeddedResourceMissingVariant indicates an embedded resource has neither text nor blob content.
+	ErrEmbeddedResourceMissingVariant = errors.New("missing text or blob field")
+
+	// ErrEmbeddedResourceMissingURI indicates an embedded resource content variant has no URI.
+	ErrEmbeddedResourceMissingURI = errors.New("resource uri is missing")
 )
 
 // URLElicitationRequiredError is returned when the server requires URL elicitation to proceed.

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1293,7 +1293,7 @@ func (e *EmbeddedResource) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unmarshaling embedded text resource: %w", err)
 		}
 		if textResource.URI == "" {
-			return fmt.Errorf("unmarshaling embedded text resource: resource uri is missing")
+			return fmt.Errorf("unmarshaling embedded text resource: %w", ErrEmbeddedResourceMissingURI)
 		}
 		resource = textResource
 	} else if _, ok := resourceFields["blob"]; ok {
@@ -1302,11 +1302,11 @@ func (e *EmbeddedResource) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("unmarshaling embedded blob resource: %w", err)
 		}
 		if blobResource.URI == "" {
-			return fmt.Errorf("unmarshaling embedded blob resource: resource uri is missing")
+			return fmt.Errorf("unmarshaling embedded blob resource: %w", ErrEmbeddedResourceMissingURI)
 		}
 		resource = blobResource
 	} else {
-		return fmt.Errorf("unmarshaling embedded resource: missing text or blob field")
+		return fmt.Errorf("unmarshaling embedded resource: %w", ErrEmbeddedResourceMissingVariant)
 	}
 
 	e.Annotated = raw.Annotated

--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1268,6 +1268,54 @@ type EmbeddedResource struct {
 
 func (EmbeddedResource) isContent() {}
 
+// UnmarshalJSON implements custom JSON unmarshaling for EmbeddedResource
+// to handle the nested ResourceContents interface.
+func (e *EmbeddedResource) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Annotated
+		Meta     *Meta           `json:"_meta,omitempty"`
+		Type     string          `json:"type"`
+		Resource json.RawMessage `json:"resource"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	var resourceFields map[string]json.RawMessage
+	if err := json.Unmarshal(raw.Resource, &resourceFields); err != nil {
+		return fmt.Errorf("unmarshaling embedded resource: %w", err)
+	}
+
+	var resource ResourceContents
+	if _, ok := resourceFields["text"]; ok {
+		var textResource TextResourceContents
+		if err := json.Unmarshal(raw.Resource, &textResource); err != nil {
+			return fmt.Errorf("unmarshaling embedded text resource: %w", err)
+		}
+		if textResource.URI == "" {
+			return fmt.Errorf("unmarshaling embedded text resource: resource uri is missing")
+		}
+		resource = textResource
+	} else if _, ok := resourceFields["blob"]; ok {
+		var blobResource BlobResourceContents
+		if err := json.Unmarshal(raw.Resource, &blobResource); err != nil {
+			return fmt.Errorf("unmarshaling embedded blob resource: %w", err)
+		}
+		if blobResource.URI == "" {
+			return fmt.Errorf("unmarshaling embedded blob resource: resource uri is missing")
+		}
+		resource = blobResource
+	} else {
+		return fmt.Errorf("unmarshaling embedded resource: missing text or blob field")
+	}
+
+	e.Annotated = raw.Annotated
+	e.Meta = raw.Meta
+	e.Type = raw.Type
+	e.Resource = resource
+	return nil
+}
+
 // ToolUseContent represents a request from the assistant to call a tool within a sampling message.
 // It must have Type set to "tool_use".
 type ToolUseContent struct {

--- a/mcp/utils_additional_test.go
+++ b/mcp/utils_additional_test.go
@@ -288,6 +288,191 @@ func TestParseGetPromptResult_Errors(t *testing.T) {
 	})
 }
 
+func TestParseCallToolResult_EmbeddedResource(t *testing.T) {
+	raw := json.RawMessage(`{
+		"content": [{
+			"type": "resource",
+			"resource": {
+				"uri": "file:///main.go",
+				"mimeType": "text/x-go",
+				"text": "package main"
+			}
+		}]
+	}`)
+
+	result, err := ParseCallToolResult(&raw)
+	require.NoError(t, err)
+	require.Len(t, result.Content, 1)
+
+	embedded, ok := result.Content[0].(EmbeddedResource)
+	require.True(t, ok)
+	resource, ok := embedded.Resource.(TextResourceContents)
+	require.True(t, ok)
+	assert.Equal(t, "file:///main.go", resource.URI)
+	assert.Equal(t, "text/x-go", resource.MIMEType)
+	assert.Equal(t, "package main", resource.Text)
+}
+
+func TestEmbeddedResourceUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		jsonData string
+		expected EmbeddedResource
+	}{
+		{
+			name: "text resource with metadata and annotations",
+			jsonData: `{
+				"type": "resource",
+				"annotations": {
+					"audience": ["user"],
+					"lastModified": "2026-07-22T00:00:00Z"
+				},
+				"_meta": {"source": "github"},
+				"resource": {
+					"uri": "file:///README.md",
+					"mimeType": "text/markdown",
+					"text": "# Project",
+					"_meta": {"etag": "abc123"}
+				}
+			}`,
+			expected: EmbeddedResource{
+				Annotated: Annotated{Annotations: &Annotations{
+					Audience:     []Role{RoleUser},
+					LastModified: "2026-07-22T00:00:00Z",
+				}},
+				Meta: NewMetaFromMap(map[string]any{"source": "github"}),
+				Type: ContentTypeResource,
+				Resource: TextResourceContents{
+					Meta:     map[string]any{"etag": "abc123"},
+					URI:      "file:///README.md",
+					MIMEType: "text/markdown",
+					Text:     "# Project",
+				},
+			},
+		},
+		{
+			name: "blob resource",
+			jsonData: `{
+				"type": "resource",
+				"resource": {
+					"uri": "file:///image.png",
+					"mimeType": "image/png",
+					"blob": "aGVsbG8="
+				}
+			}`,
+			expected: EmbeddedResource{
+				Type: ContentTypeResource,
+				Resource: BlobResourceContents{
+					URI:      "file:///image.png",
+					MIMEType: "image/png",
+					Blob:     "aGVsbG8=",
+				},
+			},
+		},
+		{
+			name:     "empty text resource",
+			jsonData: `{"type":"resource","resource":{"uri":"file:///empty.txt","text":""}}`,
+			expected: EmbeddedResource{
+				Type: ContentTypeResource,
+				Resource: TextResourceContents{
+					URI:  "file:///empty.txt",
+					Text: "",
+				},
+			},
+		},
+		{
+			name:     "empty blob resource",
+			jsonData: `{"type":"resource","resource":{"uri":"file:///empty.bin","blob":""}}`,
+			expected: EmbeddedResource{
+				Type: ContentTypeResource,
+				Resource: BlobResourceContents{
+					URI:  "file:///empty.bin",
+					Blob: "",
+				},
+			},
+		},
+		{
+			name:     "text takes precedence when both variants are present",
+			jsonData: `{"type":"resource","resource":{"uri":"file:///both","text":"text","blob":"YmxvYg=="}}`,
+			expected: EmbeddedResource{
+				Type: ContentTypeResource,
+				Resource: TextResourceContents{
+					URI:  "file:///both",
+					Text: "text",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result EmbeddedResource
+			err := json.Unmarshal([]byte(tt.jsonData), &result)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEmbeddedResourceUnmarshalJSON_Errors(t *testing.T) {
+	tests := []struct {
+		name       string
+		jsonData   string
+		errMessage string
+	}{
+		{
+			name:       "resource is not an object",
+			jsonData:   `{"type":"resource","resource":"not an object"}`,
+			errMessage: "unmarshaling embedded resource",
+		},
+		{
+			name:       "resource variant is missing",
+			jsonData:   `{"type":"resource","resource":{"uri":"file:///missing"}}`,
+			errMessage: "missing text or blob field",
+		},
+		{
+			name:       "resource uri is missing",
+			jsonData:   `{"type":"resource","resource":{"text":"content"}}`,
+			errMessage: "resource uri is missing",
+		},
+		{
+			name:       "text has invalid type",
+			jsonData:   `{"type":"resource","resource":{"uri":"file:///invalid","text":42}}`,
+			errMessage: "unmarshaling embedded text resource",
+		},
+		{
+			name:       "blob has invalid type",
+			jsonData:   `{"type":"resource","resource":{"uri":"file:///invalid","blob":42}}`,
+			errMessage: "unmarshaling embedded blob resource",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var result EmbeddedResource
+			err := json.Unmarshal([]byte(tt.jsonData), &result)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.errMessage)
+		})
+	}
+}
+
+func TestEmbeddedResourceJSONRoundTrip(t *testing.T) {
+	original := NewEmbeddedResource(TextResourceContents{
+		Meta:     map[string]any{"etag": "abc123"},
+		URI:      "file:///README.md",
+		MIMEType: "text/markdown",
+		Text:     "# Project",
+	})
+
+	data, err := json.Marshal(original)
+	require.NoError(t, err)
+
+	var result EmbeddedResource
+	require.NoError(t, json.Unmarshal(data, &result))
+	assert.Equal(t, original, result)
+}
+
 // Test ParseCallToolResult with malformed JSON
 
 func TestParseCallToolResult_Errors(t *testing.T) {

--- a/mcp/utils_additional_test.go
+++ b/mcp/utils_additional_test.go
@@ -419,6 +419,7 @@ func TestEmbeddedResourceUnmarshalJSON_Errors(t *testing.T) {
 		name       string
 		jsonData   string
 		errMessage string
+		sentinel   error
 	}{
 		{
 			name:       "resource is not an object",
@@ -429,11 +430,19 @@ func TestEmbeddedResourceUnmarshalJSON_Errors(t *testing.T) {
 			name:       "resource variant is missing",
 			jsonData:   `{"type":"resource","resource":{"uri":"file:///missing"}}`,
 			errMessage: "missing text or blob field",
+			sentinel:   ErrEmbeddedResourceMissingVariant,
 		},
 		{
-			name:       "resource uri is missing",
+			name:       "text resource uri is missing",
 			jsonData:   `{"type":"resource","resource":{"text":"content"}}`,
 			errMessage: "resource uri is missing",
+			sentinel:   ErrEmbeddedResourceMissingURI,
+		},
+		{
+			name:       "blob resource uri is missing",
+			jsonData:   `{"type":"resource","resource":{"blob":"YmxvYg=="}}`,
+			errMessage: "resource uri is missing",
+			sentinel:   ErrEmbeddedResourceMissingURI,
 		},
 		{
 			name:       "text has invalid type",
@@ -453,6 +462,9 @@ func TestEmbeddedResourceUnmarshalJSON_Errors(t *testing.T) {
 			err := json.Unmarshal([]byte(tt.jsonData), &result)
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.errMessage)
+			if tt.sentinel != nil {
+				assert.True(t, errors.Is(err, tt.sentinel))
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

`ParseCallToolResult` sends each content item through `encoding/json`, but an embedded resource contains the non-empty `ResourceContents` interface. The decoder therefore cannot choose `TextResourceContents` or `BlobResourceContents`, causing valid tool responses with `type: "resource"` to fail.

## Changes

- add concrete text/blob dispatch while unmarshaling `EmbeddedResource`
- preserve empty resource bodies, annotations, and outer/resource `_meta`
- reject selected resources missing their required URI
- expose URI/variant validation errors through documented sentinels for `errors.Is`
- add regression coverage for the reported tool-result path and decoding boundaries

Fixes #934

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Documentation is unchanged because package Go documentation defines the new error contracts and MCP wire behavior is unchanged

## Verification

```bash
go test -v './...'
cd otel && go test -v './...'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic JSON decoding for embedded resources, resolving embedded content as either text or blob.
  * Preserves top-level and nested annotations and metadata during decoding and round-tripping.
  * Validates embedded resource variants, including required URI handling.
* **Bug Fixes**
  * Improved parsing of tool results that include embedded resources.
  * Added stricter error handling for malformed embedded resource shapes and missing/invalid content.
* **Tests**
  * Added comprehensive unit tests for embedded resource decoding, precedence behavior, error cases, and JSON round-trip correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->