### PR TITLE
fix(server): recover panics in executeRegularToolAsTask (hybrid task mode)

### DIFF
--- a/server/regular_tool_as_task_panic_test.go
+++ b/server/regular_tool_as_task_panic_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestExecuteRegularToolAsTask_PanicRecovery mirrors
+// TestExecuteTaskTool_PanicRecovery (added in #880) for the sibling code
+// path: a regular ServerTool with TaskSupportOptional invoked asynchronously
+// via the hybrid task mode. That fix covered executeTaskTool but did not
+// touch executeRegularToolAsTask, which still ran without panic recovery --
+// an unrecovered panic in this goroutine crashes the whole server process.
+func TestExecuteRegularToolAsTask_PanicRecovery(t *testing.T) {
+	s := NewMCPServer("test", "1.0.0")
+
+	regularTool := ServerTool{
+		Tool: mcp.Tool{
+			Name:        "panic-regular-tool",
+			Description: "A regular tool that panics when run as a task",
+		},
+		Handler: func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			panic("deliberate panic in regular tool handler run as a task")
+		},
+	}
+
+	ctx := t.Context()
+	taskID := "test-regular-panic-task"
+	entry, err := s.createTask(ctx, taskID, "panic-regular-tool", nil, nil)
+	require.NoError(t, err)
+
+	request := mcp.CallToolRequest{}
+	request.Params.Name = "panic-regular-tool"
+
+	// Execute in a goroutine, same as the production hybrid-mode path.
+	go s.executeRegularToolAsTask(ctx, entry, regularTool, request)
+
+	select {
+	case <-entry.done:
+		// Task completed without crashing the process.
+	case <-time.After(5 * time.Second):
+		t.Fatal("task did not complete within timeout; panic recovery may have failed")
+	}
+
+	s.tasksMu.RLock()
+	assert.True(t, entry.completed)
+	assert.Equal(t, mcp.TaskStatusFailed, entry.task.Status)
+	assert.Contains(t, entry.task.StatusMessage, "panic in task tool handler")
+	assert.Contains(t, entry.task.StatusMessage, "deliberate panic in regular tool handler run as a task")
+	s.tasksMu.RUnlock()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -2222,6 +2222,12 @@ func (s *MCPServer) executeRegularToolAsTask(
 	regularTool ServerTool,
 	request mcp.CallToolRequest,
 ) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.completeTask(entry, nil, fmt.Errorf("panic in task tool handler %s: %v", request.Params.Name, r))
+		}
+	}()
+
 	// Create cancellable context for this task execution
 	taskCtx, cancel := context.WithCancel(ctx)
 	defer cancel()


### PR DESCRIPTION
### Summary

Adds panic recovery to `executeRegularToolAsTask`, the goroutine used when a regular tool with `TaskSupportOptional` is invoked asynchronously (called with task params) in hybrid mode.

### Problem

#880 added panic recovery to `executeTaskTool` after a report that an unrecovered panic in that goroutine would crash the whole server. That fix didn't cover the sibling function, `executeRegularToolAsTask`, which still runs without a recover guard.

Reproduced directly: a panicking handler run through this path propagates the panic uncaught out of the goroutine, which in Go terminates the entire process -- not just the failing request. Any tool registered with `TaskSupportOptional` that panics when called asynchronously currently takes down the server for every connected client.

### Fix

Mirrors #880's exact pattern -- a `defer`/`recover()` that completes the task as `Failed` with the panic message via `completeTask`, instead of letting the panic escape.

### Testing

- Added `TestExecuteRegularToolAsTask_PanicRecovery`, mirroring #880's own `TestExecuteTaskTool_PanicRecovery`.
- Confirmed the test crashes the process on `main` (unrecovered panic) and passes cleanly with this change.
- Full suite (`go build`, `go vet`, `go test ./...`, `go test -race ./server/...`): all green, zero regressions.

### Note on related open PRs

#900 and #889 both address a different bug in this same function (context cancellation cascading from the HTTP request lifecycle, #897) via different mechanisms. Neither touches panic recovery, and neither conflicts with this change at the line level -- this PR only adds a `defer` block at the top of the function body.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when asynchronous tool execution encounters a panic.
  * Failed tasks now receive a completed status with a clear error message, including the original failure details.
  * Added coverage to verify panic recovery and accurate task status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->