### PR TITLE
fix(server): flush final SSE response in handlePost

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -851,6 +851,7 @@ drainLoop:
 		if err := writeSSEEvent(w, response); err != nil {
 			s.logger.Error("Failed to write final SSE response event", "err", err)
 		}
+		w.Flush()
 	} else {
 		w.Header().Set("Content-Type", "application/json")
 		if isInitializeRequest && sessionID != "" {


### PR DESCRIPTION
Fixes #944.

## Problem

When a session is upgraded to SSE (`session.upgradeToSSE.Load()`) or the response was already upgraded during notification handling (`upgradedHeader`), `handlePost` writes the JSON-RPC response as a trailing SSE event via `writeSSEEvent(w, response)` but never flushes afterward. Every other SSE write site in this function does:

- the per-notification branch: `defer w.Flush()`
- the drain loop: `w.Flush()` after every `writeSSEEvent(w, nt)`
- the final-response branch (this one): nothing

## Impact

Once a session receives any server-sent notification, every subsequent POST response for that session goes through this unflushed SSE path. Behind an intermediary that needs an explicit flush per HTTP/2 chunk to forward data promptly (rather than relying on the handler returning), the response body never reaches the client. Streamable-HTTP clients that open the long-lived GET listen-stream (e.g. the official TypeScript SDK's `StreamableHTTPClientTransport`, used as-is with no special config) can end up waiting on their own client-side timeout and failing with `MCP error -32001: Request timed out`, even though the server logged nothing wrong and returned 200.

Full repro details and the real-world trace that surfaced this are in #944.

## Fix

One line: add `w.Flush()` after the final `writeSSEEvent(w, response)`, matching the existing pattern used everywhere else in this handler.

## Testing

- `go build ./...` passes.
- `go test ./server/...` passes, including the existing `TestStreamableHTTP_NotificationUpgradeDoesNotCorruptResponse` and `TestStreamableHTTPNotificationRace` tests covering adjacent behavior in this same code path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured final streaming responses are delivered immediately instead of remaining buffered.
  * Improved reliability for clients receiving server-sent events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->