### PR TITLE
Fix #943: refuse unsupported subscribe requests

### DIFF
--- a/server/resource_subscribe_test.go
+++ b/server/resource_subscribe_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"slices"
 	"sync"
 	"testing"
@@ -69,6 +70,21 @@ func (s *sessionWithSubscriptions) IsSubscribedToResource(uri string) bool {
 
 // Compile-time check.
 var _ SessionWithResourceSubscriptions = (*sessionWithSubscriptions)(nil)
+
+type sessionWithSubscriptionErrors struct {
+	*sessionWithSubscriptions
+	allowed map[string]struct{}
+}
+
+func (s *sessionWithSubscriptionErrors) SubscribeToResourceErr(uri string) error {
+	if _, ok := s.allowed[uri]; !ok {
+		return errors.New("resource is not subscribable")
+	}
+	s.SubscribeToResource(uri)
+	return nil
+}
+
+var _ SessionWithResourceSubscriptionsErr = (*sessionWithSubscriptionErrors)(nil)
 
 // TestMCPServer_SubscribeUnsubscribe_DispatcherWiring is the regression test
 // for https://github.com/mark3labs/mcp-go/issues/865. It verifies that
@@ -223,6 +239,41 @@ func TestMCPServer_Subscribe_TracksSessionState(t *testing.T) {
 	got = session.SubscribedResources()
 	assert.Equal(t, []string{"file:///b"}, got)
 	assert.False(t, session.IsSubscribedToResource("file:///a"))
+}
+
+func TestMCPServer_Subscribe_SessionCanRejectURI(t *testing.T) {
+	t.Parallel()
+
+	srv := NewMCPServer("test", "0.0.1", WithResourceCapabilities(true, false))
+	session := &sessionWithSubscriptionErrors{
+		sessionWithSubscriptions: newSessionWithSubscriptions("sess-1"),
+		allowed:                  map[string]struct{}{"file:///allowed": {}},
+	}
+	require.NoError(t, srv.RegisterSession(t.Context(), session))
+
+	ctx := srv.WithContext(t.Context(), session)
+	request := func(uri string) mcp.JSONRPCMessage {
+		t.Helper()
+		msg, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "resources/subscribe",
+			"params":  map[string]string{"uri": uri},
+		})
+		require.NoError(t, err)
+		return srv.HandleMessage(ctx, msg)
+	}
+
+	response := request("file:///not-found")
+	errResponse, ok := response.(mcp.JSONRPCError)
+	require.True(t, ok, "expected JSONRPCError, got %T: %#v", response, response)
+	assert.Equal(t, mcp.RESOURCE_NOT_FOUND, errResponse.Error.Code)
+	assert.False(t, session.IsSubscribedToResource("file:///not-found"))
+
+	response = request("file:///allowed")
+	_, ok = response.(mcp.JSONRPCResponse)
+	require.True(t, ok, "expected JSONRPCResponse, got %T: %#v", response, response)
+	assert.True(t, session.IsSubscribedToResource("file:///allowed"))
 }
 
 // TestMCPServer_Subscribe_HooksFire confirms the generator wired up

--- a/server/server.go
+++ b/server/server.go
@@ -1246,7 +1246,16 @@ func (s *MCPServer) handleSubscribe(
 	}
 
 	if session := ClientSessionFromContext(ctx); session != nil {
-		if subs, ok := session.(SessionWithResourceSubscriptions); ok {
+		switch subs := session.(type) {
+		case SessionWithResourceSubscriptionsErr:
+			if err := subs.SubscribeToResourceErr(request.Params.URI); err != nil {
+				return nil, &requestError{
+					id:   id,
+					code: mcp.RESOURCE_NOT_FOUND,
+					err:  err,
+				}
+			}
+		case SessionWithResourceSubscriptions:
 			subs.SubscribeToResource(request.Params.URI)
 		}
 	}

--- a/server/session.go
+++ b/server/session.go
@@ -80,6 +80,22 @@ type SessionWithResourceSubscriptions interface {
 	IsSubscribedToResource(uri string) bool
 }
 
+// SessionWithResourceSubscriptionsErr is an optional extension of
+// SessionWithResourceSubscriptions whose SubscribeToResourceErr method can
+// reject a subscription. When a session implements this interface, MCPServer
+// uses SubscribeToResourceErr in preference to SubscribeToResource and returns
+// RESOURCE_NOT_FOUND if it reports an error.
+//
+// Implementations must be safe for concurrent use because requests and
+// notifications may run on independent goroutines.
+type SessionWithResourceSubscriptionsErr interface {
+	SessionWithResourceSubscriptions
+	// SubscribeToResourceErr records that this session has subscribed to updates
+	// for the given resource URI, or returns an error if the URI cannot be
+	// subscribed to.
+	SubscribeToResourceErr(uri string) error
+}
+
 // SessionWithResourceTemplates is an extension of ClientSession that can store session-specific resource template data
 type SessionWithResourceTemplates interface {
 	ClientSession


### PR DESCRIPTION
## Description

Refuse subscribe requests when the server does not implement the required subscription interface. This ensures unsupported subscriptions are rejected instead of being accepted.

Fixes #943

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)
* [ ] New feature (non-breaking change that adds functionality)
* [ ] MCP spec compatibility implementation
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Code refactoring (no functional changes)
* [ ] Performance improvement
* [ ] Tests only (no functional changes)
* [ ] Other (please describe):

## Checklist

* [x] My code follows the code style of this project
* [x] I have performed a self-review of my own code
* [x] I have added tests that prove my fix is effective or that my feature works
* [ ] I have updated the documentation accordingly

## Additional Information

This change implements the interface-based handling proposed in the issue discussion and preserves existing behavior for servers that support subscriptions while correctly rejecting unsupported subscribe requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Subscription requests can now report when a requested resource is unavailable.
  * Failed subscriptions return a clear “resource not found” error without altering session state.
  * Existing subscription behavior remains supported for sessions that do not use error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->