### PR TITLE
fix: rewrite draft-07 definitions refs when adopting them as $defs

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 )
 
 var errToolSchemaConflict = errors.New("provide either InputSchema or RawInputSchema, not both")
@@ -807,12 +808,38 @@ func toolArgumentsSchemaUnmarshalJSON(data []byte, tis *ToolArgumentsSchema) err
 		return err
 	}
 
-	// If $defs wasn't provided but definitions was, use definitions
+	// If $defs wasn't provided but definitions was, use definitions.
+	// Marshaling re-emits Defs as "$defs", so local "#/definitions/..." $ref
+	// pointers must be rewritten to "#/$defs/..." or the round-tripped schema
+	// carries dangling references that strict validators reject.
 	if tis.Defs == nil && aux.Definitions != nil {
 		tis.Defs = aux.Definitions
+		rewriteDraft07LocalRefs(tis.Defs)
+		rewriteDraft07LocalRefs(tis.Properties)
+		rewriteDraft07LocalRefs(tis.AdditionalProperties)
 	}
 
 	return nil
+}
+
+// rewriteDraft07LocalRefs rewrites local draft-07 "#/definitions/..." $ref
+// pointers to their 2019-09+ "#/$defs/..." equivalent in place. It walks
+// nested maps and slices; non-local refs are left untouched.
+func rewriteDraft07LocalRefs(node any) {
+	const draft07Prefix = "#/definitions/"
+	switch v := node.(type) {
+	case map[string]any:
+		if ref, ok := v["$ref"].(string); ok && strings.HasPrefix(ref, draft07Prefix) {
+			v["$ref"] = "#/$defs/" + ref[len(draft07Prefix):]
+		}
+		for _, child := range v {
+			rewriteDraft07LocalRefs(child)
+		}
+	case []any:
+		for _, child := range v {
+			rewriteDraft07LocalRefs(child)
+		}
+	}
 }
 
 type ToolAnnotation struct {

--- a/mcp/tools_test.go
+++ b/mcp/tools_test.go
@@ -1832,6 +1832,53 @@ func TestToolArgumentsSchema_UnmarshalWithDefinitions(t *testing.T) {
 	assert.NotNil(t, operationType["enum"])
 }
 
+func TestToolArgumentsSchema_DefinitionsRoundTripKeepsRefsResolvable(t *testing.T) {
+	// A draft-07 schema whose properties $ref into "definitions". Marshaling
+	// re-emits Defs as "$defs", so unmarshal must rewrite local refs or the
+	// round-tripped schema carries dangling "#/definitions/..." pointers that
+	// strict validators (e.g. xAI) reject.
+	jsonData := `{
+		"type": "object",
+		"properties": {
+			"body": {
+				"allOf": [{"$ref": "#/definitions/json_value"}]
+			}
+		},
+		"definitions": {
+			"json_value": {
+				"anyOf": [
+					{"type": "string"},
+					{"type": "array", "items": {"$ref": "#/definitions/json_value"}}
+				]
+			}
+		}
+	}`
+
+	var schema ToolArgumentsSchema
+	require.NoError(t, json.Unmarshal([]byte(jsonData), &schema))
+
+	out, err := json.Marshal(schema)
+	require.NoError(t, err)
+	assert.NotContains(t, string(out), "#/definitions/",
+		"round-tripped schema must not reference the renamed definitions key")
+
+	var roundTripped map[string]any
+	require.NoError(t, json.Unmarshal(out, &roundTripped))
+	defs, ok := roundTripped["$defs"].(map[string]any)
+	require.True(t, ok, "definitions must be re-emitted as $defs")
+	assert.Contains(t, defs, "json_value")
+
+	properties, ok := roundTripped["properties"].(map[string]any)
+	require.True(t, ok)
+	body, ok := properties["body"].(map[string]any)
+	require.True(t, ok)
+	allOf, ok := body["allOf"].([]any)
+	require.True(t, ok)
+	ref, ok := allOf[0].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "#/$defs/json_value", ref["$ref"])
+}
+
 func TestToolArgumentsSchema_UnmarshalWithDefs(t *testing.T) {
 	// Test that "$defs" (JSON Schema 2019-09+) is properly unmarshaled into Defs field
 	jsonData := `{


### PR DESCRIPTION
## Description

Fixes #949.

`toolArgumentsSchemaUnmarshalJSON` accepts a draft-07 `definitions` map by storing it in `Defs`, but marshaling always re-emits `Defs` as `$defs`. Local `"#/definitions/..."` `$ref` pointers were left untouched, so any round-tripped draft-07 schema (e.g. zod-to-json-schema output for recursive schemas, common across TypeScript MCP servers) carried dangling references. Strict tool-schema validators — xAI grok rejects the entire chat request with `unresolvable $ref '#/definitions/...'` — fail on these, while lenient providers silently ignore them, so the corruption goes unnoticed until a strict provider is in the loop.

## Changes

- `mcp/tools.go`: when `definitions` is adopted into `Defs`, rewrite local `#/definitions/...` refs to `#/$defs/...` throughout `Defs`, `Properties`, and `AdditionalProperties` (recursive walk; non-local refs untouched). Schemas that already use `$defs` are unaffected.
- `mcp/tools_test.go`: round-trip test with a recursive draft-07 schema asserting no `#/definitions/` pointer survives and refs resolve against the emitted `$defs`.

## Testing

`go test ./...` passes. New test `TestToolArgumentsSchema_DefinitionsRoundTripKeepsRefsResolvable` fails without the fix (`$ref` = `#/definitions/json_value` against a root that only has `$defs`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with draft-07 schemas by preserving and resolving local definition references after schema conversion and serialization.
  * Ensured nested properties, arrays, additional-property schemas, and recursive references remain intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->