### PR TITLE
fix(mcp): accept empty text and blob resource contents

### DIFF
--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -832,7 +832,11 @@ func ParseResourceContents(contentMap map[string]any) (ResourceContents, error) 
 		return nil, fmt.Errorf("_meta must be an object")
 	}
 
-	if text := ExtractString(contentMap, "text"); text != "" {
+	// Select the variant on the presence of a string "text" or "blob" field,
+	// not on its emptiness. An empty resource is still a resource, and both
+	// fields marshal unconditionally, so treating "" as absent rejected
+	// payloads this library itself produces.
+	if text, ok := contentMap["text"].(string); ok {
 		return TextResourceContents{
 			Meta:     meta,
 			URI:      uri,
@@ -841,7 +845,7 @@ func ParseResourceContents(contentMap map[string]any) (ResourceContents, error) 
 		}, nil
 	}
 
-	if blob := ExtractString(contentMap, "blob"); blob != "" {
+	if blob, ok := contentMap["blob"].(string); ok {
 		return BlobResourceContents{
 			Meta:     meta,
 			URI:      uri,

--- a/mcp/utils_additional_test.go
+++ b/mcp/utils_additional_test.go
@@ -223,6 +223,40 @@ func TestParseResourceContents(t *testing.T) {
 		assert.Contains(t, err.Error(), "uri is missing")
 	})
 
+	t.Run("empty text resource", func(t *testing.T) {
+		contentMap := map[string]any{
+			"uri":      "file:///empty.txt",
+			"mimeType": "text/plain",
+			"text":     "",
+		}
+
+		result, err := ParseResourceContents(contentMap)
+		require.NoError(t, err)
+
+		textRes, ok := result.(TextResourceContents)
+		require.True(t, ok)
+		assert.Equal(t, "file:///empty.txt", textRes.URI)
+		assert.Equal(t, "text/plain", textRes.MIMEType)
+		assert.Empty(t, textRes.Text)
+	})
+
+	t.Run("empty blob resource", func(t *testing.T) {
+		contentMap := map[string]any{
+			"uri":      "file:///empty.bin",
+			"mimeType": "application/octet-stream",
+			"blob":     "",
+		}
+
+		result, err := ParseResourceContents(contentMap)
+		require.NoError(t, err)
+
+		blobRes, ok := result.(BlobResourceContents)
+		require.True(t, ok)
+		assert.Equal(t, "file:///empty.bin", blobRes.URI)
+		assert.Equal(t, "application/octet-stream", blobRes.MIMEType)
+		assert.Empty(t, blobRes.Blob)
+	})
+
 	t.Run("no text or blob", func(t *testing.T) {
 		contentMap := map[string]any{
 			"uri": "file:///test",
@@ -232,6 +266,40 @@ func TestParseResourceContents(t *testing.T) {
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "unsupported resource type")
 	})
+
+	t.Run("non-string text falls through", func(t *testing.T) {
+		contentMap := map[string]any{
+			"uri":  "file:///test",
+			"text": 42,
+		}
+
+		_, err := ParseResourceContents(contentMap)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported resource type")
+	})
+}
+
+// Test that a resources/read response carrying an empty text resource round
+// trips through ParseReadResourceResult, which is the path Client.ReadResource
+// takes.
+
+func TestParseReadResourceResultEmptyText(t *testing.T) {
+	payload, err := json.Marshal(ReadResourceResult{
+		Contents: []ResourceContents{
+			TextResourceContents{URI: "file:///empty.txt", MIMEType: "text/plain"},
+		},
+	})
+	require.NoError(t, err)
+
+	raw := json.RawMessage(payload)
+	result, err := ParseReadResourceResult(&raw)
+	require.NoError(t, err)
+	require.Len(t, result.Contents, 1)
+
+	textRes, ok := result.Contents[0].(TextResourceContents)
+	require.True(t, ok)
+	assert.Equal(t, "file:///empty.txt", textRes.URI)
+	assert.Empty(t, textRes.Text)
 }
 
 // Test ParseGetPromptResult with malformed JSON


### PR DESCRIPTION
## Description

`ParseResourceContents` picks the `TextResourceContents` / `BlobResourceContents` variant by
testing the decoded field for emptiness:

```go
if text := ExtractString(contentMap, "text"); text != "" {
    return TextResourceContents{...}, nil
}

if blob := ExtractString(contentMap, "blob"); blob != "" {
    return BlobResourceContents{...}, nil
}

return nil, fmt.Errorf("unsupported resource type")
```

`ExtractString` returns `""` both when a field is missing and when it is present but empty, so a
resource whose payload is the empty string matches neither branch and falls through to
`unsupported resource type`. An empty resource is a normal thing to serve: an empty file, a log
that has not been written to yet, a freshly created config.

Neither field is `omitempty`:

```go
Text string `json:"text"`
Blob string `json:"blob"`
```

so a server returning `TextResourceContents{URI: "file:///empty.txt", MIMEType: "text/plain"}`
puts `"text": ""` on the wire, and a client reading it back gets an error instead of the
resource. `Client.ReadResource` -> `readResourceOnce` -> `ParseReadResourceResult` ->
`ParseResourceContents` is the path, so this round trip fails between an mcp-go server and an
mcp-go client. `ParseContent` reaches the same function for `type: "resource"`, so embedded
resources in prompt and sampling content fail the same way.

## Fix

Select the variant on the presence of a string field rather than on its value:

```go
if text, ok := contentMap["text"].(string); ok {
    return TextResourceContents{...}, nil
}

if blob, ok := contentMap["blob"].(string); ok {
    return BlobResourceContents{...}, nil
}
```

A missing field, a JSON `null` and a non-string value all still fail the type assertion and fall
through to `unsupported resource type`, so the existing error cases are unchanged.

## Tests

`TestParseResourceContents` gains `empty text resource`, `empty blob resource` and
`non-string text falls through`; `TestParseReadResourceResultEmptyText` marshals a
`ReadResourceResult` holding an empty text resource and asserts it parses back through the
`Client.ReadResource` path. The first three fail on `main` with `unsupported resource type`.

`go test ./mcp/...` passes in full, `go vet ./mcp/...` is clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Empty text and binary resource payloads are now accepted and parsed correctly.
  - Invalid non-string text values continue to be rejected.
  - Empty text resources can now be read correctly from resource results.
- **Tests**
  - Expanded coverage for empty text and binary payloads, invalid text values, and resource result parsing.
  - Consolidated related parsing scenarios into a clearer, table-driven test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->