### PR TITLE
feat(client): add context-aware task polling helper

### DIFF
--- a/client/task_wait.go
+++ b/client/task_wait.go
@@ -1,0 +1,62 @@
+package client
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+var (
+	// ErrInvalidFallbackPollInterval is returned when WaitForTask receives a
+	// non-positive fallback polling interval.
+	ErrInvalidFallbackPollInterval = errors.New("fallback poll interval must be greater than zero")
+	// ErrServerPollIntervalOverflow is returned when a server-provided polling
+	// interval cannot be represented by time.Duration.
+	ErrServerPollIntervalOverflow = errors.New("server poll interval exceeds time.Duration")
+)
+
+// WaitForTask polls a task until it reaches a terminal state or the context is done.
+// The server-provided poll interval takes precedence over fallbackPollInterval.
+func (c *Client) WaitForTask(
+	ctx context.Context,
+	request mcp.GetTaskRequest,
+	fallbackPollInterval time.Duration,
+) (*mcp.GetTaskResult, error) {
+	if fallbackPollInterval <= 0 {
+		return nil, ErrInvalidFallbackPollInterval
+	}
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+
+		result, err := c.GetTask(ctx, request)
+		if err != nil {
+			return nil, fmt.Errorf("get task: %w", err)
+		}
+		if result.Status.IsTerminal() {
+			return result, nil
+		}
+
+		interval := fallbackPollInterval
+		if result.PollInterval != nil && *result.PollInterval > 0 {
+			const maxPollIntervalMilliseconds = int64(1<<63-1) / int64(time.Millisecond)
+			if *result.PollInterval > maxPollIntervalMilliseconds {
+				return nil, ErrServerPollIntervalOverflow
+			}
+			interval = time.Duration(*result.PollInterval) * time.Millisecond
+		}
+
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}

--- a/client/task_wait_test.go
+++ b/client/task_wait_test.go
@@ -1,0 +1,192 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/client/transport"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClient_WaitForTask(t *testing.T) {
+	tests := []struct {
+		name       string
+		responses  []mcp.Task
+		fallback   time.Duration
+		wantStatus mcp.TaskStatus
+		wantCalls  int
+	}{
+		{
+			name: "returns an already terminal task without waiting",
+			responses: []mcp.Task{
+				{TaskId: "task-1", Status: mcp.TaskStatusCompleted},
+			},
+			fallback:   time.Second,
+			wantStatus: mcp.TaskStatusCompleted,
+			wantCalls:  1,
+		},
+		{
+			name: "polls until the task reaches a terminal state",
+			responses: []mcp.Task{
+				{TaskId: "task-1", Status: mcp.TaskStatusWorking},
+				{TaskId: "task-1", Status: mcp.TaskStatusFailed},
+			},
+			fallback:   time.Millisecond,
+			wantStatus: mcp.TaskStatusFailed,
+			wantCalls:  2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			transport := newTaskSequenceTransport(tt.responses)
+			client := NewClient(transport, WithSession())
+
+			result, err := client.WaitForTask(t.Context(), mcp.GetTaskRequest{
+				Params: mcp.GetTaskParams{TaskId: "task-1"},
+			}, tt.fallback)
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantStatus, result.Status)
+			assert.Equal(t, tt.wantCalls, transport.callCount())
+		})
+	}
+}
+
+func TestClient_WaitForTask_UsesServerPollInterval(t *testing.T) {
+	pollInterval := int64(40)
+	transport := newTaskSequenceTransport([]mcp.Task{
+		{TaskId: "task-1", Status: mcp.TaskStatusWorking, PollInterval: &pollInterval},
+		{TaskId: "task-1", Status: mcp.TaskStatusCompleted},
+	})
+	client := NewClient(transport, WithSession())
+
+	started := time.Now()
+	_, err := client.WaitForTask(t.Context(), mcp.GetTaskRequest{
+		Params: mcp.GetTaskParams{TaskId: "task-1"},
+	}, time.Millisecond)
+
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, time.Since(started), 30*time.Millisecond)
+}
+
+func TestClient_WaitForTask_ContextCancellationInterruptsPolling(t *testing.T) {
+	pollInterval := int64(60_000)
+	transport := newTaskSequenceTransport([]mcp.Task{
+		{TaskId: "task-1", Status: mcp.TaskStatusWorking, PollInterval: &pollInterval},
+	})
+	client := NewClient(transport, WithSession())
+	ctx, cancel := context.WithCancel(t.Context())
+	transport.afterResponse = cancel
+
+	_, err := client.WaitForTask(ctx, mcp.GetTaskRequest{
+		Params: mcp.GetTaskParams{TaskId: "task-1"},
+	}, time.Second)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Equal(t, 1, transport.callCount())
+}
+
+func TestClient_WaitForTask_RejectsNonPositiveFallbackInterval(t *testing.T) {
+	client := NewClient(newTaskSequenceTransport(nil), WithSession())
+
+	_, err := client.WaitForTask(t.Context(), mcp.GetTaskRequest{
+		Params: mcp.GetTaskParams{TaskId: "task-1"},
+	}, 0)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrInvalidFallbackPollInterval)
+}
+
+func TestClient_WaitForTask_RejectsOverflowingServerPollInterval(t *testing.T) {
+	pollInterval := int64(1<<63-1)/int64(time.Millisecond) + 1
+	client := NewClient(newTaskSequenceTransport([]mcp.Task{
+		{TaskId: "task-1", Status: mcp.TaskStatusWorking, PollInterval: &pollInterval},
+	}), WithSession())
+
+	_, err := client.WaitForTask(t.Context(), mcp.GetTaskRequest{
+		Params: mcp.GetTaskParams{TaskId: "task-1"},
+	}, time.Millisecond)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrServerPollIntervalOverflow)
+}
+
+func TestClient_WaitForTask_WrapsGetTaskError(t *testing.T) {
+	wantErr := errors.New("request failed")
+	transport := newTaskSequenceTransport(nil)
+	transport.err = wantErr
+	client := NewClient(transport, WithSession())
+
+	_, err := client.WaitForTask(t.Context(), mcp.GetTaskRequest{
+		Params: mcp.GetTaskParams{TaskId: "task-1"},
+	}, time.Millisecond)
+
+	require.Error(t, err)
+	assert.ErrorIs(t, err, wantErr)
+	assert.Contains(t, err.Error(), "get task:")
+}
+
+type taskSequenceTransport struct {
+	mu            sync.Mutex
+	responses     []mcp.Task
+	calls         int
+	afterResponse func()
+	err           error
+}
+
+func newTaskSequenceTransport(responses []mcp.Task) *taskSequenceTransport {
+	return &taskSequenceTransport{responses: responses}
+}
+
+func (t *taskSequenceTransport) Start(context.Context) error { return nil }
+
+func (t *taskSequenceTransport) SendRequest(
+	_ context.Context,
+	request transport.JSONRPCRequest,
+) (*transport.JSONRPCResponse, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if request.Method != string(mcp.MethodTasksGet) {
+		return nil, errors.New("unexpected request method")
+	}
+	if t.err != nil {
+		return nil, t.err
+	}
+	if t.calls >= len(t.responses) {
+		return nil, errors.New("no scripted task response")
+	}
+
+	task := t.responses[t.calls]
+	t.calls++
+	if t.afterResponse != nil {
+		t.afterResponse()
+	}
+	raw, err := json.Marshal(mcp.GetTaskResult{Task: task})
+	if err != nil {
+		return nil, err
+	}
+	return &transport.JSONRPCResponse{Result: raw}, nil
+}
+
+func (t *taskSequenceTransport) SendNotification(context.Context, mcp.JSONRPCNotification) error {
+	return nil
+}
+
+func (t *taskSequenceTransport) SetNotificationHandler(func(mcp.JSONRPCNotification)) {}
+func (t *taskSequenceTransport) Close() error                                         { return nil }
+func (t *taskSequenceTransport) GetSessionId() string                                 { return "" }
+
+func (t *taskSequenceTransport) callCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.calls
+}


### PR DESCRIPTION
## Description

Adds a small, context-aware client helper for polling long-running MCP tasks until they reach a terminal state. The helper follows the server-provided `pollInterval` when available and falls back to a caller-provided interval.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly

## Additional Information

`WaitForTask` keeps task orchestration at the client boundary without introducing a background goroutine or changing existing task RPC methods. It returns the latest task state for `completed`, `failed`, or `cancelled` tasks, propagates request errors, and stops promptly when the caller's context is cancelled. Non-positive fallback intervals and overflowing server intervals are rejected explicitly.

The polling behavior follows the task fields defined by the [MCP Tasks utility](https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks), but this PR is an SDK convenience API rather than a protocol change.

Validation:

```text
go test ./... -race
go vet ./...
(cd otel && go test ./... -race && go vet ./...)
```

All commands passed locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added task-waiting support that automatically polls until a task completes or reaches a terminal state.
  - Respects server-provided polling intervals and supports cancellation through the request context.
  - Reports clear errors for invalid or overflowing polling intervals, interrupted polling, and task retrieval failures.
- **Tests**
  - Added coverage for task completion, repeated polling, server-provided intervals, cancellation, invalid intervals, overflow handling, and retrieval errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->