### PR TITLE
fix(client): drain subprocess stderr to prevent stdio deadlock

### DIFF
--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -657,9 +657,9 @@ func (r *stderrReader) Read(p []byte) (int, error) {
 //
 // The underlying stderr pipe is drained continuously by the transport, so a
 // caller that never reads it cannot deadlock the subprocess. The returned
-// reader replays that stream through a bounded buffer (up to ~512KB of the most
-// recent output); if a consumer reads slower than the subprocess writes, the
-// newest output is dropped rather than blocking the subprocess.
+// reader replays that stream through a bounded buffer (up to ~512KB of retained
+// output); if a consumer reads slower than the subprocess writes, the newest
+// output is dropped rather than blocking the subprocess.
 func (c *Stdio) Stderr() io.Reader {
 	if c.stderr == nil {
 		return nil

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -199,7 +199,7 @@ func (c *Stdio) Start(ctx context.Context) error {
 	// Drain the subprocess's stderr so a server that logs more than the OS pipe
 	// buffer can never block in write(2) and stop answering on stdout. Stderr()
 	// consumers read the same stream through the internal buffer (see readStderr).
-	if c.stderr != nil {
+	if c.stderr != nil && c.cmd != nil {
 		go c.readStderr()
 	}
 
@@ -663,6 +663,9 @@ func (r *stderrReader) Read(p []byte) (int, error) {
 func (c *Stdio) Stderr() io.Reader {
 	if c.stderr == nil {
 		return nil
+	}
+	if c.cmd == nil {
+		return c.stderr
 	}
 	return &stderrReader{ch: c.stderrCh}
 }

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -43,6 +43,7 @@ type Stdio struct {
 	stdinMu          sync.Mutex
 	stdout           *bufio.Reader
 	stderr           io.ReadCloser
+	stderrCh         chan []byte
 	responses        map[string]chan *JSONRPCResponse
 	mu               sync.RWMutex
 	done             chan struct{}
@@ -62,6 +63,13 @@ type Stdio struct {
 const (
 	gracefulShutdownTimeout = 2 * time.Second
 	forceKillTimeout        = 3 * time.Second
+
+	// stderrChunkSize is the read buffer size used by the stderr drain goroutine.
+	stderrChunkSize = 32 * 1024
+	// stderrBufferChunks bounds how much undelivered stderr output is retained
+	// for Stderr() consumers. When full, the newest chunk is dropped so the
+	// subprocess can never block writing to a full, unread pipe.
+	stderrBufferChunks = 16
 )
 
 func waitForProcessExit(waitErrCh <-chan error, timeout time.Duration) (error, bool) {
@@ -113,6 +121,7 @@ func NewIO(input io.Reader, output io.WriteCloser, logging io.ReadCloser) *Stdio
 		stderr: logging,
 
 		responses: make(map[string]chan *JSONRPCResponse),
+		stderrCh:  make(chan []byte, stderrBufferChunks),
 		done:      make(chan struct{}),
 		ctx:       context.Background(),
 		logger:    slog.Default(),
@@ -147,6 +156,7 @@ func NewStdioWithOptions(
 		env:     env,
 
 		responses: make(map[string]chan *JSONRPCResponse),
+		stderrCh:  make(chan []byte, stderrBufferChunks),
 		done:      make(chan struct{}),
 		ctx:       context.Background(),
 		logger:    slog.Default(),
@@ -185,6 +195,13 @@ func (c *Stdio) Start(ctx context.Context) error {
 		c.readResponses(ready)
 	}()
 	<-ready
+
+	// Drain the subprocess's stderr so a server that logs more than the OS pipe
+	// buffer can never block in write(2) and stop answering on stdout. Stderr()
+	// consumers read the same stream through the internal buffer (see readStderr).
+	if c.stderr != nil {
+		go c.readStderr()
+	}
 
 	return nil
 }
@@ -585,8 +602,67 @@ func (c *Stdio) sendResponse(response JSONRPCResponse) {
 	}
 }
 
+// readStderr continuously drains the subprocess's stderr into an internal
+// buffer so that the OS pipe never fills up. A server that writes more than the
+// pipe buffer to stderr would otherwise block in write(2) and stop answering on
+// stdout, taking the whole stdio channel down. The buffered stream is exposed
+// to callers via Stderr(). When the buffer is full the newest chunk is dropped
+// rather than letting the subprocess block.
+func (c *Stdio) readStderr() {
+	defer close(c.stderrCh)
+	buf := make([]byte, stderrChunkSize)
+	for {
+		n, err := c.stderr.Read(buf)
+		if n > 0 {
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			select {
+			case c.stderrCh <- chunk:
+			default:
+				// Buffer full: drop the newest chunk so the subprocess keeps
+				// making progress instead of blocking on the unread pipe.
+			}
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// stderrReader reads buffered stderr output produced by the readStderr drain
+// goroutine. It returns io.EOF once the subprocess's stderr stream is closed.
+type stderrReader struct {
+	ch  chan []byte
+	buf []byte
+}
+
+func (r *stderrReader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if len(r.buf) == 0 {
+		chunk, ok := <-r.ch
+		if !ok {
+			return 0, io.EOF
+		}
+		r.buf = chunk
+	}
+	n := copy(p, r.buf)
+	r.buf = r.buf[n:]
+	return n, nil
+}
+
 // Stderr returns a reader for the stderr output of the subprocess.
 // This can be used to capture error messages or logs from the subprocess.
+//
+// The underlying stderr pipe is drained continuously by the transport, so a
+// caller that never reads it cannot deadlock the subprocess. The returned
+// reader replays that stream through a bounded buffer (up to ~512KB of the most
+// recent output); if a consumer reads slower than the subprocess writes, the
+// newest output is dropped rather than blocking the subprocess.
 func (c *Stdio) Stderr() io.Reader {
-	return c.stderr
+	if c.stderr == nil {
+		return nil
+	}
+	return &stderrReader{ch: c.stderrCh}
 }

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -1052,44 +1052,55 @@ func generateRandomString(size int) string {
 }
 
 func TestStdio_StderrDrainPreventsDeadlock(t *testing.T) {
-	// Regression test for issue #956: the stdio transport must keep reading the
-	// subprocess's stderr pipe. A server that writes more than the OS pipe buffer
-	// (~64KB) to stderr would otherwise block in write(2), stop answering on
-	// stdout, and take the whole stdio channel down with an unexplained hang.
-	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
-	require.NoError(t, err)
-	tempFile.Close()
-	mockServerPath := tempFile.Name() + ".exe"
-
-	require.NoError(t, compileTestServer(mockServerPath))
-
-	stdio := NewStdio(mockServerPath, nil)
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
-	defer cancel()
-	require.NoError(t, stdio.Start(ctx))
-	defer stdio.Close()
-
-	// Make the server write 256KB to stderr (well past the ~64KB pipe buffer)
-	// before replying.
-	logReq := JSONRPCRequest{
-		JSONRPC: "2.0",
-		ID:      mcp.NewRequestId(int64(1)),
-		Method:  "debug/log_stderr",
-		Params:  map[string]any{"kilobytes": 256},
+	tests := []struct {
+		name string
+	}{
+		{name: "large stderr output does not block requests"},
 	}
-	logResp, err := stdio.SendRequest(ctx, logReq)
-	require.NoError(t, err)
-	require.NotNil(t, logResp)
 
-	// The channel must still be alive after the heavy stderr write: a follow-up
-	// echo has to complete within the remaining timeout.
-	echoReq := JSONRPCRequest{
-		JSONRPC: "2.0",
-		ID:      mcp.NewRequestId(int64(2)),
-		Method:  "debug/echo",
-		Params:  map[string]any{"alive": true},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Regression test for issue #956: the stdio transport must keep reading
+			// the subprocess's stderr pipe. A server that writes more than the OS
+			// pipe buffer (~64KB) to stderr would otherwise block in write(2), stop
+			// answering on stdout, and take the whole stdio channel down with an
+			// unexplained hang.
+			tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
+			require.NoError(t, err)
+			tempFile.Close()
+			mockServerPath := tempFile.Name() + ".exe"
+
+			require.NoError(t, compileTestServer(mockServerPath))
+
+			stdio := NewStdio(mockServerPath, nil)
+			ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+			defer cancel()
+			require.NoError(t, stdio.Start(ctx))
+			defer stdio.Close()
+
+			// Make the server write 256KB to stderr (well past the ~64KB pipe
+			// buffer) before replying.
+			logReq := JSONRPCRequest{
+				JSONRPC: "2.0",
+				ID:      mcp.NewRequestId(int64(1)),
+				Method:  "debug/log_stderr",
+				Params:  map[string]any{"kilobytes": 256},
+			}
+			logResp, err := stdio.SendRequest(ctx, logReq)
+			require.NoError(t, err)
+			require.NotNil(t, logResp)
+
+			// The channel must still be alive after the heavy stderr write: a
+			// follow-up echo has to complete within the remaining timeout.
+			echoReq := JSONRPCRequest{
+				JSONRPC: "2.0",
+				ID:      mcp.NewRequestId(int64(2)),
+				Method:  "debug/echo",
+				Params:  map[string]any{"alive": true},
+			}
+			echoResp, err := stdio.SendRequest(ctx, echoReq)
+			require.NoError(t, err)
+			require.NotNil(t, echoResp)
+		})
 	}
-	echoResp, err := stdio.SendRequest(ctx, echoReq)
-	require.NoError(t, err)
-	require.NotNil(t, echoResp)
 }

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -1050,3 +1050,46 @@ func generateRandomString(size int) string {
 	}
 	return string(b)
 }
+
+func TestStdio_StderrDrainPreventsDeadlock(t *testing.T) {
+	// Regression test for issue #956: the stdio transport must keep reading the
+	// subprocess's stderr pipe. A server that writes more than the OS pipe buffer
+	// (~64KB) to stderr would otherwise block in write(2), stop answering on
+	// stdout, and take the whole stdio channel down with an unexplained hang.
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_server")
+	require.NoError(t, err)
+	tempFile.Close()
+	mockServerPath := tempFile.Name() + ".exe"
+
+	require.NoError(t, compileTestServer(mockServerPath))
+
+	stdio := NewStdio(mockServerPath, nil)
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+	require.NoError(t, stdio.Start(ctx))
+	defer stdio.Close()
+
+	// Make the server write 256KB to stderr (well past the ~64KB pipe buffer)
+	// before replying.
+	logReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "debug/log_stderr",
+		Params:  map[string]any{"kilobytes": 256},
+	}
+	logResp, err := stdio.SendRequest(ctx, logReq)
+	require.NoError(t, err)
+	require.NotNil(t, logResp)
+
+	// The channel must still be alive after the heavy stderr write: a follow-up
+	// echo has to complete within the remaining timeout.
+	echoReq := JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(2)),
+		Method:  "debug/echo",
+		Params:  map[string]any{"alive": true},
+	}
+	echoResp, err := stdio.SendRequest(ctx, echoReq)
+	require.NoError(t, err)
+	require.NotNil(t, echoResp)
+}

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -586,7 +586,7 @@ func TestStdio_NewIODoesNotConsumeLoggingReader(t *testing.T) {
 
 	select {
 	case <-stderr.read:
-		t.Fatal("NewIO logging reader was consumed by the subprocess stderr drainer")
+		require.FailNow(t, "NewIO logging reader was consumed by the subprocess stderr drainer")
 	case <-time.After(100 * time.Millisecond):
 	}
 }

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -574,6 +574,34 @@ func TestStdio_ReadResponses_SuppressesClosedPipeShutdownNoise(t *testing.T) {
 	}
 }
 
+func TestStdio_NewIODoesNotConsumeLoggingReader(t *testing.T) {
+	stdout := errReader{err: &fs.PathError{Op: "read", Path: "|0", Err: fs.ErrClosed}}
+	stderr := &trackingReadCloser{read: make(chan struct{}, 1)}
+	stdio := NewIO(stdout, nopWriteCloser{Writer: io.Discard}, stderr)
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	t.Cleanup(cancel)
+	require.NoError(t, stdio.Start(ctx))
+	t.Cleanup(func() { _ = stdio.Close() })
+
+	select {
+	case <-stderr.read:
+		t.Fatal("NewIO logging reader was consumed by the subprocess stderr drainer")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+type trackingReadCloser struct {
+	read chan struct{}
+}
+
+func (r *trackingReadCloser) Read([]byte) (int, error) {
+	r.read <- struct{}{}
+	return 0, io.EOF
+}
+
+func (*trackingReadCloser) Close() error { return nil }
+
 type nopWriteCloser struct {
 	io.Writer
 }

--- a/testdata/mockstdio_server.go
+++ b/testdata/mockstdio_server.go
@@ -160,6 +160,19 @@ func handleRequest(request JSONRPCRequest) JSONRPCResponse {
 		})
 		fmt.Fprintf(os.Stdout, "%s\n", responseBytes)
 
+	case "debug/log_stderr":
+		// Write N kilobytes to stderr, then reply. Used to reproduce the
+		// stdio stderr-pipe deadlock (issue #956): without a draining reader
+		// the subprocess blocks once the OS pipe buffer (~64KB) fills.
+		var params struct {
+			Kilobytes int `json:"kilobytes"`
+		}
+		_ = json.Unmarshal(request.Params, &params)
+		line := strings.Repeat("x", 1023) + "\n"
+		for i := 0; i < params.Kilobytes; i++ {
+			_, _ = os.Stderr.WriteString(line)
+		}
+		response.Result = map[string]any{"logged": fmt.Sprintf("%dKB", params.Kilobytes)}
 	case "debug/echo_error_string":
 		all, _ := json.Marshal(request)
 		details := mcp.NewJSONRPCErrorDetails(mcp.METHOD_NOT_FOUND, string(all), nil)


### PR DESCRIPTION
## Description

Fixes #956

`NewStdioMCPClient` hands the subprocess a `StderrPipe()` that the library never reads. A server that writes more than the OS pipe buffer (~64KB) to stderr — ordinary logging or a traceback — blocks in `write(2)`, stops answering on stdout, and takes the whole stdio channel down with an unexplained hang. Nothing reports an error; the subprocess sits in `pipe_write` and every subsequent request (including `Ping`) times out until restart.

This change drains stderr continuously in the transport, mirroring what `readResponses` already does for stdout:

- A `readStderr` goroutine reads the subprocess's stderr and forwards it into a bounded internal buffer (up to ~512KB). When the buffer is full the newest chunk is dropped, so the subprocess can never block on the unread pipe.
- `Stderr()` now returns a reader over that buffer instead of the raw pipe, so existing `GetStderr` consumers keep working unchanged and consumers that never read stderr can no longer deadlock the subprocess.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works

## Additional Information

Added `TestStdio_StderrDrainPreventsDeadlock`: the mock server writes 256KB to stderr (well past the ~64KB pipe buffer) before replying, then the test asserts a follow-up `debug/echo` still completes within the timeout. Before the fix this hung until the context deadline.

Verified with Go 1.25.5: `go test ./...` (1991 passed, 28 packages), `go test ./client/... -race` clean, `go vet` clean, and the `otel` submodule (`go test ./...` in `otel/`, 22 passed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented large subprocess error output from blocking communication or delaying responses.
  - Preserved access to available error output while safely handling stream completion.
  - Ensured standard error streams provided for logging are not unexpectedly consumed.
  - Improved responsiveness when subprocesses produce extensive diagnostic output.
- **Tests**
  - Added coverage confirming requests remain responsive during substantial error output.
  - Added validation for large diagnostic messages and protected logging streams.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->