### PR TITLE
fix: report correct item index in RequireIntSlice conversion error

### DIFF
--- a/mcp/tools.go
+++ b/mcp/tools.go
@@ -396,8 +396,8 @@ func (r CallToolRequest) RequireIntSlice(key string) ([]int, error) {
 				case float64:
 					result = append(result, int(num))
 				case string:
-					if i, err := strconv.Atoi(num); err == nil {
-						result = append(result, i)
+					if n, err := strconv.Atoi(num); err == nil {
+						result = append(result, n)
 					} else {
 						return nil, fmt.Errorf("item %d in argument %q cannot be converted to int", i, key)
 					}

--- a/mcp/tools_additional_test.go
+++ b/mcp/tools_additional_test.go
@@ -123,6 +123,8 @@ func TestCallToolRequest_SliceWithMixedTypes(t *testing.T) {
 		_, err := req.RequireIntSlice("mixed_int_slice")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "cannot be converted to int")
+		// the offending element is at index 1, not 0
+		assert.Contains(t, err.Error(), "item 1")
 	})
 
 	t.Run("GetFloatSlice with mixed types", func(t *testing.T) {


### PR DESCRIPTION
`RequireIntSlice` reports the wrong element index when a string in the slice can't be parsed. In the string branch, `if i, err := strconv.Atoi(num)` shadows the loop index `i`, and `Atoi` returns `0` on failure — so the error always reads `item 0 in argument "x" cannot be converted to int` no matter where the bad value actually is. `RequireFloatSlice` and `RequireBoolSlice` don't have this because they bind the parsed value to a different name and leave the loop index intact.

For `["1", "not a number", "3"]` you get "item 0" instead of "item 1", which points a debugging user at the wrong input. Renamed the inner variable to `n` so the loop index survives into the error message. Extended the existing mixed-type test to assert the reported index.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting for invalid mixed-type integer lists by identifying the correct offending item position.
* **Tests**
  * Added coverage to verify accurate item indexing in validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->