### PR TITLE
fix(client): ignore duplicate SSE endpoint events

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -39,8 +39,11 @@ type SSE struct {
 	host           string
 	logger         *slog.Logger
 
-	started          atomic.Bool
+	started atomic.Bool
+	// startMu protects startDone. Concurrent Start calls share one active
+	// handshake and may cancel independently; Start and Close must not overlap.
 	startMu          sync.Mutex
+	startDone        chan struct{}
 	closed           atomic.Bool
 	cancelSSEStream  context.CancelFunc
 	protocolVersion  atomic.Value // string
@@ -166,12 +169,40 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 // Start initiates the SSE connection to the server and waits for the endpoint information.
 // Returns an error if the connection fails or times out waiting for the endpoint.
 func (c *SSE) Start(ctx context.Context) error {
-	c.startMu.Lock()
-	defer c.startMu.Unlock()
+	for {
+		c.startMu.Lock()
+		if c.started.Load() {
+			c.startMu.Unlock()
+			return nil
+		}
+		if startDone := c.startDone; startDone != nil {
+			c.startMu.Unlock()
+			select {
+			case <-startDone:
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("context cancelled while waiting for concurrent start: %w", err)
+				}
+				continue
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled while waiting for concurrent start: %w", ctx.Err())
+			}
+		}
 
-	if c.started.Load() {
-		return nil
+		startDone := make(chan struct{})
+		c.startDone = startDone
+		c.startMu.Unlock()
+
+		err := c.start(ctx)
+		c.startMu.Lock()
+		c.startDone = nil
+		close(startDone)
+		c.startMu.Unlock()
+		return err
 	}
+}
+
+// start performs one SSE connection and endpoint handshake attempt.
+func (c *SSE) start(ctx context.Context) error {
 	endpointChan := c.resetEndpointHandshake()
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -40,6 +40,7 @@ type SSE struct {
 	logger         *slog.Logger
 
 	started          atomic.Bool
+	startMu          sync.Mutex
 	closed           atomic.Bool
 	cancelSSEStream  context.CancelFunc
 	protocolVersion  atomic.Value // string
@@ -165,6 +166,9 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 // Start initiates the SSE connection to the server and waits for the endpoint information.
 // Returns an error if the connection fails or times out waiting for the endpoint.
 func (c *SSE) Start(ctx context.Context) error {
+	c.startMu.Lock()
+	defer c.startMu.Unlock()
+
 	if c.started.Load() {
 		return nil
 	}

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -32,6 +32,7 @@ type SSE struct {
 	onNotification func(mcp.JSONRPCNotification)
 	notifyMu       sync.RWMutex
 	endpointChan   chan struct{}
+	endpointOnce   sync.Once
 	headers        map[string]string
 	headerFunc     HTTPHeaderFunc
 	host           string
@@ -374,8 +375,12 @@ func (c *SSE) handleSSEEvent(event, data string) {
 			c.logger.Error("Endpoint origin does not match connection origin")
 			return
 		}
-		c.endpoint = endpoint
-		close(c.endpointChan)
+		// The endpoint event is a one-time handshake. Keep the first valid
+		// endpoint and prevent duplicate server events from closing the channel twice.
+		c.endpointOnce.Do(func() {
+			c.endpoint = endpoint
+			close(c.endpointChan)
+		})
 
 	case "message":
 		var baseMessage JSONRPCResponse

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -32,7 +32,8 @@ type SSE struct {
 	onNotification func(mcp.JSONRPCNotification)
 	notifyMu       sync.RWMutex
 	endpointChan   chan struct{}
-	endpointOnce   sync.Once
+	endpointMu     sync.RWMutex
+	endpointSet    bool
 	headers        map[string]string
 	headerFunc     HTTPHeaderFunc
 	host           string
@@ -167,6 +168,7 @@ func (c *SSE) Start(ctx context.Context) error {
 	if c.started.Load() {
 		return nil
 	}
+	endpointChan := c.resetEndpointHandshake()
 
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancelSSEStream = cancel
@@ -271,7 +273,7 @@ func (c *SSE) Start(ctx context.Context) error {
 	defer timer.Stop()
 
 	select {
-	case <-c.endpointChan:
+	case <-endpointChan:
 		// Endpoint received, proceed
 	case <-ctx.Done():
 		return fmt.Errorf("context cancelled while waiting for endpoint: %w", ctx.Err())
@@ -282,6 +284,20 @@ func (c *SSE) Start(ctx context.Context) error {
 
 	c.started.Store(true)
 	return nil
+}
+
+// resetEndpointHandshake starts a fresh endpoint handshake for one Start attempt.
+//
+// A delayed endpoint event can arrive after a previous attempt times out. Replacing
+// the channel and endpoint prevents that stale event from satisfying a later retry.
+func (c *SSE) resetEndpointHandshake() chan struct{} {
+	c.endpointMu.Lock()
+	defer c.endpointMu.Unlock()
+
+	c.endpoint = nil
+	c.endpointSet = false
+	c.endpointChan = make(chan struct{})
+	return c.endpointChan
 }
 
 // readSSE continuously reads the SSE stream and processes events.
@@ -375,12 +391,16 @@ func (c *SSE) handleSSEEvent(event, data string) {
 			c.logger.Error("Endpoint origin does not match connection origin")
 			return
 		}
+		c.endpointMu.Lock()
+		defer c.endpointMu.Unlock()
 		// The endpoint event is a one-time handshake. Keep the first valid
 		// endpoint and prevent duplicate server events from closing the channel twice.
-		c.endpointOnce.Do(func() {
-			c.endpoint = endpoint
-			close(c.endpointChan)
-		})
+		if c.endpointSet {
+			return
+		}
+		c.endpoint = endpoint
+		c.endpointSet = true
+		close(c.endpointChan)
 
 	case "message":
 		var baseMessage JSONRPCResponse
@@ -753,6 +773,8 @@ func (c *SSE) SendNotification(ctx context.Context, notification mcp.JSONRPCNoti
 
 // GetEndpoint returns the current endpoint URL for the SSE connection.
 func (c *SSE) GetEndpoint() *url.URL {
+	c.endpointMu.RLock()
+	defer c.endpointMu.RUnlock()
 	return c.endpoint
 }
 

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -252,7 +252,7 @@ func (c *SSE) Start(ctx context.Context) error {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	go c.readSSE(resp.Body)
+	go c.readSSE(resp.Body, endpointChan)
 
 	// Wait for the endpoint to be received
 	endpointTimeout := c.endpointTimeout
@@ -300,9 +300,10 @@ func (c *SSE) resetEndpointHandshake() chan struct{} {
 	return c.endpointChan
 }
 
-// readSSE continuously reads the SSE stream and processes events.
+// readSSE continuously reads one connection's SSE stream and processes events.
+// endpointChan identifies the Start attempt that owns endpoint handshake events.
 // It runs until the connection is closed or an error occurs.
-func (c *SSE) readSSE(reader io.ReadCloser) {
+func (c *SSE) readSSE(reader io.ReadCloser, endpointChan chan struct{}) {
 	defer reader.Close()
 
 	br := bufio.NewReader(reader)
@@ -320,7 +321,7 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 					if event == "" {
 						event = "message"
 					}
-					c.handleSSEEvent(event, data)
+					c.handleSSEEvent(event, data, endpointChan)
 				}
 			}
 			c.connectionLostMu.RLock()
@@ -344,7 +345,7 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 				if event == "" {
 					event = "message"
 				}
-				c.handleSSEEvent(event, data)
+				c.handleSSEEvent(event, data, endpointChan)
 				event = ""
 				data = ""
 			}
@@ -379,7 +380,7 @@ func appendSSEData(existing, line string) string {
 
 // handleSSEEvent processes SSE events based on their type.
 // Handles 'endpoint' events for connection setup and 'message' events for JSON-RPC communication.
-func (c *SSE) handleSSEEvent(event, data string) {
+func (c *SSE) handleSSEEvent(event, data string, endpointChan chan struct{}) {
 	switch event {
 	case "endpoint":
 		endpoint, err := c.baseURL.Parse(data)
@@ -395,7 +396,8 @@ func (c *SSE) handleSSEEvent(event, data string) {
 		defer c.endpointMu.Unlock()
 		// The endpoint event is a one-time handshake. Keep the first valid
 		// endpoint and prevent duplicate server events from closing the channel twice.
-		if c.endpointSet {
+		// Ignore endpoint events from a reader owned by an earlier Start attempt.
+		if endpointChan != c.endpointChan || c.endpointSet {
 			return
 		}
 		c.endpoint = endpoint

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -321,6 +321,84 @@ func TestSSEStartRetriesWithFreshEndpointHandshake(t *testing.T) {
 	require.Equal(t, server.URL+"/messages/retry", transport.GetEndpoint().String())
 }
 
+// TestSSEConcurrentStartUsesSingleHandshake verifies that overlapping Start
+// calls share the first successful connection instead of replacing its state.
+func TestSSEConcurrentStartUsesSingleHandshake(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		callers int
+	}{
+		{name: "two callers", callers: 2},
+		{name: "many callers", callers: 8},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var connections atomic.Int32
+			firstConnected := make(chan struct{})
+			releaseEndpoint := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				flusher := w.(http.Flusher)
+				flusher.Flush()
+
+				if connections.Add(1) == 1 {
+					close(firstConnected)
+				}
+				select {
+				case <-releaseEndpoint:
+				case <-r.Context().Done():
+					return
+				}
+				_, _ = fmt.Fprint(w, "event: endpoint\ndata: /messages\n\n")
+				flusher.Flush()
+				<-r.Context().Done()
+			}))
+			defer server.Close()
+
+			transport, err := NewSSE(server.URL, WithEndpointTimeout(time.Second))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = transport.Close() })
+
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer cancel()
+			results := make(chan error, tt.callers)
+			go func() {
+				results <- transport.Start(ctx)
+			}()
+
+			select {
+			case <-firstConnected:
+			case <-ctx.Done():
+				t.Fatalf("first SSE connection was not established: %v", ctx.Err())
+			}
+
+			var launched sync.WaitGroup
+			launched.Add(tt.callers - 1)
+			for range tt.callers - 1 {
+				go func() {
+					launched.Done()
+					results <- transport.Start(ctx)
+				}()
+			}
+			launched.Wait()
+			time.Sleep(50 * time.Millisecond)
+			require.Equal(t, int32(1), connections.Load(), "concurrent Start calls must not create new handshakes")
+
+			close(releaseEndpoint)
+			for range tt.callers {
+				require.NoError(t, <-results)
+			}
+			require.Equal(t, int32(1), connections.Load())
+		})
+	}
+}
+
 func TestSSE(t *testing.T) {
 	// Compile mock server
 	url, closeF := startMockSSEEchoServer()

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -211,6 +211,21 @@ func TestAppendSSEData(t *testing.T) {
 	require.NoError(t, json.Unmarshal([]byte(data), &msg))
 }
 
+// TestSSEHandleDuplicateEndpoint verifies that repeated endpoint handshake
+// events cannot panic or replace the first accepted message endpoint.
+func TestSSEHandleDuplicateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	transport, err := NewSSE("https://example.com/sse")
+	require.NoError(t, err)
+
+	require.NotPanics(t, func() {
+		transport.handleSSEEvent("endpoint", "/messages/first")
+		transport.handleSSEEvent("endpoint", "/messages/second")
+	})
+	require.Equal(t, "https://example.com/messages/first", transport.endpoint.String())
+}
+
 func TestSSE(t *testing.T) {
 	// Compile mock server
 	url, closeF := startMockSSEEchoServer()

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -224,6 +225,44 @@ func TestSSEHandleDuplicateEndpoint(t *testing.T) {
 		transport.handleSSEEvent("endpoint", "/messages/second")
 	})
 	require.Equal(t, "https://example.com/messages/first", transport.endpoint.String())
+}
+
+func TestSSEStartRetriesWithFreshEndpointHandshake(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher := w.(http.Flusher)
+		flusher.Flush()
+
+		if attempts.Add(1) == 1 {
+			// Keep the first handshake incomplete until its Start context expires.
+			<-r.Context().Done()
+			return
+		}
+
+		_, _ = fmt.Fprint(w, "event: endpoint\ndata: /messages/retry\n\n")
+		flusher.Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	transport, err := NewSSE(server.URL, WithEndpointTimeout(50*time.Millisecond))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = transport.Close() })
+
+	firstCtx, firstCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer firstCancel()
+	require.Error(t, transport.Start(firstCtx))
+
+	// Simulate an endpoint event delivered late by the cancelled first stream.
+	// The next Start must not treat this stale endpoint as a successful retry.
+	transport.handleSSEEvent("endpoint", "/messages/stale")
+
+	secondCtx, secondCancel := context.WithTimeout(t.Context(), time.Second)
+	defer secondCancel()
+	require.NoError(t, transport.Start(secondCtx))
+	require.Equal(t, server.URL+"/messages/retry", transport.GetEndpoint().String())
 }
 
 func TestSSE(t *testing.T) {

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -399,6 +399,84 @@ func TestSSEConcurrentStartUsesSingleHandshake(t *testing.T) {
 	}
 }
 
+// TestSSEConcurrentStartHonorsFollowerContext verifies that a caller waiting
+// for an active handshake can cancel without interrupting the shared attempt.
+func TestSSEConcurrentStartHonorsFollowerContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		followerTimeout time.Duration
+	}{
+		{name: "short follower deadline", followerTimeout: 25 * time.Millisecond},
+		{name: "longer follower deadline", followerTimeout: 75 * time.Millisecond},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var connections atomic.Int32
+			firstConnected := make(chan struct{})
+			releaseEndpoint := make(chan struct{})
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				connections.Add(1)
+				w.Header().Set("Content-Type", "text/event-stream")
+				w.WriteHeader(http.StatusOK)
+				flusher := w.(http.Flusher)
+				flusher.Flush()
+				close(firstConnected)
+
+				select {
+				case <-releaseEndpoint:
+				case <-r.Context().Done():
+					return
+				}
+				_, _ = fmt.Fprint(w, "event: endpoint\ndata: /messages\n\n")
+				flusher.Flush()
+				<-r.Context().Done()
+			}))
+			defer server.Close()
+
+			transport, err := NewSSE(server.URL, WithEndpointTimeout(time.Second))
+			require.NoError(t, err)
+			t.Cleanup(func() { _ = transport.Close() })
+
+			leaderCtx, leaderCancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer leaderCancel()
+			leaderResult := make(chan error, 1)
+			go func() {
+				leaderResult <- transport.Start(leaderCtx)
+			}()
+
+			select {
+			case <-firstConnected:
+			case <-leaderCtx.Done():
+				t.Fatalf("leader SSE connection was not established: %v", leaderCtx.Err())
+			}
+
+			followerCtx, followerCancel := context.WithTimeout(t.Context(), tt.followerTimeout)
+			defer followerCancel()
+			followerResult := make(chan error, 1)
+			go func() {
+				followerResult <- transport.Start(followerCtx)
+			}()
+
+			select {
+			case err := <-followerResult:
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+			case <-time.After(500 * time.Millisecond):
+				close(releaseEndpoint)
+				t.Fatal("follower Start did not honor its context deadline")
+			}
+
+			close(releaseEndpoint)
+			require.NoError(t, <-leaderResult)
+			require.Equal(t, int32(1), connections.Load())
+		})
+	}
+}
+
 func TestSSE(t *testing.T) {
 	// Compile mock server
 	url, closeF := startMockSSEEchoServer()

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -420,12 +420,14 @@ func TestSSEConcurrentStartHonorsFollowerContext(t *testing.T) {
 			firstConnected := make(chan struct{})
 			releaseEndpoint := make(chan struct{})
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				connections.Add(1)
+				first := connections.Add(1) == 1
 				w.Header().Set("Content-Type", "text/event-stream")
 				w.WriteHeader(http.StatusOK)
 				flusher := w.(http.Flusher)
 				flusher.Flush()
-				close(firstConnected)
+				if first {
+					close(firstConnected)
+				}
 
 				select {
 				case <-releaseEndpoint:

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -217,18 +217,47 @@ func TestAppendSSEData(t *testing.T) {
 func TestSSEHandleDuplicateEndpoint(t *testing.T) {
 	t.Parallel()
 
-	transport, err := NewSSE("https://example.com/sse")
-	require.NoError(t, err)
+	tests := []struct {
+		name   string
+		first  string
+		second string
+		want   string
+	}{
+		{
+			name:   "relative endpoints",
+			first:  "/messages/first",
+			second: "/messages/second",
+			want:   "https://example.com/messages/first",
+		},
+		{
+			name:   "absolute endpoints",
+			first:  "https://example.com/messages/first",
+			second: "https://example.com/messages/second",
+			want:   "https://example.com/messages/first",
+		},
+	}
 
-	require.NotPanics(t, func() {
-		transport.handleSSEEvent("endpoint", "/messages/first")
-		transport.handleSSEEvent("endpoint", "/messages/second")
-	})
-	require.Equal(t, "https://example.com/messages/first", transport.endpoint.String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transport, err := NewSSE("https://example.com/sse")
+			require.NoError(t, err)
+			endpointChan := transport.resetEndpointHandshake()
+
+			require.NotPanics(t, func() {
+				transport.handleSSEEvent("endpoint", tt.first, endpointChan)
+				transport.handleSSEEvent("endpoint", tt.second, endpointChan)
+			})
+			require.Equal(t, tt.want, transport.GetEndpoint().String())
+		})
+	}
 }
 
 func TestSSEStartRetriesWithFreshEndpointHandshake(t *testing.T) {
 	var attempts atomic.Int32
+	secondConnected := make(chan struct{})
+	releaseSecondEndpoint := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/event-stream")
 		w.WriteHeader(http.StatusOK)
@@ -241,27 +270,54 @@ func TestSSEStartRetriesWithFreshEndpointHandshake(t *testing.T) {
 			return
 		}
 
+		close(secondConnected)
+		select {
+		case <-releaseSecondEndpoint:
+		case <-r.Context().Done():
+			return
+		}
 		_, _ = fmt.Fprint(w, "event: endpoint\ndata: /messages/retry\n\n")
 		flusher.Flush()
 		<-r.Context().Done()
 	}))
 	defer server.Close()
 
-	transport, err := NewSSE(server.URL, WithEndpointTimeout(50*time.Millisecond))
+	transport, err := NewSSE(server.URL, WithEndpointTimeout(500*time.Millisecond))
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = transport.Close() })
 
-	firstCtx, firstCancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	firstCtx, firstCancel := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer firstCancel()
 	require.Error(t, transport.Start(firstCtx))
 
-	// Simulate an endpoint event delivered late by the cancelled first stream.
-	// The next Start must not treat this stale endpoint as a successful retry.
-	transport.handleSSEEvent("endpoint", "/messages/stale")
+	transport.endpointMu.RLock()
+	staleEndpointChan := transport.endpointChan
+	transport.endpointMu.RUnlock()
 
-	secondCtx, secondCancel := context.WithTimeout(t.Context(), time.Second)
+	secondCtx, secondCancel := context.WithTimeout(t.Context(), 2*time.Second)
 	defer secondCancel()
-	require.NoError(t, transport.Start(secondCtx))
+	secondResult := make(chan error, 1)
+	go func() {
+		secondResult <- transport.Start(secondCtx)
+	}()
+
+	select {
+	case <-secondConnected:
+	case <-secondCtx.Done():
+		t.Fatalf("second SSE connection was not established: %v", secondCtx.Err())
+	}
+
+	// Deliver an endpoint event from the cancelled reader after Start has reset
+	// its handshake. The stale event must not complete or overwrite the retry.
+	transport.handleSSEEvent("endpoint", "/messages/stale", staleEndpointChan)
+	select {
+	case err := <-secondResult:
+		t.Fatalf("stale endpoint completed the retry: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(releaseSecondEndpoint)
+	require.NoError(t, <-secondResult)
 	require.Equal(t, server.URL+"/messages/retry", transport.GetEndpoint().String())
 }
 
@@ -664,7 +720,7 @@ func TestSSE(t *testing.T) {
 		// that the readSSE method returns without calling any handler
 
 		// Directly test the readSSE method with our mock reader
-		go trans.readSSE(mockReader)
+		go trans.readSSE(mockReader, trans.endpointChan)
 
 		// Wait for readSSE to complete
 		time.Sleep(100 * time.Millisecond)
@@ -706,7 +762,7 @@ func TestSSE(t *testing.T) {
 		})
 
 		// Directly test the readSSE method with our mock reader that simulates ERROR
-		go trans.readSSE(mockReader)
+		go trans.readSSE(mockReader, trans.endpointChan)
 
 		// Wait for connection lost handler to be called
 		timeout := time.After(1 * time.Second)


### PR DESCRIPTION
## Description

Prevent duplicate SSE endpoint events from panicking the client and keep endpoint handshakes isolated across retries and concurrent callers.

Each Start attempt passes its captured handshake channel to readSSE. Endpoint handling accepts only the first valid event whose channel still matches the current attempt, so an older stream cannot close a newer handshake or replace its endpoint. Overlapping Start calls share one in-flight attempt through startDone; each waiting caller can still return on its own context cancellation, and a surviving caller can retry if the active attempt fails.

This addresses the duplicate endpoint path reported in #959. The separate concurrent Close/message response race remains intentionally out of scope for a focused follow-up.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly

## Additional Information

Validation completed with Go 1.25.5:

- duplicate, retry, stale-reader, concurrent-Start, and follower-cancellation tests: 10 consecutive runs
- concurrent Start coverage with 2 and 8 callers, each producing one SSE connection
- follower contexts with 25ms and 75ms deadlines return independently while the shared leader succeeds
- go generate ./...
- golangci-lint v2.8.0: 0 issues
- go test ./... -race
- go vet ./...
- coverage suite: 75.3% total statement coverage

An earlier full race run hit a transient EOF in the existing OAuth test that calls example.com. Its isolated race test passed three consecutive runs, and three subsequent complete race suites passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSE retry handling after incomplete connection handshakes.
  * Prevented delayed endpoint events from earlier attempts from interfering with new connections.
  * Ensured each attempt waits for and uses its current endpoint.
  * Improved handling of relative and absolute endpoint URLs.
  * Prevented overlapping connection starts from creating duplicate handshakes.
  * Allowed waiting connection attempts to be canceled without interrupting an active connection.
* **Tests**
  * Expanded coverage for retries, endpoint events, URL formats, and concurrent connection starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->