### PR TITLE
fix: don't fire connection-lost handler on intentional SSE close

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -296,6 +296,12 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 		// and the for loop will break.
 		line, err := br.ReadString('\n')
 		if err != nil {
+			// Close() cancels the stream context, which surfaces here as a read
+			// error; firing the handler would reconnect a transport the caller
+			// just shut down.
+			if c.closed.Load() {
+				return
+			}
 			if err == io.EOF {
 				// Process any pending event before exit
 				if data != "" {
@@ -312,7 +318,7 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 			if handler != nil {
 				// Notify that the connection will be closed due to an error
 				handler(err)
-			} else if err == io.EOF && !c.closed.Load() {
+			} else if err == io.EOF {
 				c.logger.Error("SSE stream error", "err", err)
 			}
 			return

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -678,6 +678,58 @@ func TestSSE(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("IntentionalCloseDoesNotNotify", func(t *testing.T) {
+		// Close() cancels the stream context, so the read errors out just like a
+		// dropped connection would. The handler must not fire in that case,
+		// otherwise the caller reconnects a transport it deliberately shut down.
+		var connectionLostCalled bool
+		var mu sync.Mutex
+
+		mockReader := &mockReaderWithError{
+			data: []byte("event: endpoint\ndata: /message\n\n"),
+			err:  context.Canceled,
+		}
+
+		url, closeF := startMockSSEEchoServer()
+		defer closeF()
+
+		trans, err := NewSSE(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		trans.SetConnectionLostHandler(func(err error) {
+			mu.Lock()
+			defer mu.Unlock()
+			connectionLostCalled = true
+		})
+
+		// Mimic Close() having already flipped the flag before the read failed.
+		trans.closed.Store(true)
+
+		done := make(chan struct{})
+		go func() {
+			trans.readSSE(mockReader)
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(1 * time.Second):
+			t.Fatal("readSSE did not return after intentional close")
+		}
+
+		// Let any erroneously-scheduled handler run before asserting it didn't.
+		time.Sleep(50 * time.Millisecond)
+
+		mu.Lock()
+		called := connectionLostCalled
+		mu.Unlock()
+		if called {
+			t.Fatal("connection lost handler fired on intentional close")
+		}
+	})
 }
 
 func TestSSEErrors(t *testing.T) {

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -679,57 +680,64 @@ func TestSSE(t *testing.T) {
 		}
 	})
 
-	t.Run("IntentionalCloseDoesNotNotify", func(t *testing.T) {
-		// Close() cancels the stream context, so the read errors out just like a
-		// dropped connection would. The handler must not fire in that case,
-		// otherwise the caller reconnects a transport it deliberately shut down.
-		var connectionLostCalled bool
-		var mu sync.Mutex
+	// Close() cancels the stream context, so the read errors out just like a
+	// dropped connection would. The handler must fire for a genuine drop but
+	// stay silent when the closure was intentional, otherwise the caller
+	// reconnects a transport it deliberately shut down.
+	closeCases := []struct {
+		name         string
+		closedBefore bool
+		wantNotify   bool
+	}{
+		{name: "GenuineDropNotifies", closedBefore: false, wantNotify: true},
+		{name: "IntentionalCloseDoesNotNotify", closedBefore: true, wantNotify: false},
+	}
 
-		mockReader := &mockReaderWithError{
-			data: []byte("event: endpoint\ndata: /message\n\n"),
-			err:  context.Canceled,
-		}
+	for _, tc := range closeCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var connectionLostCalled bool
+			var mu sync.Mutex
 
-		url, closeF := startMockSSEEchoServer()
-		defer closeF()
+			mockReader := &mockReaderWithError{
+				data: []byte("event: endpoint\ndata: /message\n\n"),
+				err:  context.Canceled,
+			}
 
-		trans, err := NewSSE(url)
-		if err != nil {
-			t.Fatal(err)
-		}
+			url, closeF := startMockSSEEchoServer()
+			defer closeF()
 
-		trans.SetConnectionLostHandler(func(err error) {
+			trans, err := NewSSE(url)
+			require.NoError(t, err)
+
+			trans.SetConnectionLostHandler(func(err error) {
+				mu.Lock()
+				defer mu.Unlock()
+				connectionLostCalled = true
+			})
+
+			trans.closed.Store(tc.closedBefore)
+
+			done := make(chan struct{})
+			go func() {
+				trans.readSSE(mockReader)
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(1 * time.Second):
+				t.Fatal("readSSE did not return in time")
+			}
+
+			// Let any erroneously-scheduled handler run before asserting.
+			time.Sleep(50 * time.Millisecond)
+
 			mu.Lock()
-			defer mu.Unlock()
-			connectionLostCalled = true
+			called := connectionLostCalled
+			mu.Unlock()
+			assert.Equal(t, tc.wantNotify, called)
 		})
-
-		// Mimic Close() having already flipped the flag before the read failed.
-		trans.closed.Store(true)
-
-		done := make(chan struct{})
-		go func() {
-			trans.readSSE(mockReader)
-			close(done)
-		}()
-
-		select {
-		case <-done:
-		case <-time.After(1 * time.Second):
-			t.Fatal("readSSE did not return after intentional close")
-		}
-
-		// Let any erroneously-scheduled handler run before asserting it didn't.
-		time.Sleep(50 * time.Millisecond)
-
-		mu.Lock()
-		called := connectionLostCalled
-		mu.Unlock()
-		if called {
-			t.Fatal("connection lost handler fired on intentional close")
-		}
-	})
+	}
 }
 
 func TestSSEErrors(t *testing.T) {


### PR DESCRIPTION
Calling `Close()` on an SSE client fires the connection-lost handler as if the stream had dropped on its own. `Close()` flips the `closed` flag and cancels the stream context, which wakes `ReadString` in `readSSE` with a context-cancellation error. That lands in the error branch, and since a handler is set, `onConnectionLost(err)` gets called — so a caller that reconnects from that handler ends up reconnecting a transport it just deliberately shut down.

The `closed` flag was already being consulted, but only on the logging `else if` branch, not before the handler call. Moved the check to the top of the error branch so a read error that surfaces after `Close()` returns quietly instead of reporting connection loss. A genuine drop (flag still false) reaches the handler exactly as before. The `!c.closed.Load()` on the logging branch is now redundant, so I dropped it.

Added a regression test that flips `closed` before letting `readSSE` hit an errored reader and asserts the handler never fires; it fails without the guard. Full `client/transport` suite passes with `-race`, gofmt/vet clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented intentional transport closures from triggering connection-lost notifications.
  * Avoided processing pending server-sent events after a deliberate shutdown.
* **Tests**
  * Added coverage for both genuine connection losses and intentional closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->