### PR TITLE
fix(transport): drain stdio subprocess stderr to avoid pipe-full deadlock

### DIFF
--- a/client/stdio.go
+++ b/client/stdio.go
@@ -47,6 +47,12 @@ func NewStdioMCPClientWithOptions(
 // GetStderr returns a reader for the stderr output of the subprocess.
 // This can be used to capture error messages or logs from the subprocess.
 //
+// The stdio transport drains the subprocess's stderr into a bounded buffer so
+// the OS pipe never fills up and deadlocks the child. The returned reader
+// yields the most recent output; older output is dropped once the buffer is
+// full. To capture the full, real-time stream, use
+// transport.WithCommandStderrWriter instead.
+//
 // It works with any transport that exposes a Stderr() io.Reader method,
 // including *transport.Stdio and *transport.CommandTransport.
 func GetStderr(c *Client) (io.Reader, bool) {

--- a/client/transport/stderr_buffer_test.go
+++ b/client/transport/stderr_buffer_test.go
@@ -9,6 +9,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestStderrBuffer_ReadBlocksUntilData verifies Read blocks until Write
+// delivers data.
 func TestStderrBuffer_ReadBlocksUntilData(t *testing.T) {
 	buf := newStderrBuffer()
 
@@ -36,6 +38,8 @@ func TestStderrBuffer_ReadBlocksUntilData(t *testing.T) {
 	}
 }
 
+// TestStderrBuffer_ReadAfterCloseReturnsEOF verifies buffered data stays
+// readable after Close and drained reads then return io.EOF.
 func TestStderrBuffer_ReadAfterCloseReturnsEOF(t *testing.T) {
 	buf := newStderrBuffer()
 
@@ -53,6 +57,8 @@ func TestStderrBuffer_ReadAfterCloseReturnsEOF(t *testing.T) {
 	require.ErrorIs(t, err, io.EOF)
 }
 
+// TestStderrBuffer_WriteAfterCloseFails verifies Write reports
+// io.ErrClosedPipe after the stream is closed.
 func TestStderrBuffer_WriteAfterCloseFails(t *testing.T) {
 	buf := newStderrBuffer()
 	require.NoError(t, buf.Close())
@@ -61,6 +67,8 @@ func TestStderrBuffer_WriteAfterCloseFails(t *testing.T) {
 	require.ErrorIs(t, err, io.ErrClosedPipe)
 }
 
+// TestStderrBuffer_WriteDropsOldest verifies a full buffer evicts the oldest
+// bytes to make room for new output.
 func TestStderrBuffer_WriteDropsOldest(t *testing.T) {
 	buf := newStderrBuffer()
 
@@ -88,6 +96,8 @@ func TestStderrBuffer_WriteDropsOldest(t *testing.T) {
 	require.Equal(t, string(want), string(got))
 }
 
+// TestStderrBuffer_WriteOversizeChunkKeepsTail verifies a single write larger
+// than the buffer retains only its tail.
 func TestStderrBuffer_WriteOversizeChunkKeepsTail(t *testing.T) {
 	buf := newStderrBuffer()
 

--- a/client/transport/stderr_buffer_test.go
+++ b/client/transport/stderr_buffer_test.go
@@ -1,0 +1,114 @@
+package transport
+
+import (
+	"bytes"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStderrBuffer_ReadBlocksUntilData(t *testing.T) {
+	buf := newStderrBuffer()
+
+	result := make(chan string, 1)
+	go func() {
+		p := make([]byte, 5)
+		n, err := buf.Read(p)
+		if err != nil {
+			result <- "err: " + err.Error()
+			return
+		}
+		result <- string(p[:n])
+	}()
+
+	// Give the reader a moment to block, then deliver data.
+	time.Sleep(20 * time.Millisecond)
+	_, err := buf.Write([]byte("hello"))
+	require.NoError(t, err)
+
+	select {
+	case got := <-result:
+		require.Equal(t, "hello", got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("Read did not unblock after Write")
+	}
+}
+
+func TestStderrBuffer_ReadAfterCloseReturnsEOF(t *testing.T) {
+	buf := newStderrBuffer()
+
+	_, err := buf.Write([]byte("data"))
+	require.NoError(t, err)
+	require.NoError(t, buf.Close())
+
+	p := make([]byte, 10)
+	n, err := buf.Read(p)
+	require.NoError(t, err)
+	require.Equal(t, "data", string(p[:n]))
+
+	// Subsequent reads report EOF once the buffer is drained.
+	_, err = buf.Read(p)
+	require.ErrorIs(t, err, io.EOF)
+}
+
+func TestStderrBuffer_WriteAfterCloseFails(t *testing.T) {
+	buf := newStderrBuffer()
+	require.NoError(t, buf.Close())
+
+	_, err := buf.Write([]byte("late"))
+	require.ErrorIs(t, err, io.ErrClosedPipe)
+}
+
+func TestStderrBuffer_WriteDropsOldest(t *testing.T) {
+	buf := newStderrBuffer()
+
+	// Fill the buffer to capacity with a known pattern.
+	first := bytes.Repeat([]byte("a"), stderrBufferSize/2)
+	second := bytes.Repeat([]byte("b"), stderrBufferSize/2)
+	_, err := buf.Write(first)
+	require.NoError(t, err)
+	_, err = buf.Write(second)
+	require.NoError(t, err)
+
+	// Push the "a" data out: only the latest output must be retained.
+	_, err = buf.Write([]byte("tail"))
+	require.NoError(t, err)
+
+	require.NoError(t, buf.Close())
+	got, err := io.ReadAll(buf)
+	require.NoError(t, err)
+
+	// Only the oldest 4 bytes ("a") are dropped to make room for "tail".
+	want := append(bytes.Repeat([]byte("a"), stderrBufferSize/2-4),
+		bytes.Repeat([]byte("b"), stderrBufferSize/2)...)
+	want = append(want, []byte("tail")...)
+	require.Len(t, got, stderrBufferSize)
+	require.Equal(t, string(want), string(got))
+}
+
+func TestStderrBuffer_WriteOversizeChunkKeepsTail(t *testing.T) {
+	buf := newStderrBuffer()
+
+	// A single write larger than the whole buffer keeps only its tail.
+	big := bytes.Repeat([]byte("x"), stderrBufferSize+32)
+	_, err := buf.Write(big)
+	require.NoError(t, err)
+
+	require.NoError(t, buf.Close())
+	got, err := io.ReadAll(buf)
+	require.NoError(t, err)
+	require.Len(t, got, stderrBufferSize)
+}
+
+// TestStdio_StderrFallsBackToRawPipe verifies the non-ring fallback path of
+// Stderr() used by NewIO.
+func TestStdio_StderrFallsBackToRawPipe(t *testing.T) {
+	pipeReader, pipeWriter := io.Pipe()
+	defer pipeReader.Close()
+	defer pipeWriter.Close()
+
+	stdio := NewIO(bytes.NewReader(nil), pipeWriter, pipeReader)
+	require.Equal(t, pipeReader, stdio.Stderr())
+}

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -43,6 +44,8 @@ type Stdio struct {
 	stdinMu          sync.Mutex
 	stdout           *bufio.Reader
 	stderr           io.ReadCloser
+	stderrWriter     io.Writer
+	stderrRing       *stderrBuffer
 	responses        map[string]chan *JSONRPCResponse
 	mu               sync.RWMutex
 	done             chan struct{}
@@ -62,7 +65,72 @@ type Stdio struct {
 const (
 	gracefulShutdownTimeout = 2 * time.Second
 	forceKillTimeout        = 3 * time.Second
+
+	// stderrBufferSize bounds how much recent stderr output the transport
+	// keeps available through Stderr(). The OS pipe itself is only ~64KB, so
+	// a larger buffer would not add fidelity once the child outruns readers.
+	stderrBufferSize = 64 * 1024
 )
+
+// stderrBuffer is a bounded, drop-oldest buffer of the subprocess's stderr
+// output. The transport writes into it continuously so the OS pipe never
+// fills up and blocks the child, while callers can still read recent stderr
+// through Stderr(). Reads block until data is available or the stream ends.
+type stderrBuffer struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+	buf  bytes.Buffer
+	done bool
+}
+
+func newStderrBuffer() *stderrBuffer {
+	b := &stderrBuffer{}
+	b.cond = sync.NewCond(&b.mu)
+	return b
+}
+
+// Write appends p to the buffer, dropping the oldest data when the buffer is
+// full. It never blocks, so a child writing to stderr can never deadlock the
+// transport.
+func (b *stderrBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.done {
+		return 0, io.ErrClosedPipe
+	}
+	if len(p) > stderrBufferSize {
+		p = p[len(p)-stderrBufferSize:]
+	}
+	if overflow := b.buf.Len() + len(p) - stderrBufferSize; overflow > 0 {
+		b.buf.Next(overflow)
+	}
+	b.buf.Write(p)
+	b.cond.Broadcast()
+	return len(p), nil
+}
+
+// Read returns buffered data, blocking until data is available or the stream
+// is marked done.
+func (b *stderrBuffer) Read(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	for b.buf.Len() == 0 && !b.done {
+		b.cond.Wait()
+	}
+	if b.buf.Len() == 0 {
+		return 0, io.EOF
+	}
+	return b.buf.Read(p)
+}
+
+// Close marks the stream as ended and wakes up blocked readers.
+func (b *stderrBuffer) Close() error {
+	b.mu.Lock()
+	b.done = true
+	b.cond.Broadcast()
+	b.mu.Unlock()
+	return nil
+}
 
 func waitForProcessExit(waitErrCh <-chan error, timeout time.Duration) (error, bool) {
 	select {
@@ -103,19 +171,15 @@ func WithCommandLogger(logger *slog.Logger) StdioOption {
 	}
 }
 
-// NewIO returns a new stdio-based transport using existing input, output, and
-// logging streams instead of spawning a subprocess.
-// This is useful for testing and simulating client behavior.
-func NewIO(input io.Reader, output io.WriteCloser, logging io.ReadCloser) *Stdio {
-	return &Stdio{
-		stdin:  output,
-		stdout: bufio.NewReader(input),
-		stderr: logging,
-
-		responses: make(map[string]chan *JSONRPCResponse),
-		done:      make(chan struct{}),
-		ctx:       context.Background(),
-		logger:    slog.Default(),
+// WithCommandStderrWriter sets the destination for the subprocess's stderr
+// output. The default destination is io.Discard: the transport drains stderr
+// continuously so that the OS pipe (about 64KB) can never fill up and block
+// the child process, which would deadlock the whole stdio channel.
+// Pass os.Stderr, a log file, or an in-memory buffer to capture the child's
+// stderr instead.
+func WithCommandStderrWriter(w io.Writer) StdioOption {
+	return func(s *Stdio) {
+		s.stderrWriter = w
 	}
 }
 
@@ -157,6 +221,22 @@ func NewStdioWithOptions(
 	}
 
 	return s
+}
+
+// NewIO returns a new stdio-based transport using existing input, output, and
+// logging streams instead of spawning a subprocess.
+// This is useful for testing and simulating client behavior.
+func NewIO(input io.Reader, output io.WriteCloser, logging io.ReadCloser) *Stdio {
+	return &Stdio{
+		stdin:  output,
+		stdout: bufio.NewReader(input),
+		stderr: logging,
+
+		responses: make(map[string]chan *JSONRPCResponse),
+		done:      make(chan struct{}),
+		ctx:       context.Background(),
+		logger:    slog.Default(),
+	}
 }
 
 func (c *Stdio) Start(ctx context.Context) error {
@@ -219,9 +299,14 @@ func (c *Stdio) spawnCommand(ctx context.Context) error {
 		return fmt.Errorf("failed to create stdout pipe: %w", err)
 	}
 
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("failed to create stderr pipe: %w", err)
+	// Respect a stderr destination configured by a custom command factory;
+	// otherwise capture stderr so it can be drained below.
+	var stderr io.ReadCloser
+	if cmd.Stderr == nil {
+		stderr, err = cmd.StderrPipe()
+		if err != nil {
+			return fmt.Errorf("failed to create stderr pipe: %w", err)
+		}
 	}
 
 	c.cmd = cmd
@@ -231,6 +316,25 @@ func (c *Stdio) spawnCommand(ctx context.Context) error {
 
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("failed to start command: %w", err)
+	}
+
+	// Drain stderr continuously. An unread pipe holds only about 64KB;
+	// once it fills, the child blocks inside write(2) and stops answering
+	// on stdout, deadlocking every request (including Ping) with no error.
+	// The output is written to the bounded ring buffer (readable through
+	// Stderr()) and to stderrWriter, which defaults to io.Discard.
+	if stderr != nil {
+		c.stderrRing = newStderrBuffer()
+		stderrDest := c.stderrWriter
+		if stderrDest == nil {
+			stderrDest = io.Discard
+		}
+		go func() {
+			_, _ = io.Copy(io.MultiWriter(c.stderrRing, stderrDest), stderr)
+			// The pipe is exhausted (child exited or Close() closed it);
+			// wake up any readers blocked in Stderr().Read.
+			_ = c.stderrRing.Close()
+		}()
 	}
 
 	return nil
@@ -587,6 +691,14 @@ func (c *Stdio) sendResponse(response JSONRPCResponse) {
 
 // Stderr returns a reader for the stderr output of the subprocess.
 // This can be used to capture error messages or logs from the subprocess.
+//
+// The transport drains the subprocess's stderr into a bounded buffer so the
+// OS pipe never fills up and deadlocks the child. The reader returns the most
+// recent output; older output is dropped once the buffer is full. To capture
+// the full, real-time stream, use WithCommandStderrWriter instead.
 func (c *Stdio) Stderr() io.Reader {
+	if c.stderrRing != nil {
+		return c.stderrRing
+	}
 	return c.stderr
 }

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -98,6 +98,9 @@ func (b *stderrBuffer) Write(p []byte) (int, error) {
 	if b.done {
 		return 0, io.ErrClosedPipe
 	}
+	// Report the original length per the io.Writer contract even when the
+	// tail truncation below drops the leading bytes.
+	written := len(p)
 	if len(p) > stderrBufferSize {
 		p = p[len(p)-stderrBufferSize:]
 	}
@@ -106,7 +109,7 @@ func (b *stderrBuffer) Write(p []byte) (int, error) {
 	}
 	b.buf.Write(p)
 	b.cond.Broadcast()
-	return len(p), nil
+	return written, nil
 }
 
 // Read returns buffered data, blocking until data is available or the stream
@@ -335,27 +338,32 @@ func (c *Stdio) spawnCommand(ctx context.Context) error {
 // stderrWriter, which defaults to io.Discard.
 func (c *Stdio) startStderrDrain(stderr io.ReadCloser) {
 	c.stderrRing = newStderrBuffer()
-	stderrDest := c.stderrWriter
-	if stderrDest == nil {
-		stderrDest = io.Discard
-	}
-	go drainStderrIntoRing(c.stderrRing, stderr, stderrDest)
+	go drainStderrIntoRing(c.stderrRing, stderr, c.stderrWriter, c.logger)
 }
 
 // drainStderrIntoRing copies src into the ring buffer until the stream ends,
 // closing the ring afterwards to wake readers blocked in Stderr().Read.
 //
 // The drain must never stop while the child runs: a full OS pipe blocks the
-// child inside write(2) and deadlocks every request. Mirroring into dest is
-// therefore decoupled through a bounded queue: a failing or blocked writer
-// must not stop the pipe drain, so once the queue fills up (or the mirror
-// goroutine exits) further chunks are dropped. The mirror goroutine is
-// intentionally not waited for: a writer stuck inside Write would otherwise
-// delay ring Close and leave Stderr() readers blocked.
-func drainStderrIntoRing(ring *stderrBuffer, src io.ReadCloser, dest io.Writer) {
+// child inside write(2) and deadlocks every request. When dest is nil the
+// stream is drained directly into the ring without any mirroring overhead;
+// otherwise mirroring is decoupled through a bounded queue so a failing or
+// blocked writer cannot stop the pipe drain: once the queue fills up (or the
+// mirror goroutine exits) further chunks are dropped and the loss is logged
+// at debug level. The mirror goroutine is intentionally not waited for: a
+// writer stuck inside Write would otherwise delay ring Close and leave
+// Stderr() readers blocked.
+func drainStderrIntoRing(ring *stderrBuffer, src io.ReadCloser, dest io.Writer, logger *slog.Logger) {
 	defer func() {
 		_ = ring.Close()
 	}()
+
+	// No custom destination configured: drain directly without spawning a
+	// mirror goroutine or allocating mirror chunks.
+	if dest == nil {
+		_, _ = io.Copy(ring, src)
+		return
+	}
 
 	mirror := make(chan []byte, 8)
 	go func() {
@@ -380,6 +388,9 @@ func drainStderrIntoRing(ring *stderrBuffer, src io.ReadCloser, dest io.Writer) 
 			default:
 				// Mirror is full or gone; dropping the
 				// chunk keeps the pipe draining.
+				if logger != nil {
+					logger.Debug("stderr mirror queue full; dropping chunk", "bytes", n)
+				}
 			}
 		}
 		if rerr != nil {

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -318,69 +318,75 @@ func (c *Stdio) spawnCommand(ctx context.Context) error {
 		return fmt.Errorf("failed to start command: %w", err)
 	}
 
-	// Drain stderr continuously. An unread pipe holds only about 64KB;
-	// once it fills, the child blocks inside write(2) and stops answering
-	// on stdout, deadlocking every request (including Ping) with no error.
-	// The output is written to the bounded ring buffer (readable through
-	// Stderr()) and to stderrWriter, which defaults to io.Discard.
+	// Drain stderr continuously so the subprocess can never deadlock on a
+	// full pipe (see startStderrDrain).
 	if stderr != nil {
-		c.stderrRing = newStderrBuffer()
-		stderrDest := c.stderrWriter
-		if stderrDest == nil {
-			stderrDest = io.Discard
-		}
-		go func() {
-			// Drain stderr into the ring buffer no matter what the
-			// mirror writer does: a full OS pipe blocks the child
-			// inside write(2) and deadlocks every request.
-			defer func() {
-				// The pipe is exhausted (child exited or Close()
-				// closed it); wake up readers blocked in
-				// Stderr().Read.
-				_ = c.stderrRing.Close()
-			}()
-
-			// Mirror drained chunks to stderrDest through a bounded
-			// queue. A failing or blocked writer must not stop the
-			// pipe drain: once the queue fills up (or the mirror
-			// goroutine exits) further chunks are dropped. The
-			// mirror goroutine is intentionally not waited for: a
-			// writer stuck inside Write would otherwise delay ring
-			// Close and leave Stderr() readers blocked.
-			mirror := make(chan []byte, 8)
-			go func() {
-				for chunk := range mirror {
-					if _, err := stderrDest.Write(chunk); err != nil {
-						return
-					}
-				}
-			}()
-
-			buf := make([]byte, 32*1024)
-			for {
-				n, rerr := stderr.Read(buf)
-				if n > 0 {
-					if _, werr := c.stderrRing.Write(buf[:n]); werr != nil {
-						break
-					}
-					chunk := make([]byte, n)
-					copy(chunk, buf[:n])
-					select {
-					case mirror <- chunk:
-					default:
-						// Mirror is full or gone; dropping the
-						// chunk keeps the pipe draining.
-					}
-				}
-				if rerr != nil {
-					break
-				}
-			}
-			close(mirror)
-		}()
+		c.startStderrDrain(stderr)
 	}
 
 	return nil
+}
+
+// startStderrDrain starts the background goroutine that keeps the subprocess
+// stderr pipe empty. An unread pipe holds only about 64KB; once it fills, the
+// child blocks inside write(2) and stops answering on stdout, deadlocking
+// every request (including Ping) with no error. The output is written to the
+// bounded ring buffer (readable through Stderr()) and mirrored to
+// stderrWriter, which defaults to io.Discard.
+func (c *Stdio) startStderrDrain(stderr io.ReadCloser) {
+	c.stderrRing = newStderrBuffer()
+	stderrDest := c.stderrWriter
+	if stderrDest == nil {
+		stderrDest = io.Discard
+	}
+	go drainStderrIntoRing(c.stderrRing, stderr, stderrDest)
+}
+
+// drainStderrIntoRing copies src into the ring buffer until the stream ends,
+// closing the ring afterwards to wake readers blocked in Stderr().Read.
+//
+// The drain must never stop while the child runs: a full OS pipe blocks the
+// child inside write(2) and deadlocks every request. Mirroring into dest is
+// therefore decoupled through a bounded queue: a failing or blocked writer
+// must not stop the pipe drain, so once the queue fills up (or the mirror
+// goroutine exits) further chunks are dropped. The mirror goroutine is
+// intentionally not waited for: a writer stuck inside Write would otherwise
+// delay ring Close and leave Stderr() readers blocked.
+func drainStderrIntoRing(ring *stderrBuffer, src io.ReadCloser, dest io.Writer) {
+	defer func() {
+		_ = ring.Close()
+	}()
+
+	mirror := make(chan []byte, 8)
+	go func() {
+		for chunk := range mirror {
+			if _, err := dest.Write(chunk); err != nil {
+				return
+			}
+		}
+	}()
+
+	buf := make([]byte, 32*1024)
+	for {
+		n, rerr := src.Read(buf)
+		if n > 0 {
+			if _, werr := ring.Write(buf[:n]); werr != nil {
+				break
+			}
+			chunk := make([]byte, n)
+			copy(chunk, buf[:n])
+			select {
+			case mirror <- chunk:
+			default:
+				// Mirror is full or gone; dropping the
+				// chunk keeps the pipe draining.
+			}
+		}
+		if rerr != nil {
+			break
+		}
+	}
+	close(mirror)
 }
 
 // closeDone safely closes the done channel exactly once, unblocking all

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -330,10 +330,53 @@ func (c *Stdio) spawnCommand(ctx context.Context) error {
 			stderrDest = io.Discard
 		}
 		go func() {
-			_, _ = io.Copy(io.MultiWriter(c.stderrRing, stderrDest), stderr)
-			// The pipe is exhausted (child exited or Close() closed it);
-			// wake up any readers blocked in Stderr().Read.
-			_ = c.stderrRing.Close()
+			// Drain stderr into the ring buffer no matter what the
+			// mirror writer does: a full OS pipe blocks the child
+			// inside write(2) and deadlocks every request.
+			defer func() {
+				// The pipe is exhausted (child exited or Close()
+				// closed it); wake up readers blocked in
+				// Stderr().Read.
+				_ = c.stderrRing.Close()
+			}()
+
+			// Mirror drained chunks to stderrDest through a bounded
+			// queue. A failing or blocked writer must not stop the
+			// pipe drain: once the queue fills up (or the mirror
+			// goroutine exits) further chunks are dropped. The
+			// mirror goroutine is intentionally not waited for: a
+			// writer stuck inside Write would otherwise delay ring
+			// Close and leave Stderr() readers blocked.
+			mirror := make(chan []byte, 8)
+			go func() {
+				for chunk := range mirror {
+					if _, err := stderrDest.Write(chunk); err != nil {
+						return
+					}
+				}
+			}()
+
+			buf := make([]byte, 32*1024)
+			for {
+				n, rerr := stderr.Read(buf)
+				if n > 0 {
+					if _, werr := c.stderrRing.Write(buf[:n]); werr != nil {
+						break
+					}
+					chunk := make([]byte, n)
+					copy(chunk, buf[:n])
+					select {
+					case mirror <- chunk:
+					default:
+						// Mirror is full or gone; dropping the
+						// chunk keeps the pipe draining.
+					}
+				}
+				if rerr != nil {
+					break
+				}
+			}
+			close(mirror)
 		}()
 	}
 

--- a/client/transport/stdio.go
+++ b/client/transport/stdio.go
@@ -83,6 +83,7 @@ type stderrBuffer struct {
 	done bool
 }
 
+// newStderrBuffer returns an empty, open stderr buffer ready for writing.
 func newStderrBuffer() *stderrBuffer {
 	b := &stderrBuffer{}
 	b.cond = sync.NewCond(&b.mu)

--- a/client/transport/stdio_coverage_test.go
+++ b/client/transport/stdio_coverage_test.go
@@ -1,0 +1,463 @@
+package transport
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// newBareStdio builds a Stdio transport whose process fields are unset, so
+// individual code paths (request routing, error responses, close cleanup)
+// can be exercised deterministically without spawning a subprocess.
+func newBareStdio() *Stdio {
+	return &Stdio{
+		responses: make(map[string]chan *JSONRPCResponse),
+		done:      make(chan struct{}),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+// errWriteCloser is a write sink that returns a configurable error from Write
+// and Close, recording whether it was closed.
+type errWriteCloser struct {
+	mu     sync.Mutex
+	closed bool
+	err    error
+}
+
+func (w *errWriteCloser) Write(p []byte) (int, error) { return len(p), w.err }
+
+func (w *errWriteCloser) Close() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.closed = true
+	return w.err
+}
+
+func (w *errWriteCloser) IsClosed() bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.closed
+}
+
+// failingReadCloser returns err on every Read and closeErr on Close.
+type failingReadCloser struct{ err, closeErr error }
+
+func (r failingReadCloser) Read([]byte) (int, error) { return 0, r.err }
+func (r failingReadCloser) Close() error             { return r.closeErr }
+
+func TestStdio_GetSessionId(t *testing.T) {
+	require.Equal(t, "", newBareStdio().GetSessionId())
+}
+
+func TestStdio_WithCommandLogger(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// Non-nil logger is kept.
+	stdio := NewStdioWithOptions("cmd", nil, nil, WithCommandLogger(logger))
+	require.Same(t, logger, stdio.logger)
+
+	// Nil logger falls back to slog.Default.
+	stdio = NewStdioWithOptions("cmd", nil, nil, WithCommandLogger(nil))
+	require.Same(t, slog.Default(), stdio.logger)
+}
+
+func TestStdio_SendRequest_ClosedTransport(t *testing.T) {
+	stdio := newBareStdio()
+	close(stdio.done)
+
+	_, err := stdio.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorIs(t, err, ErrTransportClosed)
+}
+
+func TestStdio_SendRequest_ContextCanceled(t *testing.T) {
+	stdio := newBareStdio()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := stdio.SendRequest(ctx, JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStdio_SendRequest_NotStarted(t *testing.T) {
+	_, err := newBareStdio().SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.EqualError(t, err, "stdio client not started")
+}
+
+func TestStdio_SendRequest_WriteError(t *testing.T) {
+	stdio := newBareStdio()
+	writeErr := errors.New("stdin broken")
+	stdio.stdin = &errWriteCloser{err: writeErr}
+
+	_, err := stdio.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.EqualError(t, err, "failed to write request: stdin broken")
+}
+
+// doneClosingWriter closes its done channel on the first Write, letting tests
+// race transport shutdown with an in-flight request write.
+type doneClosingWriter struct{ done chan struct{} }
+
+func (w *doneClosingWriter) Write(p []byte) (int, error) {
+	close(w.done)
+	return len(p), nil
+}
+
+func (w *doneClosingWriter) Close() error { return nil }
+
+func TestStdio_SendRequest_DoneWithoutResponse(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.stdin = &doneClosingWriter{done: stdio.done}
+
+	// The write succeeds but the transport closes before a response is
+	// delivered; the request must fail with ErrTransportClosed and clean
+	// up its pending response channel.
+	_, err := stdio.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorIs(t, err, ErrTransportClosed)
+
+	stdio.mu.RLock()
+	defer stdio.mu.RUnlock()
+	require.NotContains(t, stdio.responses, mcp.NewRequestId(int64(1)).String())
+}
+
+// injectingWriter closes the done channel on the first Write and delivers a
+// response into the request's freshly registered channel, modeling a response
+// that arrives right as the transport shuts down.
+type injectingWriter struct {
+	done  chan struct{}
+	once  sync.Once
+	stdio *Stdio
+	idKey string
+}
+
+func (w *injectingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.done)
+		w.stdio.mu.RLock()
+		ch := w.stdio.responses[w.idKey]
+		w.stdio.mu.RUnlock()
+		if ch != nil {
+			ch <- &JSONRPCResponse{
+				JSONRPC: "2.0",
+				ID:      mcp.NewRequestId(int64(1)),
+				Result:  json.RawMessage(`"ok"`),
+			}
+		}
+	})
+	return len(p), nil
+}
+
+func (w *injectingWriter) Close() error { return nil }
+
+func TestStdio_SendRequest_DoneWithBufferedResponse(t *testing.T) {
+	stdio := newBareStdio()
+	idKey := mcp.NewRequestId(int64(1)).String()
+	stdio.stdin = &injectingWriter{done: stdio.done, stdio: stdio, idKey: idKey}
+
+	// A response delivered just before close must win over ErrTransportClosed.
+	resp, err := stdio.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Equal(t, json.RawMessage(`"ok"`), resp.Result)
+}
+
+func TestStdio_SendRequest_ContextCanceledAfterWrite(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.stdin = &errWriteCloser{}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	_, err := stdio.SendRequest(ctx, JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestStdio_SendNotification_NotStarted(t *testing.T) {
+	err := newBareStdio().SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	require.EqualError(t, err, "stdio client not started")
+}
+
+func TestStdio_SendNotification_ClosedTransport(t *testing.T) {
+	stdio := newBareStdio()
+	close(stdio.done)
+
+	err := stdio.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	require.ErrorIs(t, err, ErrTransportClosed)
+}
+
+func TestStdio_SendNotification_WriteError(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.stdin = &errWriteCloser{err: errors.New("stdin broken")}
+
+	err := stdio.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	require.EqualError(t, err, "failed to write notification: stdin broken")
+}
+
+func TestStdio_SendNotification_Success(t *testing.T) {
+	stdio := newBareStdio()
+	sink := &concurrentBuffer{}
+	stdio.stdin = sink
+
+	err := stdio.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	require.NoError(t, err)
+	require.Contains(t, sink.String(), `"method":"test"`)
+}
+
+// concurrentBuffer is a mutex-guarded buffer safe for the handler goroutines
+// spawned by handleIncomingRequest to write while the test reads.
+type concurrentBuffer struct {
+	mu  sync.Mutex
+	buf strings.Builder
+}
+
+func (b *concurrentBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *concurrentBuffer) Close() error { return nil }
+
+func (b *concurrentBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func TestStdio_HandleIncomingRequest_NoHandler(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.ctx = t.Context()
+	sink := &concurrentBuffer{}
+	stdio.stdin = sink
+
+	stdio.handleIncomingRequest(JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Method: "sample",
+	})
+	require.Contains(t, sink.String(), "-32601")
+	require.Contains(t, sink.String(), "No request handler configured")
+}
+
+func TestStdio_HandleIncomingRequest_HandlerResponds(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.ctx = t.Context()
+	sink := &concurrentBuffer{}
+	stdio.stdin = sink
+	stdio.SetRequestHandler(func(ctx context.Context, request JSONRPCRequest) (*JSONRPCResponse, error) {
+		return &JSONRPCResponse{JSONRPC: "2.0", ID: request.ID, Result: json.RawMessage(`"done"`)}, nil
+	})
+
+	stdio.handleIncomingRequest(JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Method: "sample",
+	})
+
+	// The handler runs asynchronously; wait for its response to be written.
+	require.Eventually(t, func() bool {
+		return strings.Contains(sink.String(), `"result":"done"`)
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestStdio_HandleIncomingRequest_HandlerError(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.ctx = t.Context()
+	sink := &concurrentBuffer{}
+	stdio.stdin = sink
+	stdio.SetRequestHandler(func(ctx context.Context, request JSONRPCRequest) (*JSONRPCResponse, error) {
+		return nil, errors.New("handler exploded")
+	})
+
+	stdio.handleIncomingRequest(JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Method: "sample",
+	})
+
+	require.Eventually(t, func() bool {
+		out := sink.String()
+		return strings.Contains(out, "-32603") &&
+			strings.Contains(out, "handler exploded")
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestStdio_HandleIncomingRequest_HandlerNilResponse(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.ctx = t.Context()
+	sink := &concurrentBuffer{}
+	stdio.stdin = sink
+	called := make(chan struct{})
+	stdio.SetRequestHandler(func(ctx context.Context, request JSONRPCRequest) (*JSONRPCResponse, error) {
+		close(called)
+		return nil, nil
+	})
+
+	stdio.handleIncomingRequest(JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Method: "sample",
+	})
+
+	// A nil response must not be written back.
+	select {
+	case <-called:
+	case <-t.Context().Done():
+		t.Fatal("handler was not invoked")
+	}
+	require.NotContains(t, sink.String(), "result")
+}
+
+func TestStdio_HandleIncomingRequest_CtxCanceled(t *testing.T) {
+	stdio := newBareStdio()
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	stdio.ctx = ctx
+	sink := &concurrentBuffer{}
+	stdio.stdin = sink
+	stdio.SetRequestHandler(func(ctx context.Context, request JSONRPCRequest) (*JSONRPCResponse, error) {
+		t.Fatal("handler must not run with a canceled context")
+		return nil, nil
+	})
+
+	stdio.handleIncomingRequest(JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Method: "sample",
+	})
+
+	require.Eventually(t, func() bool {
+		out := sink.String()
+		return strings.Contains(out, "-32603") &&
+			strings.Contains(out, context.Canceled.Error())
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
+func TestStdio_SendResponse_MarshalError(t *testing.T) {
+	stdio := newBareStdio()
+	sink := &concurrentBuffer{}
+	stdio.stdin = sink
+
+	// A channel cannot be marshaled; sendResponse must log and skip the write.
+	stdio.sendResponse(JSONRPCResponse{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Result: json.RawMessage("{invalid"),
+	})
+	require.Empty(t, sink.String())
+}
+
+func TestStdio_SendResponse_WriteError(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.stdin = &errWriteCloser{err: errors.New("stdin broken")}
+
+	// The write error must be logged, not propagated.
+	stdio.sendResponse(JSONRPCResponse{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Result: json.RawMessage(`"ok"`),
+	})
+}
+
+func TestStdio_Close_CleanupErrors(t *testing.T) {
+	// Both stdin and stderr close errors must be captured by Close.
+	stdio := newBareStdio()
+	stdio.stdin = &errWriteCloser{err: errors.New("stdin close failed")}
+	stdio.stderr = failingReadCloser{err: io.EOF, closeErr: errors.New("stderr close failed")}
+
+	err := stdio.Close()
+	require.ErrorContains(t, err, "stdin close failed")
+
+	// Second call is a no-op.
+	require.NoError(t, stdio.Close())
+}
+
+func TestStdio_ReadResponses_DoneBeforeRead(t *testing.T) {
+	stdio := newBareStdio()
+	close(stdio.done)
+	stdio.stdout = nil // never touched because done wins the select
+
+	require.NotPanics(t, func() {
+		stdio.readResponses(nil)
+	})
+}
+
+func TestStdio_ReadResponses_EOFClosesDone(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.stdout = bufio.NewReader(strings.NewReader(""))
+
+	stdio.readResponses(nil)
+
+	// EOF signals the server died; done must be closed so in-flight
+	// requests unblock.
+	select {
+	case <-stdio.done:
+	default:
+		t.Fatal("done channel was not closed on stdout EOF")
+	}
+}
+
+func TestStdio_ReadResponses_ReadErrorLogsAndClosesDone(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.stdout = bufio.NewReader(failingReadCloser{err: errors.New("stdout exploded")})
+
+	require.NotPanics(t, func() {
+		stdio.readResponses(nil)
+	})
+
+	select {
+	case <-stdio.done:
+	default:
+		t.Fatal("done channel was not closed on read error")
+	}
+}
+
+func TestStdio_ReadResponses_NotifiesHandler(t *testing.T) {
+	stdio := newBareStdio()
+	stdio.stdout = bufio.NewReader(strings.NewReader(
+		`{"jsonrpc":"2.0","method":"notify","params":{}}` + "\n"))
+
+	got := make(chan mcp.JSONRPCNotification, 1)
+	stdio.SetNotificationHandler(func(n mcp.JSONRPCNotification) {
+		got <- n
+	})
+
+	stdio.readResponses(nil)
+
+	select {
+	case n := <-got:
+		require.Equal(t, "notify", n.Method)
+	case <-t.Context().Done():
+		t.Fatal("notification handler was not invoked")
+	}
+}
+
+

--- a/client/transport/stdio_coverage_test.go
+++ b/client/transport/stdio_coverage_test.go
@@ -529,5 +529,3 @@ func TestStdio_BlockingStderrWriterDoesNotStopDrain(t *testing.T) {
 
 	close(writer.release)
 }
-
-

--- a/client/transport/stdio_coverage_test.go
+++ b/client/transport/stdio_coverage_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -458,6 +459,75 @@ func TestStdio_ReadResponses_NotifiesHandler(t *testing.T) {
 	case <-t.Context().Done():
 		t.Fatal("notification handler was not invoked")
 	}
+}
+
+// blockingWriter blocks inside its first Write until release is closed,
+// modeling a custom stderr destination that stalls without returning an error.
+type blockingWriter struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (w *blockingWriter) Write(p []byte) (int, error) {
+	w.once.Do(func() { close(w.entered) })
+	<-w.release
+	return len(p), nil
+}
+
+// TestStdio_BlockingStderrWriterDoesNotStopDrain verifies that a stderr writer
+// stuck inside Write cannot stop the pipe drain: once the mirror queue fills,
+// further chunks are dropped and the drain keeps consuming the pipe, so a
+// stderr-heavy server still answers Ping.
+func TestStdio_BlockingStderrWriterDoesNotStopDrain(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_stderr_flood_server")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tempFile.Close()
+	mockServerPath := tempFile.Name() + ".exe"
+
+	if compileErr := compileTestServerFromSource(mockServerPath, "../../testdata/mockstdio_stderr_flood_server.go"); compileErr != nil {
+		t.Fatalf("Failed to compile mock server: %v", compileErr)
+	}
+
+	writer := &blockingWriter{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	stdio := NewStdioWithOptions(mockServerPath, nil, nil, WithCommandStderrWriter(writer))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	if err := stdio.Start(ctx); err != nil {
+		t.Fatalf("Failed to start Stdio transport: %v", err)
+	}
+	defer stdio.Close()
+
+	// The server writes 320KB of stderr before answering; wait until the
+	// mirror goroutine is stuck in the writer, then let the server finish
+	// and verify the transport still answers requests.
+	select {
+	case <-writer.entered:
+	case <-ctx.Done():
+		t.Fatal("stderr writer was never called")
+	}
+
+	for i := range 3 {
+		reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err := stdio.SendRequest(reqCtx, JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      mcp.NewRequestId(int64(i + 1)),
+			Method:  "ping",
+		})
+		reqCancel()
+		if err != nil {
+			t.Fatalf("SendRequest %d failed with blocked stderr writer: %v", i+1, err)
+		}
+	}
+
+	close(writer.release)
 }
 
 

--- a/client/transport/stdio_coverage_test.go
+++ b/client/transport/stdio_coverage_test.go
@@ -36,8 +36,10 @@ type errWriteCloser struct {
 	err    error
 }
 
+// Write reports the full write length and returns the configured error.
 func (w *errWriteCloser) Write(p []byte) (int, error) { return len(p), w.err }
 
+// Close marks the writer closed and returns the configured error.
 func (w *errWriteCloser) Close() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -45,6 +47,7 @@ func (w *errWriteCloser) Close() error {
 	return w.err
 }
 
+// IsClosed reports whether Close has been called.
 func (w *errWriteCloser) IsClosed() bool {
 	w.mu.Lock()
 	defer w.mu.Unlock()
@@ -54,13 +57,20 @@ func (w *errWriteCloser) IsClosed() bool {
 // failingReadCloser returns err on every Read and closeErr on Close.
 type failingReadCloser struct{ err, closeErr error }
 
+// Read always returns the configured error.
 func (r failingReadCloser) Read([]byte) (int, error) { return 0, r.err }
-func (r failingReadCloser) Close() error             { return r.closeErr }
 
+// Close returns the configured close error.
+func (r failingReadCloser) Close() error { return r.closeErr }
+
+// TestStdio_GetSessionId verifies the session ID accessor returns an empty
+// string for the stdio transport.
 func TestStdio_GetSessionId(t *testing.T) {
 	require.Equal(t, "", newBareStdio().GetSessionId())
 }
 
+// TestStdio_WithCommandLogger verifies WithCommandLogger keeps a non-nil
+// logger and falls back to slog.Default for nil.
 func TestStdio_WithCommandLogger(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
@@ -73,6 +83,8 @@ func TestStdio_WithCommandLogger(t *testing.T) {
 	require.Same(t, slog.Default(), stdio.logger)
 }
 
+// TestStdio_SendRequest_ClosedTransport verifies SendRequest fails with
+// ErrTransportClosed after the transport is closed.
 func TestStdio_SendRequest_ClosedTransport(t *testing.T) {
 	stdio := newBareStdio()
 	close(stdio.done)
@@ -83,6 +95,8 @@ func TestStdio_SendRequest_ClosedTransport(t *testing.T) {
 	require.ErrorIs(t, err, ErrTransportClosed)
 }
 
+// TestStdio_SendRequest_ContextCanceled verifies SendRequest fails with
+// context.Canceled when the context is already canceled.
 func TestStdio_SendRequest_ContextCanceled(t *testing.T) {
 	stdio := newBareStdio()
 	ctx, cancel := context.WithCancel(t.Context())
@@ -94,6 +108,8 @@ func TestStdio_SendRequest_ContextCanceled(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// TestStdio_SendRequest_NotStarted verifies SendRequest fails with
+// "stdio client not started" before Start has run.
 func TestStdio_SendRequest_NotStarted(t *testing.T) {
 	_, err := newBareStdio().SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
@@ -101,6 +117,8 @@ func TestStdio_SendRequest_NotStarted(t *testing.T) {
 	require.EqualError(t, err, "stdio client not started")
 }
 
+// TestStdio_SendRequest_WriteError verifies SendRequest wraps a stdin write
+// failure.
 func TestStdio_SendRequest_WriteError(t *testing.T) {
 	stdio := newBareStdio()
 	writeErr := errors.New("stdin broken")
@@ -116,13 +134,18 @@ func TestStdio_SendRequest_WriteError(t *testing.T) {
 // race transport shutdown with an in-flight request write.
 type doneClosingWriter struct{ done chan struct{} }
 
+// Write closes the done channel once and reports the full write length.
 func (w *doneClosingWriter) Write(p []byte) (int, error) {
 	close(w.done)
 	return len(p), nil
 }
 
+// Close is a no-op.
 func (w *doneClosingWriter) Close() error { return nil }
 
+// TestStdio_SendRequest_DoneWithoutResponse verifies a request whose transport
+// closes before delivery fails with ErrTransportClosed and cleans up its
+// pending response channel.
 func TestStdio_SendRequest_DoneWithoutResponse(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.stdin = &doneClosingWriter{done: stdio.done}
@@ -150,6 +173,8 @@ type injectingWriter struct {
 	idKey string
 }
 
+// Write closes the done channel once and delivers a canned response into the
+// request's freshly registered response channel.
 func (w *injectingWriter) Write(p []byte) (int, error) {
 	w.once.Do(func() {
 		close(w.done)
@@ -167,8 +192,11 @@ func (w *injectingWriter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// Close is a no-op.
 func (w *injectingWriter) Close() error { return nil }
 
+// TestStdio_SendRequest_DoneWithBufferedResponse verifies a response delivered
+// just before close wins over ErrTransportClosed.
 func TestStdio_SendRequest_DoneWithBufferedResponse(t *testing.T) {
 	stdio := newBareStdio()
 	idKey := mcp.NewRequestId(int64(1)).String()
@@ -183,6 +211,8 @@ func TestStdio_SendRequest_DoneWithBufferedResponse(t *testing.T) {
 	require.Equal(t, json.RawMessage(`"ok"`), resp.Result)
 }
 
+// TestStdio_SendRequest_ContextCanceledAfterWrite verifies a canceled context
+// wins once the request has been written.
 func TestStdio_SendRequest_ContextCanceledAfterWrite(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.stdin = &errWriteCloser{}
@@ -195,6 +225,8 @@ func TestStdio_SendRequest_ContextCanceledAfterWrite(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 }
 
+// TestStdio_SendNotification_NotStarted verifies SendNotification fails with
+// "stdio client not started" before Start has run.
 func TestStdio_SendNotification_NotStarted(t *testing.T) {
 	err := newBareStdio().SendNotification(t.Context(), mcp.JSONRPCNotification{
 		JSONRPC: "2.0",
@@ -205,6 +237,8 @@ func TestStdio_SendNotification_NotStarted(t *testing.T) {
 	require.EqualError(t, err, "stdio client not started")
 }
 
+// TestStdio_SendNotification_ClosedTransport verifies SendNotification fails
+// with ErrTransportClosed after the transport is closed.
 func TestStdio_SendNotification_ClosedTransport(t *testing.T) {
 	stdio := newBareStdio()
 	close(stdio.done)
@@ -218,6 +252,8 @@ func TestStdio_SendNotification_ClosedTransport(t *testing.T) {
 	require.ErrorIs(t, err, ErrTransportClosed)
 }
 
+// TestStdio_SendNotification_WriteError verifies SendNotification wraps a
+// stdin write failure.
 func TestStdio_SendNotification_WriteError(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.stdin = &errWriteCloser{err: errors.New("stdin broken")}
@@ -231,6 +267,8 @@ func TestStdio_SendNotification_WriteError(t *testing.T) {
 	require.EqualError(t, err, "failed to write notification: stdin broken")
 }
 
+// TestStdio_SendNotification_Success verifies a notification is written to
+// stdin without error.
 func TestStdio_SendNotification_Success(t *testing.T) {
 	stdio := newBareStdio()
 	sink := &concurrentBuffer{}
@@ -253,20 +291,25 @@ type concurrentBuffer struct {
 	buf strings.Builder
 }
 
+// Write appends p to the guarded builder.
 func (b *concurrentBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.Write(p)
 }
 
+// Close is a no-op.
 func (b *concurrentBuffer) Close() error { return nil }
 
+// String returns the buffered output.
 func (b *concurrentBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
 }
 
+// TestStdio_HandleIncomingRequest_NoHandler verifies an incoming request
+// without a handler is answered with a -32601 method-not-found error.
 func TestStdio_HandleIncomingRequest_NoHandler(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.ctx = t.Context()
@@ -280,6 +323,8 @@ func TestStdio_HandleIncomingRequest_NoHandler(t *testing.T) {
 	require.Contains(t, sink.String(), "No request handler configured")
 }
 
+// TestStdio_HandleIncomingRequest_HandlerResponds verifies a handler's
+// response is written back to the client.
 func TestStdio_HandleIncomingRequest_HandlerResponds(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.ctx = t.Context()
@@ -299,6 +344,8 @@ func TestStdio_HandleIncomingRequest_HandlerResponds(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
+// TestStdio_HandleIncomingRequest_HandlerError verifies a handler error is
+// answered with a -32603 internal error.
 func TestStdio_HandleIncomingRequest_HandlerError(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.ctx = t.Context()
@@ -319,6 +366,8 @@ func TestStdio_HandleIncomingRequest_HandlerError(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
+// TestStdio_HandleIncomingRequest_HandlerNilResponse verifies a nil handler
+// response is not written back.
 func TestStdio_HandleIncomingRequest_HandlerNilResponse(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.ctx = t.Context()
@@ -343,6 +392,8 @@ func TestStdio_HandleIncomingRequest_HandlerNilResponse(t *testing.T) {
 	require.NotContains(t, sink.String(), "result")
 }
 
+// TestStdio_HandleIncomingRequest_CtxCanceled verifies the handler is not
+// invoked with a canceled context and an internal error is answered instead.
 func TestStdio_HandleIncomingRequest_CtxCanceled(t *testing.T) {
 	stdio := newBareStdio()
 	ctx, cancel := context.WithCancel(t.Context())
@@ -366,6 +417,8 @@ func TestStdio_HandleIncomingRequest_CtxCanceled(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 }
 
+// TestStdio_SendResponse_MarshalError verifies sendResponse skips writing a
+// response that cannot be marshaled.
 func TestStdio_SendResponse_MarshalError(t *testing.T) {
 	stdio := newBareStdio()
 	sink := &concurrentBuffer{}
@@ -378,6 +431,8 @@ func TestStdio_SendResponse_MarshalError(t *testing.T) {
 	require.Empty(t, sink.String())
 }
 
+// TestStdio_SendResponse_WriteError verifies sendResponse logs rather than
+// propagates a stdin write failure.
 func TestStdio_SendResponse_WriteError(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.stdin = &errWriteCloser{err: errors.New("stdin broken")}
@@ -388,6 +443,8 @@ func TestStdio_SendResponse_WriteError(t *testing.T) {
 	})
 }
 
+// TestStdio_Close_CleanupErrors verifies Close captures stdin close errors and
+// is a no-op on the second call.
 func TestStdio_Close_CleanupErrors(t *testing.T) {
 	// Both stdin and stderr close errors must be captured by Close.
 	stdio := newBareStdio()
@@ -401,6 +458,8 @@ func TestStdio_Close_CleanupErrors(t *testing.T) {
 	require.NoError(t, stdio.Close())
 }
 
+// TestStdio_ReadResponses_DoneBeforeRead verifies readResponses returns
+// immediately when done is already closed.
 func TestStdio_ReadResponses_DoneBeforeRead(t *testing.T) {
 	stdio := newBareStdio()
 	close(stdio.done)
@@ -411,6 +470,8 @@ func TestStdio_ReadResponses_DoneBeforeRead(t *testing.T) {
 	})
 }
 
+// TestStdio_ReadResponses_EOFClosesDone verifies readResponses closes done on
+// stdout EOF so in-flight requests unblock.
 func TestStdio_ReadResponses_EOFClosesDone(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.stdout = bufio.NewReader(strings.NewReader(""))
@@ -426,6 +487,8 @@ func TestStdio_ReadResponses_EOFClosesDone(t *testing.T) {
 	}
 }
 
+// TestStdio_ReadResponses_ReadErrorLogsAndClosesDone verifies a stdout read
+// error closes done without panicking.
 func TestStdio_ReadResponses_ReadErrorLogsAndClosesDone(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.stdout = bufio.NewReader(failingReadCloser{err: errors.New("stdout exploded")})
@@ -441,6 +504,8 @@ func TestStdio_ReadResponses_ReadErrorLogsAndClosesDone(t *testing.T) {
 	}
 }
 
+// TestStdio_ReadResponses_NotifiesHandler verifies notifications read from
+// stdout are delivered to the registered handler.
 func TestStdio_ReadResponses_NotifiesHandler(t *testing.T) {
 	stdio := newBareStdio()
 	stdio.stdout = bufio.NewReader(strings.NewReader(
@@ -469,6 +534,8 @@ type blockingWriter struct {
 	release chan struct{}
 }
 
+// Write signals entered on the first call and then blocks until release is
+// closed.
 func (w *blockingWriter) Write(p []byte) (int, error) {
 	w.once.Do(func() { close(w.entered) })
 	<-w.release

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -2,6 +2,7 @@ package transport
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -23,13 +24,17 @@ import (
 )
 
 func compileTestServer(outputPath string) error {
+	return compileTestServerFromSource(outputPath, "../../testdata/mockstdio_server.go")
+}
+
+func compileTestServerFromSource(outputPath, sourcePath string) error {
 	cmd := exec.Command(
 		"go",
 		"build",
 		"-buildmode=pie",
 		"-o",
 		outputPath,
-		"../../testdata/mockstdio_server.go",
+		sourcePath,
 	)
 	tmpCache, _ := os.MkdirTemp("", "gocache")
 	cmd.Env = append(os.Environ(), "GOCACHE="+tmpCache)
@@ -1049,4 +1054,106 @@ func generateRandomString(size int) string {
 		b[i] = charset[i%len(charset)]
 	}
 	return string(b)
+}
+
+// syncBuffer is a mutex-guarded bytes.Buffer used by tests that read Len()
+// while the stderr drain goroutine writes.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) Len() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Len()
+}
+
+// TestStdio_ServerStderrDoesNotDeadlock verifies that a subprocess which fills
+// its stderr pipe keeps answering on stdout. Regression test for the deadlock
+// where StderrPipe was never read: once the ~64KB OS pipe buffer fills, the
+// child blocks inside write(2) and every request times out.
+func TestStdio_ServerStderrDoesNotDeadlock(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_stderr_server")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tempFile.Close()
+	mockServerPath := tempFile.Name() + ".exe"
+
+	if compileErr := compileTestServerFromSource(mockServerPath, "../../testdata/mockstdio_stderr_server.go"); compileErr != nil {
+		t.Fatalf("Failed to compile mock server: %v", compileErr)
+	}
+
+	stdio := NewStdio(mockServerPath, nil)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	if err := stdio.Start(ctx); err != nil {
+		t.Fatalf("Failed to start Stdio transport: %v", err)
+	}
+	defer stdio.Close()
+
+	// The mock server writes ~256KB to stderr before answering anything. If the
+	// transport does not drain stderr, the first Ping already times out.
+	for i := range 3 {
+		reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err := stdio.SendRequest(reqCtx, JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      mcp.NewRequestId(int64(i + 1)),
+			Method:  "ping",
+		})
+		reqCancel()
+		if err != nil {
+			t.Fatalf("SendRequest %d failed: %v", i+1, err)
+		}
+	}
+}
+
+// TestStdio_WithCommandStderrWriter_CapturesStderr verifies that the drain
+// goroutine forwards the child's stderr to the configured writer.
+func TestStdio_WithCommandStderrWriter_CapturesStderr(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_stderr_server")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tempFile.Close()
+	mockServerPath := tempFile.Name() + ".exe"
+
+	if compileErr := compileTestServerFromSource(mockServerPath, "../../testdata/mockstdio_stderr_server.go"); compileErr != nil {
+		t.Fatalf("Failed to compile mock server: %v", compileErr)
+	}
+
+	var stderrBuf syncBuffer
+	stdio := NewStdioWithOptions(mockServerPath, nil, nil, WithCommandStderrWriter(&stderrBuf))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	if err := stdio.Start(ctx); err != nil {
+		t.Fatalf("Failed to start Stdio transport: %v", err)
+	}
+	defer stdio.Close()
+
+	// A single Ping proves the child is past its stderr burst.
+	reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+	if _, err := stdio.SendRequest(reqCtx, JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "ping",
+	}); err != nil {
+		t.Fatalf("SendRequest failed: %v", err)
+	}
+	reqCancel()
+
+	require.Eventually(t, func() bool {
+		return stderrBuf.Len() >= 64*1024
+	}, 10*time.Second, 50*time.Millisecond, "stderr output was not forwarded to the configured writer")
 }

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -27,6 +27,8 @@ func compileTestServer(outputPath string) error {
 	return compileTestServerFromSource(outputPath, "../../testdata/mockstdio_server.go")
 }
 
+// compileTestServerFromSource builds a mock JSON-RPC server binary from the
+// given source file into outputPath, using a temporary build cache.
 func compileTestServerFromSource(outputPath, sourcePath string) error {
 	cmd := exec.Command(
 		"go",
@@ -1046,6 +1048,8 @@ func TestStdio_ConcurrentWritesDoNotInterleave(t *testing.T) {
 	}
 }
 
+// generateRandomString returns a deterministic pseudo-random string of the
+// given size by cycling through a fixed charset.
 func generateRandomString(size int) string {
 	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 "
 
@@ -1063,12 +1067,14 @@ type syncBuffer struct {
 	buf bytes.Buffer
 }
 
+// Write appends p to the guarded buffer.
 func (b *syncBuffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.Write(p)
 }
 
+// Len returns the guarded buffer's length.
 func (b *syncBuffer) Len() int {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -1166,6 +1172,7 @@ type failingWriter struct {
 	writes int
 }
 
+// Write accepts the first write and fails every subsequent one.
 func (w *failingWriter) Write(p []byte) (int, error) {
 	w.mu.Lock()
 	defer w.mu.Unlock()

--- a/client/transport/stdio_test.go
+++ b/client/transport/stdio_test.go
@@ -1157,3 +1157,76 @@ func TestStdio_WithCommandStderrWriter_CapturesStderr(t *testing.T) {
 		return stderrBuf.Len() >= 64*1024
 	}, 10*time.Second, 50*time.Millisecond, "stderr output was not forwarded to the configured writer")
 }
+
+// failingWriter accepts the first write and then reports an error on every
+// subsequent write, modeling a custom stderr destination that breaks after
+// the child has already started emitting output.
+type failingWriter struct {
+	mu     sync.Mutex
+	writes int
+}
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.writes++
+	if w.writes > 1 {
+		return 0, errors.New("stderr writer failed")
+	}
+	return len(p), nil
+}
+
+// WriteCount reports how many writes the failing writer has observed.
+func (w *failingWriter) WriteCount() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writes
+}
+
+// TestStdio_WithCommandStderrWriterFailureStillDrains verifies that a custom
+// stderr writer which fails after its first write does not stop the stderr
+// drain. If the drain goroutine stopped, the child's stderr pipe would fill
+// up, the child would block inside write(2), and even Ping would time out.
+func TestStdio_WithCommandStderrWriterFailureStillDrains(t *testing.T) {
+	tempFile, err := os.CreateTemp(t.TempDir(), "mockstdio_stderr_server")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	tempFile.Close()
+	mockServerPath := tempFile.Name() + ".exe"
+
+	if compileErr := compileTestServerFromSource(mockServerPath, "../../testdata/mockstdio_stderr_server.go"); compileErr != nil {
+		t.Fatalf("Failed to compile mock server: %v", compileErr)
+	}
+
+	writer := &failingWriter{}
+	stdio := NewStdioWithOptions(mockServerPath, nil, nil, WithCommandStderrWriter(writer))
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	defer cancel()
+
+	if err := stdio.Start(ctx); err != nil {
+		t.Fatalf("Failed to start Stdio transport: %v", err)
+	}
+	defer stdio.Close()
+
+	// The mock server writes ~256KB to stderr before answering. With the
+	// writer failing after the first chunk, only a drain that is decoupled
+	// from the writer keeps the pipe empty and the child responsive.
+	for i := range 3 {
+		reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+		_, err := stdio.SendRequest(reqCtx, JSONRPCRequest{
+			JSONRPC: "2.0",
+			ID:      mcp.NewRequestId(int64(i + 1)),
+			Method:  "ping",
+		})
+		reqCancel()
+		if err != nil {
+			t.Fatalf("SendRequest %d failed after stderr writer error: %v", i+1, err)
+		}
+	}
+
+	// The writer must have been exercised at least once, confirming this
+	// test actually runs the failure path rather than skipping it.
+	require.GreaterOrEqual(t, writer.WriteCount(), 1)
+}

--- a/testdata/mockstdio_stderr_flood_server.go
+++ b/testdata/mockstdio_stderr_flood_server.go
@@ -22,6 +22,8 @@ type JSONRPCResponse struct {
 	Result  any            `json:"result,omitempty"`
 }
 
+// main writes 320KB to stderr before serving newline-delimited JSON-RPC
+// requests from stdin.
 func main() {
 	// Write 320KB of stderr (ten 32KB drain chunks) before answering, so a
 	// test can fill the drain goroutine's bounded mirror queue and exercise

--- a/testdata/mockstdio_stderr_flood_server.go
+++ b/testdata/mockstdio_stderr_flood_server.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+type JSONRPCRequest struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      *mcp.RequestId `json:"id,omitempty"`
+	Method  string         `json:"method"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      *mcp.RequestId `json:"id,omitempty"`
+	Result  any            `json:"result,omitempty"`
+}
+
+func main() {
+	// Write 320KB of stderr (ten 32KB drain chunks) before answering, so a
+	// test can fill the drain goroutine's bounded mirror queue and exercise
+	// the chunk-dropping branch while the custom stderr writer is blocked.
+	filler := strings.Repeat("x", 64*1024) + "\n"
+	for i := 0; i < 5; i++ {
+		if _, err := fmt.Fprint(os.Stderr, filler); err != nil {
+			return
+		}
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+
+		var request JSONRPCRequest
+		if err := json.Unmarshal([]byte(line), &request); err != nil {
+			continue
+		}
+
+		response := JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Result:  map[string]any{},
+		}
+		if request.Method == "ping" {
+			response.Result = struct{}{}
+		}
+
+		responseBytes, _ := json.Marshal(response)
+		fmt.Fprintf(os.Stdout, "%s\n", responseBytes)
+	}
+}

--- a/testdata/mockstdio_stderr_server.go
+++ b/testdata/mockstdio_stderr_server.go
@@ -22,6 +22,8 @@ type JSONRPCResponse struct {
 	Result  any            `json:"result,omitempty"`
 }
 
+// main writes ~256KB to stderr before serving newline-delimited JSON-RPC
+// requests from stdin.
 func main() {
 	// Write far more than an OS pipe buffer (~64KB) to stderr before answering
 	// anything. A client that never drains stderr deadlocks right here: the

--- a/testdata/mockstdio_stderr_server.go
+++ b/testdata/mockstdio_stderr_server.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+type JSONRPCRequest struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      *mcp.RequestId `json:"id,omitempty"`
+	Method  string         `json:"method"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string         `json:"jsonrpc"`
+	ID      *mcp.RequestId `json:"id,omitempty"`
+	Result  any            `json:"result,omitempty"`
+}
+
+func main() {
+	// Write far more than an OS pipe buffer (~64KB) to stderr before answering
+	// anything. A client that never drains stderr deadlocks right here: the
+	// child blocks inside write(2) once the pipe fills up and stops responding
+	// on stdout.
+	filler := strings.Repeat("x", 64*1024) + "\n"
+	for i := 0; i < 4; i++ {
+		if _, err := fmt.Fprint(os.Stderr, filler); err != nil {
+			return
+		}
+	}
+
+	reader := bufio.NewReader(os.Stdin)
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			break
+		}
+
+		line = strings.TrimRight(line, "\r\n")
+
+		var request JSONRPCRequest
+		if err := json.Unmarshal([]byte(line), &request); err != nil {
+			continue
+		}
+
+		response := JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      request.ID,
+			Result:  map[string]any{},
+		}
+		if request.Method == "ping" {
+			response.Result = struct{}{}
+		}
+
+		responseBytes, _ := json.Marshal(response)
+		fmt.Fprintf(os.Stdout, "%s\n", responseBytes)
+	}
+}


### PR DESCRIPTION
## What changed

The stdio client transport launches its MCP subprocess with a `StderrPipe()` that nothing ever reads. An OS pipe holds about 64KB; once a server fills it — verbose logging, a warning on every request, a traceback — the child blocks inside `write(2)` and stops answering on stdout. Every subsequent request (including `Ping`) times out with no error, presenting as an unexplained hang.

## How it's fixed

`spawnCommand` now drains stderr continuously after starting the subprocess:

- Output goes to a bounded, drop-oldest ring buffer (64KB) exposed through the existing `Stderr()` / `client.GetStderr` API, so callers can still read recent server logs.
- A new `WithCommandStderrWriter(io.Writer)` option forwards the full, real-time stream to a custom destination (`os.Stderr`, a log file, an in-memory buffer). It defaults to `io.Discard`.
- A custom `CommandFunc` that already sets `cmd.Stderr` is respected (no second pipe is created).

## How it's verified

- New mock server (`testdata/mockstdio_stderr_server.go`) writes ~256KB to stderr before answering anything. `TestStdio_ServerStderrDoesNotDeadlock` pings it three times; with the drain disabled the first `Ping` fails with `context deadline exceeded`, reproducing the deadlock.
- `TestStdio_WithCommandStderrWriter_CapturesStderr` asserts the configured writer receives the stream.
- Six unit tests cover the ring buffer (`stderr_buffer_test.go`): blocking reads, EOF after close, write-after-close, drop-oldest overflow, oversized chunks, and the `NewIO` fallback path.
- `go test ./... -race`, `go vet`, and `golangci-lint` pass; patch coverage of this change is ~97%.

Fixes #956

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved stdio transport handling for subprocess error output.
  * Added bounded buffering that retains the most recent output.
  * Added an option to forward error output to a separate writer.
  * Prevented large output or blocked writers from interrupting normal communication.
* **Documentation**
  * Clarified buffering behavior and recommendations for capturing complete output.
* **Tests**
  * Added coverage for buffering, closure, fallback behavior, and capture scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->