### PR TITLE
fix(transport): prevent SSE client panics on duplicate endpoint and concurrent close

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -36,7 +36,12 @@ type SSE struct {
 	host           string
 	logger         *slog.Logger
 
-	startMu          sync.Mutex
+	// startMu protects startDone. Concurrent Start calls share one active
+	// handshake and may cancel independently; Start and Close must not
+	// overlap.
+	startMu   sync.Mutex
+	startDone chan struct{}
+
 	started          atomic.Bool
 	closed           atomic.Bool
 	cancelSSEStream  context.CancelFunc
@@ -162,16 +167,44 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 // Start initiates the SSE connection to the server and waits for the endpoint information.
 // Returns an error if the connection fails or times out waiting for the endpoint.
 func (c *SSE) Start(ctx context.Context) error {
-	// Serialize Start attempts so overlapping calls cannot open multiple
-	// streams that race for the same handshake. A failed attempt releases
-	// the lock so the caller can retry.
-	c.startMu.Lock()
-	defer c.startMu.Unlock()
+	for {
+		c.startMu.Lock()
+		if c.started.Load() {
+			c.startMu.Unlock()
+			return nil
+		}
+		// A concurrent Start is already in flight: wait for it and honor
+		// our own context instead of blocking on the mutex.
+		if startDone := c.startDone; startDone != nil {
+			c.startMu.Unlock()
+			select {
+			case <-startDone:
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("context cancelled while waiting for concurrent start: %w", err)
+				}
+				continue
+			case <-ctx.Done():
+				return fmt.Errorf("context cancelled while waiting for concurrent start: %w", ctx.Err())
+			}
+		}
 
-	if c.started.Load() {
-		return nil
+		// Become the owner of this handshake attempt.
+		startDone := make(chan struct{})
+		c.startDone = startDone
+		c.startMu.Unlock()
+
+		err := c.start(ctx)
+
+		c.startMu.Lock()
+		c.startDone = nil
+		close(startDone)
+		c.startMu.Unlock()
+		return err
 	}
+}
 
+// start performs one SSE connection and endpoint handshake attempt.
+func (c *SSE) start(ctx context.Context) error {
 	// The handshake state belongs to this Start attempt only. Delayed
 	// endpoint events from a superseded reader (e.g. after a failed Start)
 	// close only this attempt's channel and cannot corrupt a later retry.

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -32,6 +32,7 @@ type SSE struct {
 	onNotification func(mcp.JSONRPCNotification)
 	notifyMu       sync.RWMutex
 	endpointChan   chan struct{}
+	endpointOnce   sync.Once
 	headers        map[string]string
 	headerFunc     HTTPHeaderFunc
 	host           string
@@ -374,9 +375,15 @@ func (c *SSE) handleSSEEvent(event, data string) {
 			c.logger.Error("Endpoint origin does not match connection origin")
 			return
 		}
+		c.mu.Lock()
 		c.endpoint = endpoint
-		close(c.endpointChan)
-
+		c.mu.Unlock()
+		// The SSE spec sends a single endpoint event, but a proxy or a
+		// re-broadcasting server can emit it more than once. Closing the
+		// channel twice panics, so guard the close with sync.Once.
+		c.endpointOnce.Do(func() {
+			close(c.endpointChan)
+		})
 	case "message":
 		var baseMessage JSONRPCResponse
 		if err := json.Unmarshal([]byte(data), &baseMessage); err != nil {
@@ -401,16 +408,16 @@ func (c *SSE) handleSSEEvent(event, data string) {
 		// Create string key for map lookup
 		idKey := baseMessage.ID.String()
 
-		c.mu.RLock()
+		// Hold the write lock while sending: Close() also takes the write
+		// lock to close pending response channels, so the send can never
+		// race a close and panic with "send on closed channel".
+		c.mu.Lock()
 		ch, exists := c.responses[idKey]
-		c.mu.RUnlock()
-
 		if exists {
 			ch <- &baseMessage
-			c.mu.Lock()
 			delete(c.responses, idKey)
-			c.mu.Unlock()
 		}
+		c.mu.Unlock()
 	}
 }
 
@@ -440,7 +447,12 @@ func (c *SSE) SendRequest(
 	if c.closed.Load() {
 		return nil, fmt.Errorf("transport has been closed")
 	}
-	if c.endpoint == nil {
+
+	c.mu.RLock()
+	endpoint := c.endpoint
+	c.mu.RUnlock()
+
+	if endpoint == nil {
 		return nil, fmt.Errorf("endpoint not received")
 	}
 
@@ -451,7 +463,7 @@ func (c *SSE) SendRequest(
 	}
 
 	// Create HTTP request
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint.String(), bytes.NewReader(requestBytes))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint.String(), bytes.NewReader(requestBytes))
 	if err != nil {
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
@@ -639,7 +651,11 @@ func (c *SSE) SetProtocolVersion(version string) {
 
 // SendNotification sends a JSON-RPC notification to the server without expecting a response.
 func (c *SSE) SendNotification(ctx context.Context, notification mcp.JSONRPCNotification) error {
-	if c.endpoint == nil {
+	c.mu.RLock()
+	endpoint := c.endpoint
+	c.mu.RUnlock()
+
+	if endpoint == nil {
 		return fmt.Errorf("endpoint not received")
 	}
 
@@ -651,7 +667,7 @@ func (c *SSE) SendNotification(ctx context.Context, notification mcp.JSONRPCNoti
 	req, err := http.NewRequestWithContext(
 		ctx,
 		"POST",
-		c.endpoint.String(),
+		endpoint.String(),
 		bytes.NewReader(notificationBytes),
 	)
 	if err != nil {
@@ -748,6 +764,8 @@ func (c *SSE) SendNotification(ctx context.Context, notification mcp.JSONRPCNoti
 
 // GetEndpoint returns the current endpoint URL for the SSE connection.
 func (c *SSE) GetEndpoint() *url.URL {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
 	return c.endpoint
 }
 

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -31,13 +31,12 @@ type SSE struct {
 	mu             sync.RWMutex
 	onNotification func(mcp.JSONRPCNotification)
 	notifyMu       sync.RWMutex
-	endpointChan   chan struct{}
-	endpointOnce   sync.Once
 	headers        map[string]string
 	headerFunc     HTTPHeaderFunc
 	host           string
 	logger         *slog.Logger
 
+	startMu          sync.Mutex
 	started          atomic.Bool
 	closed           atomic.Bool
 	cancelSSEStream  context.CancelFunc
@@ -138,7 +137,6 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 		baseURL:         parsedURL,
 		httpClient:      &http.Client{},
 		responses:       make(map[string]chan *JSONRPCResponse),
-		endpointChan:    make(chan struct{}),
 		headers:         make(map[string]string),
 		logger:          slog.Default(),
 		endpointTimeout: 30 * time.Second,
@@ -164,9 +162,21 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 // Start initiates the SSE connection to the server and waits for the endpoint information.
 // Returns an error if the connection fails or times out waiting for the endpoint.
 func (c *SSE) Start(ctx context.Context) error {
+	// Serialize Start attempts so overlapping calls cannot open multiple
+	// streams that race for the same handshake. A failed attempt releases
+	// the lock so the caller can retry.
+	c.startMu.Lock()
+	defer c.startMu.Unlock()
+
 	if c.started.Load() {
 		return nil
 	}
+
+	// The handshake state belongs to this Start attempt only. Delayed
+	// endpoint events from a superseded reader (e.g. after a failed Start)
+	// close only this attempt's channel and cannot corrupt a later retry.
+	endpointChan := make(chan struct{})
+	endpointOnce := &sync.Once{}
 
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancelSSEStream = cancel
@@ -250,7 +260,7 @@ func (c *SSE) Start(ctx context.Context) error {
 		return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	go c.readSSE(resp.Body)
+	go c.readSSE(resp.Body, endpointChan, endpointOnce)
 
 	// Wait for the endpoint to be received
 	endpointTimeout := c.endpointTimeout
@@ -271,7 +281,7 @@ func (c *SSE) Start(ctx context.Context) error {
 	defer timer.Stop()
 
 	select {
-	case <-c.endpointChan:
+	case <-endpointChan:
 		// Endpoint received, proceed
 	case <-ctx.Done():
 		return fmt.Errorf("context cancelled while waiting for endpoint: %w", ctx.Err())
@@ -286,7 +296,7 @@ func (c *SSE) Start(ctx context.Context) error {
 
 // readSSE continuously reads the SSE stream and processes events.
 // It runs until the connection is closed or an error occurs.
-func (c *SSE) readSSE(reader io.ReadCloser) {
+func (c *SSE) readSSE(reader io.ReadCloser, endpointChan chan struct{}, endpointOnce *sync.Once) {
 	defer reader.Close()
 
 	br := bufio.NewReader(reader)
@@ -304,7 +314,7 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 					if event == "" {
 						event = "message"
 					}
-					c.handleSSEEvent(event, data)
+					c.handleSSEEvent(event, data, endpointChan, endpointOnce)
 				}
 			}
 			c.connectionLostMu.RLock()
@@ -328,7 +338,7 @@ func (c *SSE) readSSE(reader io.ReadCloser) {
 				if event == "" {
 					event = "message"
 				}
-				c.handleSSEEvent(event, data)
+				c.handleSSEEvent(event, data, endpointChan, endpointOnce)
 				event = ""
 				data = ""
 			}
@@ -363,7 +373,7 @@ func appendSSEData(existing, line string) string {
 
 // handleSSEEvent processes SSE events based on their type.
 // Handles 'endpoint' events for connection setup and 'message' events for JSON-RPC communication.
-func (c *SSE) handleSSEEvent(event, data string) {
+func (c *SSE) handleSSEEvent(event, data string, endpointChan chan struct{}, endpointOnce *sync.Once) {
 	switch event {
 	case "endpoint":
 		endpoint, err := c.baseURL.Parse(data)
@@ -380,9 +390,10 @@ func (c *SSE) handleSSEEvent(event, data string) {
 		c.mu.Unlock()
 		// The SSE spec sends a single endpoint event, but a proxy or a
 		// re-broadcasting server can emit it more than once. Closing the
-		// channel twice panics, so guard the close with sync.Once.
-		c.endpointOnce.Do(func() {
-			close(c.endpointChan)
+		// channel twice panics, so guard the close with the attempt's
+		// sync.Once.
+		endpointOnce.Do(func() {
+			close(endpointChan)
 		})
 	case "message":
 		var baseMessage JSONRPCResponse

--- a/client/transport/sse_coverage_test.go
+++ b/client/transport/sse_coverage_test.go
@@ -102,7 +102,7 @@ func TestSSE_SetConnectionLostHandler(t *testing.T) {
 func TestSSE_HandleSSEEvent_MessageInvalidJSON(t *testing.T) {
 	sse := newBareSSE()
 	require.NotPanics(t, func() {
-		sse.handleSSEEvent("message", "not-json")
+		sse.handleSSEEvent("message", "not-json", make(chan struct{}), &sync.Once{})
 	})
 }
 
@@ -111,7 +111,7 @@ func TestSSE_HandleSSEEvent_MessageInvalidJSON(t *testing.T) {
 func TestSSE_HandleSSEEvent_NotificationWithoutHandler(t *testing.T) {
 	sse := newBareSSE()
 	require.NotPanics(t, func() {
-		sse.handleSSEEvent("message", `{"jsonrpc":"2.0","method":"notify"}`)
+		sse.handleSSEEvent("message", `{"jsonrpc":"2.0","method":"notify"}`, make(chan struct{}), &sync.Once{})
 	})
 }
 
@@ -122,7 +122,7 @@ func TestSSE_HandleSSEEvent_EndpointParseError(t *testing.T) {
 
 	// An unparsable endpoint event must be ignored and leave endpoint unset.
 	require.NotPanics(t, func() {
-		sse.handleSSEEvent("endpoint", "http://[::1")
+		sse.handleSSEEvent("endpoint", "http://[::1", make(chan struct{}), &sync.Once{})
 	})
 	require.Nil(t, sse.endpoint)
 }
@@ -134,7 +134,7 @@ func TestSSE_HandleSSEEvent_UnknownResponseID(t *testing.T) {
 
 	// No pending request with this ID; delivery must be a no-op.
 	require.NotPanics(t, func() {
-		sse.handleSSEEvent("message", `{"jsonrpc":"2.0","id":42,"result":{}}`)
+		sse.handleSSEEvent("message", `{"jsonrpc":"2.0","id":42,"result":{}}`, make(chan struct{}), &sync.Once{})
 	})
 }
 

--- a/client/transport/sse_coverage_test.go
+++ b/client/transport/sse_coverage_test.go
@@ -1,0 +1,416 @@
+package transport
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/require"
+)
+
+// newBareSSE builds an SSE transport with no live connection so individual
+// branches (accessors, event handling, request error paths) can be exercised
+// deterministically.
+func newBareSSE() *SSE {
+	baseURL, _ := url.Parse("http://127.0.0.1:1/")
+	return &SSE{
+		baseURL:    baseURL,
+		httpClient: http.DefaultClient,
+		responses:  make(map[string]chan *JSONRPCResponse),
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func TestSSE_Accessors(t *testing.T) {
+	sse := newBareSSE()
+	require.Equal(t, "", sse.GetSessionId())
+	require.Nil(t, sse.GetOAuthHandler())
+	require.False(t, sse.IsOAuthEnabled())
+
+	// Protocol version is stored for later header attachment.
+	sse.SetProtocolVersion("2025-03-26")
+	require.Equal(t, "2025-03-26", sse.protocolVersion.Load())
+
+	// Endpoint and base URL accessors.
+	endpoint, _ := url.Parse("http://127.0.0.1:1/message")
+	sse.endpoint = endpoint
+	require.Equal(t, endpoint, sse.GetEndpoint())
+	require.Equal(t, sse.baseURL, sse.GetBaseURL())
+}
+
+func TestSSE_ClientOptions(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	client := &http.Client{}
+	headers := map[string]string{"X-Test": "1"}
+	headerFunc := func(ctx context.Context) map[string]string {
+		return map[string]string{"X-Func": "2"}
+	}
+
+	sse, err := NewSSE(
+		"http://127.0.0.1:1/",
+		WithSSELogger(logger),
+		WithHeaders(headers),
+		WithHeaderFunc(headerFunc),
+		WithHTTPClient(client),
+		WithEndpointTimeout(10*time.Second),
+	)
+	require.NoError(t, err)
+	require.Same(t, logger, sse.logger)
+	require.Equal(t, headers, sse.headers)
+	require.NotNil(t, sse.headerFunc)
+	require.Same(t, client, sse.httpClient)
+	require.Equal(t, 10*time.Second, sse.endpointTimeout)
+
+	// Non-positive timeout keeps the default.
+	sse, err = NewSSE("http://127.0.0.1:1/", WithEndpointTimeout(0))
+	require.NoError(t, err)
+	require.NotZero(t, sse.endpointTimeout)
+
+	// Nil logger falls back to slog.Default.
+	sse, err = NewSSE("http://127.0.0.1:1/", WithSSELogger(nil))
+	require.NoError(t, err)
+	require.Same(t, slog.Default(), sse.logger)
+}
+
+func TestSSE_SetConnectionLostHandler(t *testing.T) {
+	sse := newBareSSE()
+	var got error
+	sse.SetConnectionLostHandler(func(err error) { got = err })
+	require.NotNil(t, sse.onConnectionLost)
+
+	sse.onConnectionLost(errors.New("connection lost"))
+	require.EqualError(t, got, "connection lost")
+}
+
+func TestSSE_HandleSSEEvent_MessageInvalidJSON(t *testing.T) {
+	sse := newBareSSE()
+	require.NotPanics(t, func() {
+		sse.handleSSEEvent("message", "not-json")
+	})
+}
+
+func TestSSE_HandleSSEEvent_NotificationWithoutHandler(t *testing.T) {
+	sse := newBareSSE()
+	require.NotPanics(t, func() {
+		sse.handleSSEEvent("message", `{"jsonrpc":"2.0","method":"notify"}`)
+	})
+}
+
+func TestSSE_HandleSSEEvent_EndpointParseError(t *testing.T) {
+	sse := newBareSSE()
+
+	// An unparsable endpoint event must be ignored and leave endpoint unset.
+	require.NotPanics(t, func() {
+		sse.handleSSEEvent("endpoint", "http://[::1")
+	})
+	require.Nil(t, sse.endpoint)
+}
+
+func TestSSE_HandleSSEEvent_UnknownResponseID(t *testing.T) {
+	sse := newBareSSE()
+
+	// No pending request with this ID; delivery must be a no-op.
+	require.NotPanics(t, func() {
+		sse.handleSSEEvent("message", `{"jsonrpc":"2.0","id":42,"result":{}}`)
+	})
+}
+
+func TestSSE_SendRequest_NotStarted(t *testing.T) {
+	_, err := newBareSSE().SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.EqualError(t, err, "transport not started yet")
+}
+
+func TestSSE_SendRequest_Closed(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+	sse.closed.Store(true)
+
+	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.EqualError(t, err, "transport has been closed")
+}
+
+func TestSSE_SendRequest_EndpointNotReceived(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+
+	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.EqualError(t, err, "endpoint not received")
+}
+
+func TestSSE_SendRequest_MarshalError(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+	sse.endpoint = sse.baseURL
+
+	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)), Params: make(chan int),
+	})
+	require.ErrorContains(t, err, "failed to marshal request")
+}
+
+func TestSSE_SendRequest_ConnectionError(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+	sse.endpoint = sse.baseURL // 127.0.0.1:1 refuses connections
+
+	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorContains(t, err, "failed to send request")
+}
+
+func TestSSE_SendRequest_UnauthorizedWithoutOAuth(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	sse.endpoint = mustURL(t, server.URL)
+
+	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	var authErr *AuthorizationRequiredError
+	require.ErrorAs(t, err, &authErr)
+}
+
+func TestSSE_SendRequest_ServerError(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	sse.endpoint = mustURL(t, server.URL)
+
+	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorContains(t, err, "request failed with status 500")
+}
+
+func TestSSE_SendRequest_DeadlineAlreadyPassed(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	sse.endpoint = mustURL(t, server.URL)
+
+	ctx, cancel := context.WithDeadline(t.Context(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	_, err := sse.SendRequest(ctx, JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestSSE_SendRequest_HeaderOptions(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+	var gotHeader http.Header
+	var gotHost string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHeader = r.Header.Clone()
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	sse.endpoint = mustURL(t, server.URL)
+	sse.headers = map[string]string{"X-Static": "1"}
+	sse.headerFunc = func(ctx context.Context) map[string]string {
+		return map[string]string{"X-Func": "2"}
+	}
+	sse.protocolVersion.Store("2025-03-26")
+	sse.host = "example.com"
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	// The server returns 200 without delivering an SSE response, so the
+	// request times out waiting; the headers are what this test verifies.
+	_, err := sse.SendRequest(ctx, JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.ErrorContains(t, err, "timeout waiting for SSE response")
+
+	require.Equal(t, "1", gotHeader.Get("X-Static"))
+	require.Equal(t, "2", gotHeader.Get("X-Func"))
+	require.Equal(t, "2025-03-26", gotHeader.Get(HeaderKeyProtocolVersion))
+	require.Equal(t, "example.com", gotHost)
+}
+
+// chanClosingTransport closes the request's registered response channel after
+// the server responds, modeling Close() racing with an in-flight delivery.
+type chanClosingTransport struct {
+	base  http.RoundTripper
+	sse   *SSE
+	idKey string
+}
+
+func (t *chanClosingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	resp, err := t.base.RoundTrip(req)
+	t.sse.mu.RLock()
+	ch := t.sse.responses[t.idKey]
+	t.sse.mu.RUnlock()
+	if ch != nil {
+		close(ch)
+	}
+	return resp, err
+}
+
+func TestSSE_SendRequest_ResponseChanClosed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	sse := newBareSSE()
+	sse.started.Store(true)
+	sse.endpoint = mustURL(t, server.URL)
+	sse.responseTimeout = time.Minute
+	idKey := mcp.NewRequestId(int64(1)).String()
+	sse.httpClient = &http.Client{Transport: &chanClosingTransport{
+		base:  http.DefaultTransport,
+		sse:   sse,
+		idKey: idKey,
+	}}
+
+	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
+		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
+	})
+	require.EqualError(t, err, "connection has been closed")
+}
+
+func TestSSE_SendNotification_MarshalError(t *testing.T) {
+	sse := newBareSSE()
+	sse.endpoint = sse.baseURL
+
+	err := sse.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+			Params: mcp.NotificationParams{AdditionalFields: map[string]any{
+				"bad": make(chan int),
+			}},
+		},
+	})
+	require.ErrorContains(t, err, "failed to marshal notification")
+}
+
+func TestSSE_SendNotification_ConnectionError(t *testing.T) {
+	sse := newBareSSE()
+	sse.endpoint = sse.baseURL
+
+	err := sse.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	require.ErrorContains(t, err, "failed to send notification")
+}
+
+func TestSSE_SendNotification_UnauthorizedWithoutOAuth(t *testing.T) {
+	sse := newBareSSE()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+	sse.endpoint = mustURL(t, server.URL)
+
+	err := sse.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	var authErr *AuthorizationRequiredError
+	require.ErrorAs(t, err, &authErr)
+}
+
+func TestSSE_SendNotification_ServerError(t *testing.T) {
+	sse := newBareSSE()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	sse.endpoint = mustURL(t, server.URL)
+
+	err := sse.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	require.ErrorContains(t, err, "notification failed with status 500")
+}
+
+func TestSSE_SendNotification_Success(t *testing.T) {
+	sse := newBareSSE()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+	sse.endpoint = mustURL(t, server.URL)
+
+	err := sse.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test",
+		},
+	})
+	require.NoError(t, err)
+}
+
+func TestSSE_Close_WithoutStream(t *testing.T) {
+	sse := newBareSSE()
+	pending := make(chan *JSONRPCResponse)
+	sse.responses["pending"] = pending
+
+	require.NoError(t, sse.Close())
+	require.True(t, sse.closed.Load())
+
+	// The pending channel must be closed and dropped from the map.
+	select {
+	case _, ok := <-pending:
+		require.False(t, ok)
+	default:
+		t.Fatal("pending response channel was not closed")
+	}
+	require.Empty(t, sse.responses)
+
+	// Second close is a no-op.
+	require.NoError(t, sse.Close())
+}
+
+func TestSSE_Start_AlreadyStarted(t *testing.T) {
+	sse := newBareSSE()
+	sse.started.Store(true)
+
+	require.NoError(t, sse.Start(t.Context()))
+}
+
+// mustURL parses s or fails the test.
+func mustURL(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	require.NoError(t, err)
+	return u
+}

--- a/client/transport/sse_coverage_test.go
+++ b/client/transport/sse_coverage_test.go
@@ -167,6 +167,8 @@ func TestSSE_SendRequest_MarshalError(t *testing.T) {
 // port being unbound.
 type errorTransport struct{ err error }
 
+// RoundTrip always fails with the transport's configured error, regardless of
+// the request.
 func (t errorTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, t.err
 }

--- a/client/transport/sse_coverage_test.go
+++ b/client/transport/sse_coverage_test.go
@@ -29,6 +29,8 @@ func newBareSSE() *SSE {
 	}
 }
 
+// TestSSE_Accessors verifies the no-connection accessors: session ID, OAuth
+// state, protocol version, endpoint, and base URL.
 func TestSSE_Accessors(t *testing.T) {
 	sse := newBareSSE()
 	require.Equal(t, "", sse.GetSessionId())
@@ -46,6 +48,9 @@ func TestSSE_Accessors(t *testing.T) {
 	require.Equal(t, sse.baseURL, sse.GetBaseURL())
 }
 
+// TestSSE_ClientOptions verifies that every WithSSE* option is applied when
+// constructing the transport, including the fallbacks for a zero endpoint
+// timeout and a nil logger.
 func TestSSE_ClientOptions(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	client := &http.Client{}
@@ -80,6 +85,8 @@ func TestSSE_ClientOptions(t *testing.T) {
 	require.Same(t, slog.Default(), sse.logger)
 }
 
+// TestSSE_SetConnectionLostHandler verifies the connection-lost callback is
+// stored and invoked with the connection error.
 func TestSSE_SetConnectionLostHandler(t *testing.T) {
 	sse := newBareSSE()
 	var got error
@@ -90,6 +97,8 @@ func TestSSE_SetConnectionLostHandler(t *testing.T) {
 	require.EqualError(t, got, "connection lost")
 }
 
+// TestSSE_HandleSSEEvent_MessageInvalidJSON verifies a message event with
+// invalid JSON is ignored without panicking.
 func TestSSE_HandleSSEEvent_MessageInvalidJSON(t *testing.T) {
 	sse := newBareSSE()
 	require.NotPanics(t, func() {
@@ -97,6 +106,8 @@ func TestSSE_HandleSSEEvent_MessageInvalidJSON(t *testing.T) {
 	})
 }
 
+// TestSSE_HandleSSEEvent_NotificationWithoutHandler verifies a notification
+// message with no registered handler is dropped without panicking.
 func TestSSE_HandleSSEEvent_NotificationWithoutHandler(t *testing.T) {
 	sse := newBareSSE()
 	require.NotPanics(t, func() {
@@ -104,6 +115,8 @@ func TestSSE_HandleSSEEvent_NotificationWithoutHandler(t *testing.T) {
 	})
 }
 
+// TestSSE_HandleSSEEvent_EndpointParseError verifies an unparsable endpoint
+// event is ignored and leaves the endpoint unset.
 func TestSSE_HandleSSEEvent_EndpointParseError(t *testing.T) {
 	sse := newBareSSE()
 
@@ -114,6 +127,8 @@ func TestSSE_HandleSSEEvent_EndpointParseError(t *testing.T) {
 	require.Nil(t, sse.endpoint)
 }
 
+// TestSSE_HandleSSEEvent_UnknownResponseID verifies a message whose ID has no
+// pending response is a no-op.
 func TestSSE_HandleSSEEvent_UnknownResponseID(t *testing.T) {
 	sse := newBareSSE()
 
@@ -123,6 +138,8 @@ func TestSSE_HandleSSEEvent_UnknownResponseID(t *testing.T) {
 	})
 }
 
+// TestSSE_SendRequest_NotStarted verifies SendRequest fails with
+// "transport not started yet" before Start has run.
 func TestSSE_SendRequest_NotStarted(t *testing.T) {
 	_, err := newBareSSE().SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
@@ -130,6 +147,8 @@ func TestSSE_SendRequest_NotStarted(t *testing.T) {
 	require.EqualError(t, err, "transport not started yet")
 }
 
+// TestSSE_SendRequest_Closed verifies SendRequest fails with
+// "transport has been closed" after Close has run.
 func TestSSE_SendRequest_Closed(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -141,6 +160,8 @@ func TestSSE_SendRequest_Closed(t *testing.T) {
 	require.EqualError(t, err, "transport has been closed")
 }
 
+// TestSSE_SendRequest_EndpointNotReceived verifies SendRequest fails with
+// "endpoint not received" when no endpoint event has arrived.
 func TestSSE_SendRequest_EndpointNotReceived(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -151,6 +172,8 @@ func TestSSE_SendRequest_EndpointNotReceived(t *testing.T) {
 	require.EqualError(t, err, "endpoint not received")
 }
 
+// TestSSE_SendRequest_MarshalError verifies SendRequest wraps JSON marshaling
+// failures of the request.
 func TestSSE_SendRequest_MarshalError(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -173,6 +196,8 @@ func (t errorTransport) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, t.err
 }
 
+// TestSSE_SendRequest_ConnectionError verifies SendRequest wraps HTTP
+// connection failures using the injected errorTransport.
 func TestSSE_SendRequest_ConnectionError(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -185,6 +210,8 @@ func TestSSE_SendRequest_ConnectionError(t *testing.T) {
 	require.ErrorContains(t, err, "failed to send request")
 }
 
+// TestSSE_SendRequest_UnauthorizedWithoutOAuth verifies a 401 response is
+// surfaced as AuthorizationRequiredError when OAuth is not configured.
 func TestSSE_SendRequest_UnauthorizedWithoutOAuth(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -201,6 +228,8 @@ func TestSSE_SendRequest_UnauthorizedWithoutOAuth(t *testing.T) {
 	require.ErrorAs(t, err, &authErr)
 }
 
+// TestSSE_SendRequest_ServerError verifies a 500 response is surfaced with the
+// status code in the error.
 func TestSSE_SendRequest_ServerError(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -216,6 +245,8 @@ func TestSSE_SendRequest_ServerError(t *testing.T) {
 	require.ErrorContains(t, err, "request failed with status 500")
 }
 
+// TestSSE_SendRequest_DeadlineAlreadyPassed verifies a request whose context
+// deadline already passed fails with context.DeadlineExceeded.
 func TestSSE_SendRequest_DeadlineAlreadyPassed(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -234,6 +265,9 @@ func TestSSE_SendRequest_DeadlineAlreadyPassed(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+// TestSSE_SendRequest_HeaderOptions verifies static headers, the dynamic
+// header function, the protocol version, and the host override are all
+// attached to the outbound HTTP request.
 func TestSSE_SendRequest_HeaderOptions(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
@@ -284,6 +318,8 @@ type chanClosingTransport struct {
 	idKey string
 }
 
+// RoundTrip delegates to the base transport and then closes the registered
+// response channel, modeling Close racing an in-flight delivery.
 func (t *chanClosingTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	resp, err := t.base.RoundTrip(req)
 	t.sse.mu.RLock()
@@ -295,6 +331,9 @@ func (t *chanClosingTransport) RoundTrip(req *http.Request) (*http.Response, err
 	return resp, err
 }
 
+// TestSSE_SendRequest_ResponseChanClosed verifies SendRequest reports
+// "connection has been closed" when the response channel is closed before
+// delivery.
 func TestSSE_SendRequest_ResponseChanClosed(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -318,6 +357,8 @@ func TestSSE_SendRequest_ResponseChanClosed(t *testing.T) {
 	require.EqualError(t, err, "connection has been closed")
 }
 
+// TestSSE_SendNotification_MarshalError verifies SendNotification wraps JSON
+// marshaling failures of the notification.
 func TestSSE_SendNotification_MarshalError(t *testing.T) {
 	sse := newBareSSE()
 	sse.endpoint = sse.baseURL
@@ -334,6 +375,8 @@ func TestSSE_SendNotification_MarshalError(t *testing.T) {
 	require.ErrorContains(t, err, "failed to marshal notification")
 }
 
+// TestSSE_SendNotification_ConnectionError verifies SendNotification wraps
+// HTTP connection failures using the injected errorTransport.
 func TestSSE_SendNotification_ConnectionError(t *testing.T) {
 	sse := newBareSSE()
 	sse.endpoint = sse.baseURL
@@ -348,6 +391,9 @@ func TestSSE_SendNotification_ConnectionError(t *testing.T) {
 	require.ErrorContains(t, err, "failed to send notification")
 }
 
+// TestSSE_SendNotification_UnauthorizedWithoutOAuth verifies a 401 response to
+// a notification is surfaced as AuthorizationRequiredError when OAuth is not
+// configured.
 func TestSSE_SendNotification_UnauthorizedWithoutOAuth(t *testing.T) {
 	sse := newBareSSE()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -366,6 +412,8 @@ func TestSSE_SendNotification_UnauthorizedWithoutOAuth(t *testing.T) {
 	require.ErrorAs(t, err, &authErr)
 }
 
+// TestSSE_SendNotification_ServerError verifies a 500 response to a
+// notification is surfaced with the status code in the error.
 func TestSSE_SendNotification_ServerError(t *testing.T) {
 	sse := newBareSSE()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -383,6 +431,8 @@ func TestSSE_SendNotification_ServerError(t *testing.T) {
 	require.ErrorContains(t, err, "notification failed with status 500")
 }
 
+// TestSSE_SendNotification_Success verifies a notification accepted by the
+// server returns no error.
 func TestSSE_SendNotification_Success(t *testing.T) {
 	sse := newBareSSE()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -400,6 +450,8 @@ func TestSSE_SendNotification_Success(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestSSE_Close_WithoutStream verifies Close without a live stream closes and
+// drops pending response channels and is idempotent.
 func TestSSE_Close_WithoutStream(t *testing.T) {
 	sse := newBareSSE()
 	pending := make(chan *JSONRPCResponse)
@@ -421,6 +473,8 @@ func TestSSE_Close_WithoutStream(t *testing.T) {
 	require.NoError(t, sse.Close())
 }
 
+// TestSSE_Start_AlreadyStarted verifies Start is a no-op returning no error
+// when the transport is already started.
 func TestSSE_Start_AlreadyStarted(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)

--- a/client/transport/sse_coverage_test.go
+++ b/client/transport/sse_coverage_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"testing"
 	"time"
 
@@ -161,10 +162,20 @@ func TestSSE_SendRequest_MarshalError(t *testing.T) {
 	require.ErrorContains(t, err, "failed to marshal request")
 }
 
+// errorTransport is an http.RoundTripper that always fails with a fixed error,
+// making connection-error tests deterministic without relying on a particular
+// port being unbound.
+type errorTransport struct{ err error }
+
+func (t errorTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, t.err
+}
+
 func TestSSE_SendRequest_ConnectionError(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
-	sse.endpoint = sse.baseURL // 127.0.0.1:1 refuses connections
+	sse.endpoint = sse.baseURL
+	sse.httpClient = &http.Client{Transport: errorTransport{err: errors.New("connection refused")}}
 
 	_, err := sse.SendRequest(t.Context(), JSONRPCRequest{
 		JSONRPC: "2.0", ID: mcp.NewRequestId(int64(1)),
@@ -224,11 +235,16 @@ func TestSSE_SendRequest_DeadlineAlreadyPassed(t *testing.T) {
 func TestSSE_SendRequest_HeaderOptions(t *testing.T) {
 	sse := newBareSSE()
 	sse.started.Store(true)
+	// The server handler runs on a different goroutine than the assertions
+	// below; guard the captured request data with a mutex.
+	var gotMu sync.Mutex
 	var gotHeader http.Header
 	var gotHost string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMu.Lock()
 		gotHeader = r.Header.Clone()
 		gotHost = r.Host
+		gotMu.Unlock()
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
@@ -250,6 +266,8 @@ func TestSSE_SendRequest_HeaderOptions(t *testing.T) {
 	})
 	require.ErrorContains(t, err, "timeout waiting for SSE response")
 
+	gotMu.Lock()
+	defer gotMu.Unlock()
 	require.Equal(t, "1", gotHeader.Get("X-Static"))
 	require.Equal(t, "2", gotHeader.Get("X-Func"))
 	require.Equal(t, "2025-03-26", gotHeader.Get(HeaderKeyProtocolVersion))
@@ -317,6 +335,7 @@ func TestSSE_SendNotification_MarshalError(t *testing.T) {
 func TestSSE_SendNotification_ConnectionError(t *testing.T) {
 	sse := newBareSSE()
 	sse.endpoint = sse.baseURL
+	sse.httpClient = &http.Client{Transport: errorTransport{err: errors.New("connection refused")}}
 
 	err := sse.SendNotification(t.Context(), mcp.JSONRPCNotification{
 		JSONRPC: "2.0",

--- a/client/transport/sse_lifecycle_test.go
+++ b/client/transport/sse_lifecycle_test.go
@@ -1,0 +1,169 @@
+package transport
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSE_Start_RetryAfterFailure verifies a failed Start can be retried and
+// the retry completes with its own handshake instead of stale state.
+func TestSSE_Start_RetryAfterFailure(t *testing.T) {
+	var requests atomic.Int32
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			// First attempt fails before a stream is established.
+			http.Error(w, "temporary failure", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "event: endpoint\ndata: %s/messages\n\n", server.URL)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	transport, err := NewSSE(server.URL, WithEndpointTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer transport.Close()
+
+	require.Error(t, transport.Start(t.Context()))
+	require.NoError(t, transport.Start(t.Context()))
+	require.Equal(t, int32(2), requests.Load())
+}
+
+// TestSSE_HandleSSEEvent_PerAttemptEndpointIsolation verifies each Start
+// attempt owns its endpoint channel: closing one attempt's channel (e.g. by a
+// delayed event from a superseded reader) must not satisfy a different
+// attempt's wait, and duplicate endpoint events on the same attempt must not
+// panic.
+func TestSSE_HandleSSEEvent_PerAttemptEndpointIsolation(t *testing.T) {
+	sse := newBareSSE()
+	const endpointData = "http://127.0.0.1:1/messages"
+
+	first := make(chan struct{})
+	firstOnce := &sync.Once{}
+	sse.handleSSEEvent("endpoint", endpointData, first, firstOnce)
+	select {
+	case <-first:
+	default:
+		t.Fatal("first attempt's channel was not closed")
+	}
+
+	second := make(chan struct{})
+	secondOnce := &sync.Once{}
+	sse.handleSSEEvent("endpoint", endpointData, second, secondOnce)
+	select {
+	case <-second:
+	default:
+		t.Fatal("second attempt's channel was not closed")
+	}
+
+	// A third attempt that has not seen an endpoint yet must stay blocked.
+	third := make(chan struct{})
+	select {
+	case <-third:
+		t.Fatal("third attempt was satisfied by a superseded reader's event")
+	default:
+	}
+
+	// A proxy re-sending the endpoint for the same attempt must not panic.
+	require.NotPanics(t, func() {
+		sse.handleSSEEvent("endpoint", endpointData, first, firstOnce)
+	})
+}
+
+// TestSSE_Start_ConcurrentSingleStream verifies overlapping Start calls are
+// serialized: exactly one HTTP stream is opened and both callers succeed.
+func TestSSE_Start_ConcurrentSingleStream(t *testing.T) {
+	var requests atomic.Int32
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintf(w, "event: endpoint\ndata: %s/messages\n\n", server.URL)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	transport, err := NewSSE(server.URL, WithEndpointTimeout(2*time.Second))
+	require.NoError(t, err)
+	defer transport.Close()
+
+	var wg sync.WaitGroup
+	errs := make([]error, 2)
+	for i := range 2 {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			errs[idx] = transport.Start(t.Context())
+		}(i)
+	}
+	wg.Wait()
+
+	require.NoError(t, errs[0])
+	require.NoError(t, errs[1])
+	require.Equal(t, int32(1), requests.Load(), "overlapping Start opened multiple streams")
+}
+
+// TestSSE_ReadSSE_PendingEndpointAtEOF verifies an endpoint event buffered
+// before EOF is processed as a pending event before the reader exits.
+func TestSSE_ReadSSE_PendingEndpointAtEOF(t *testing.T) {
+	sse := newBareSSE()
+	ch := make(chan struct{})
+	once := &sync.Once{}
+	// No trailing blank line: the endpoint event is still buffered when the
+	// reader hits EOF and must be processed as a pending event.
+	body := "event: endpoint\ndata: http://127.0.0.1:1/messages\n"
+	sse.readSSE(io.NopCloser(strings.NewReader(body)), ch, once)
+	select {
+	case <-ch:
+	default:
+		t.Fatal("pending endpoint event was not processed on EOF")
+	}
+}
+
+// TestSSE_Start_FollowerContextCancellation verifies cancelling the caller's
+// context while waiting for the endpoint aborts Start with the context error.
+func TestSSE_Start_FollowerContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		// Never send the endpoint; wait for the client to give up.
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	transport, err := NewSSE(server.URL, WithEndpointTimeout(10*time.Second))
+	require.NoError(t, err)
+	defer transport.Close()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	cancelled := make(chan struct{})
+	go func() {
+		<-time.After(100 * time.Millisecond)
+		cancel()
+		close(cancelled)
+	}()
+
+	err = transport.Start(ctx)
+	<-cancelled
+
+	require.Error(t, err)
+	require.ErrorIs(t, err, context.Canceled)
+	require.Contains(t, err.Error(), "context cancelled while waiting for endpoint")
+}

--- a/client/transport/sse_lifecycle_test.go
+++ b/client/transport/sse_lifecycle_test.go
@@ -136,6 +136,67 @@ func TestSSE_ReadSSE_PendingEndpointAtEOF(t *testing.T) {
 	}
 }
 
+// TestSSE_Start_FollowerCancelsIndependently verifies a concurrent Start
+// waiting for the owner's in-flight handshake honors its own context and
+// cancels without disturbing the owner.
+func TestSSE_Start_FollowerCancelsIndependently(t *testing.T) {
+	releaseEndpoint := make(chan struct{})
+	var requests atomic.Int32
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.(http.Flusher).Flush()
+		<-releaseEndpoint
+		fmt.Fprintf(w, "event: endpoint\ndata: %s/messages\n\n", server.URL)
+		w.(http.Flusher).Flush()
+		<-r.Context().Done()
+	}))
+	defer server.Close()
+
+	transport, err := NewSSE(server.URL, WithEndpointTimeout(5*time.Second))
+	require.NoError(t, err)
+	defer transport.Close()
+
+	// Owner: blocks waiting for the endpoint.
+	ownerDone := make(chan error, 1)
+	go func() { ownerDone <- transport.Start(t.Context()) }()
+
+	// Wait until the owner registered its in-flight handshake.
+	require.Eventually(t, func() bool {
+		transport.startMu.Lock()
+		defer transport.startMu.Unlock()
+		return transport.startDone != nil
+	}, time.Second, 5*time.Millisecond)
+
+	// Follower: waits on the shared handshake but cancels its own context.
+	followerCtx, cancel := context.WithCancel(t.Context())
+	followerDone := make(chan error, 1)
+	go func() { followerDone <- transport.Start(followerCtx) }()
+	time.Sleep(20 * time.Millisecond) // let the follower reach the wait
+	cancel()
+
+	select {
+	case err := <-followerDone:
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("follower did not honor its own context cancellation")
+	}
+
+	// Release the endpoint: the owner still completes successfully.
+	close(releaseEndpoint)
+	select {
+	case err := <-ownerDone:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("owner did not complete after the endpoint was sent")
+	}
+
+	require.Equal(t, int32(1), requests.Load(), "concurrent Start opened extra streams")
+}
+
 // TestSSE_Start_FollowerContextCancellation verifies cancelling the caller's
 // context while waiting for the endpoint aborts Start with the context error.
 func TestSSE_Start_FollowerContextCancellation(t *testing.T) {

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -1675,22 +1676,27 @@ func TestSSE_CloseConcurrentWithMessageDoesNotPanic(t *testing.T) {
 		trans.handleSSEEvent("message", msg)
 	}()
 
-	// Wait until the sender is about to deliver, then give it time to reach
-	// the blocking send before running the closer.
+	// Wait until the sender owns trans.mu: TryLock fails exactly while the
+	// write lock is held, i.e. while the sender is blocked sending into the
+	// unbuffered responseChan. Polling the lock state is deterministic and
+	// does not depend on scheduling delays like timing sleeps do.
 	<-entering
-	time.Sleep(20 * time.Millisecond)
+	deadline := time.Now().Add(5 * time.Second)
+	for trans.mu.TryLock() {
+		trans.mu.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("sender never acquired the write lock")
+		}
+		runtime.Gosched()
+	}
 
 	// Closer: runs while the send is in flight. Before the fix this closed
-	// responseChan under the sender and the blocked send panicked.
+	// responseChan under the sender and the blocked send panicked; with the
+	// fix it blocks on the write lock until the send completes.
 	go func() {
 		defer wg.Done()
 		_ = trans.Close()
 	}()
-
-	// Give the closer time to reach Close() before draining the channel:
-	// before the fix it closes the channel here and panics the blocked send;
-	// with the fix it blocks on the write lock until the send completes.
-	time.Sleep(50 * time.Millisecond)
 
 	// Drain the channel so the in-flight send completes; with the fix the
 	// closer's Close() waits for this before closing (now empty) channels.

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -611,8 +611,7 @@ func TestSSE(t *testing.T) {
 		// that the readSSE method returns without calling any handler
 
 		// Directly test the readSSE method with our mock reader
-		go trans.readSSE(mockReader)
-
+		go trans.readSSE(mockReader, make(chan struct{}), &sync.Once{})
 		// Wait for readSSE to complete
 		time.Sleep(100 * time.Millisecond)
 
@@ -653,8 +652,7 @@ func TestSSE(t *testing.T) {
 		})
 
 		// Directly test the readSSE method with our mock reader that simulates ERROR
-		go trans.readSSE(mockReader)
-
+		go trans.readSSE(mockReader, make(chan struct{}), &sync.Once{})
 		// Wait for connection lost handler to be called
 		timeout := time.After(1 * time.Second)
 		ticker := time.NewTicker(10 * time.Millisecond)
@@ -1675,7 +1673,7 @@ func TestSSE_CloseConcurrentWithMessageDoesNotPanic(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		close(entering)
-		trans.handleSSEEvent("message", msg)
+		trans.handleSSEEvent("message", msg, make(chan struct{}), &sync.Once{})
 	}()
 
 	// Wait until the sender owns trans.mu: TryLock fails exactly while the

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -1449,3 +1449,257 @@ func TestSSE_SendRequest_Timeout(t *testing.T) {
 			"Expected context.DeadlineExceeded, got: %v", err)
 	})
 }
+
+// TestSSE_DuplicateEndpointEventDoesNotPanic is a regression test for the
+// "close of closed channel" panic triggered when a server (or proxy) sends a
+// second `endpoint` event. The transport must survive and keep processing
+// messages.
+func TestSSE_DuplicateEndpointEventDoesNotPanic(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		sseWriter http.ResponseWriter
+		flush     func()
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+		mu.Lock()
+		sseWriter = w
+		flush = flusher.Flush
+		mu.Unlock()
+
+		// Duplicate endpoint event: the SSE spec sends one, a re-broadcasting
+		// proxy may send more.
+		mu.Lock()
+		fmt.Fprintf(w, "event: endpoint\ndata: /message\n\n")
+		flusher.Flush()
+		fmt.Fprintf(w, "event: endpoint\ndata: /message\n\n")
+		flusher.Flush()
+		mu.Unlock()
+
+		<-r.Context().Done()
+	})
+	mux.HandleFunc("/message", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
+			return
+		}
+		response := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request["id"],
+			"result":  map[string]any{},
+		}
+		data, _ := json.Marshal(response)
+		mu.Lock()
+		defer mu.Unlock()
+		if sseWriter != nil && flush != nil {
+			fmt.Fprintf(sseWriter, "event: message\ndata: %s\n\n", data)
+			flush()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
+
+	trans, err := NewSSE(testServer.URL)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	require.NoError(t, trans.Start(ctx))
+	defer trans.Close()
+
+	// After two endpoint events the transport must still route a response.
+	reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+	_, err = trans.SendRequest(reqCtx, JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "ping",
+	})
+	reqCancel()
+	require.NoError(t, err, "SendRequest should succeed after a duplicate endpoint event")
+
+	// The negotiated endpoint must be readable without racing the SSE reader.
+	require.Equal(t, testServer.URL+"/message", trans.GetEndpoint().String())
+}
+
+// TestSSE_InvalidEndpointEventsIgnored verifies that malformed or cross-origin
+// endpoint events are ignored: they must not panic, must not clobber the
+// endpoint, and must not prevent a later valid endpoint event from working.
+func TestSSE_InvalidEndpointEventsIgnored(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		sseWriter http.ResponseWriter
+		flush     func()
+	)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming unsupported", http.StatusInternalServerError)
+			return
+		}
+		mu.Lock()
+		sseWriter = w
+		flush = flusher.Flush
+		mu.Unlock()
+
+		// Invalid URL escape, then a cross-origin URL, then the valid one.
+		mu.Lock()
+		fmt.Fprintf(w, "event: endpoint\ndata: %%zz\n\n")
+		flusher.Flush()
+		fmt.Fprintf(w, "event: endpoint\ndata: http://evil.example.com/message\n\n")
+		flusher.Flush()
+		fmt.Fprintf(w, "event: endpoint\ndata: /message\n\n")
+		flusher.Flush()
+		mu.Unlock()
+
+		<-r.Context().Done()
+	})
+	mux.HandleFunc("/message", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		var request map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			http.Error(w, fmt.Sprintf("Invalid JSON: %v", err), http.StatusBadRequest)
+			return
+		}
+		response := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      request["id"],
+			"result":  map[string]any{},
+		}
+		data, _ := json.Marshal(response)
+		mu.Lock()
+		defer mu.Unlock()
+		if sseWriter != nil && flush != nil {
+			fmt.Fprintf(sseWriter, "event: message\ndata: %s\n\n", data)
+			flush()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+	})
+
+	testServer := httptest.NewServer(mux)
+	defer testServer.Close()
+
+	trans, err := NewSSE(testServer.URL)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	defer cancel()
+
+	require.NoError(t, trans.Start(ctx))
+	defer trans.Close()
+
+	// The invalid events must be ignored: only the valid endpoint is kept.
+	require.Equal(t, testServer.URL+"/message", trans.GetEndpoint().String())
+
+	reqCtx, reqCancel := context.WithTimeout(ctx, 5*time.Second)
+	_, err = trans.SendRequest(reqCtx, JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      mcp.NewRequestId(int64(1)),
+		Method:  "ping",
+	})
+	reqCancel()
+	require.NoError(t, err)
+}
+
+// TestSSE_SendNotification_EndpointNotReceived verifies the error path of the
+// endpoint read introduced by the endpoint locking.
+func TestSSE_SendNotification_EndpointNotReceived(t *testing.T) {
+	trans, err := NewSSE("http://127.0.0.1:1/")
+	require.NoError(t, err)
+
+	err = trans.SendNotification(t.Context(), mcp.JSONRPCNotification{
+		JSONRPC: "2.0",
+		Notification: mcp.Notification{
+			Method: "test/notification",
+		},
+	})
+	require.EqualError(t, err, "endpoint not received")
+}
+
+// TestSSE_CloseConcurrentWithMessageDoesNotPanic is a regression test for the
+// "send on closed channel" panic: Close() closes pending response channels
+// while handleSSEEvent is delivering a message. Delivery must hold the same
+// write lock as Close so the two can never interleave.
+//
+// The test uses an unbuffered channel to make the interleaving deterministic:
+// the sender blocks inside the delivery, the test then closes the transport,
+// and only afterwards drains the channel. Before the fix, Close() closed the
+// channel while the send was in flight and the blocked send panicked. With the
+// fix the send happens under the write lock, so Close() waits for it.
+func TestSSE_CloseConcurrentWithMessageDoesNotPanic(t *testing.T) {
+	trans, err := NewSSE("http://127.0.0.1:1/")
+	require.NoError(t, err)
+
+	// RequestId.String() disambiguates JSON numbers and strings ("int64:1" vs
+	// "string:1"), so the registered key and the wire message must agree.
+	idKey := mcp.NewRequestId(int64(1)).String()
+	// Unbuffered channel: the delivery blocks until somebody receives.
+	responseChan := make(chan *JSONRPCResponse)
+	trans.mu.Lock()
+	trans.responses[idKey] = responseChan
+	trans.mu.Unlock()
+
+	msg := `{"jsonrpc":"2.0","id":1,"result":{}}`
+
+	entering := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Sender: deliver the response. It blocks in the send until the test
+	// drains the channel below.
+	go func() {
+		defer wg.Done()
+		close(entering)
+		trans.handleSSEEvent("message", msg)
+	}()
+
+	// Wait until the sender is about to deliver, then give it time to reach
+	// the blocking send before running the closer.
+	<-entering
+	time.Sleep(20 * time.Millisecond)
+
+	// Closer: runs while the send is in flight. Before the fix this closed
+	// responseChan under the sender and the blocked send panicked.
+	go func() {
+		defer wg.Done()
+		_ = trans.Close()
+	}()
+
+	// Give the closer time to reach Close() before draining the channel:
+	// before the fix it closes the channel here and panics the blocked send;
+	// with the fix it blocks on the write lock until the send completes.
+	time.Sleep(50 * time.Millisecond)
+
+	// Drain the channel so the in-flight send completes; with the fix the
+	// closer's Close() waits for this before closing (now empty) channels.
+	select {
+	case resp := <-responseChan:
+		require.NotNil(t, resp)
+	case <-time.After(5 * time.Second):
+		t.Fatal("response was not delivered")
+	}
+
+	wg.Wait()
+}

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -1194,6 +1194,8 @@ func TestSSEHostOverride(t *testing.T) {
 	})
 }
 
+// TestSSE_SendRequest_Timeout verifies SendRequest fails with a timeout error
+// when the server accepts the request but never delivers an SSE response.
 func TestSSE_SendRequest_Timeout(t *testing.T) {
 	t.Run("TimeoutWhenServerNeverResponds", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What changed

Two panic paths in the SSE client transport, both reachable from server-side behavior that is outside the happy path:

1. **Duplicate `endpoint` event → `panic: close of closed channel`.** The spec sends a single `endpoint` event, but a re-broadcasting proxy can send a second one; `handleSSEEvent` closed `endpointChan` without a guard.
2. **`Close()` racing message delivery → `panic: send on closed channel`.** `Close()` closes pending response channels under the write lock, while `handleSSEEvent` delivered messages after releasing a read lock — the two could interleave.

While fixing these, `go test -race` also surfaced a data race on `c.endpoint`: `handleSSEEvent` writes it while `SendRequest`/`SendNotification`/`GetEndpoint` read it unsynchronized.

## How it's fixed

- `endpointChan` is closed exactly once via `sync.Once`.
- Message delivery now holds the transport write lock for the send, serializing it against `Close()`'s channel cleanup.
- `c.endpoint` reads and writes are guarded by the existing `c.mu`.

## How it's verified

- `TestSSE_DuplicateEndpointEventDoesNotPanic`: a server that emits two `endpoint` events; before this change the transport goroutine panics with `close of closed channel`.
- `TestSSE_CloseConcurrentWithMessageDoesNotPanic`: a deterministic interleaving (unbuffered channel) that reproduces `send on closed channel` before the fix.
- `TestSSE_InvalidEndpointEventsIgnored`: malformed and cross-origin endpoint events are ignored without panic, and a later valid event still works.
- `TestSSE_SendNotification_EndpointNotReceived`: the endpoint-not-received error path.
- `go test ./... -race`, `go vet`, and `golangci-lint` pass; patch coverage of this change is 100%.

Fixes #959

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSE connection stability when duplicate, invalid, or cross-origin endpoint events are received.
  * Prevented race conditions and potential panics when closing connections during response delivery.
  * Improved error handling for notifications sent before an endpoint is available.
  * Improved reliability when starting or closing SSE connections multiple times.
* **Tests**
  * Added comprehensive coverage for SSE requests, notifications, errors, headers, endpoint handling, and shutdown scenarios.
  * Added concurrency tests to verify safe transport closure during message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->