### PR TITLE
fix(mcp): carry _meta on ResourceLink content

### DIFF
--- a/mcp/types.go
+++ b/mcp/types.go
@@ -1287,6 +1287,8 @@ func (AudioContent) isContent() {}
 // ResourceLink represents a link to a resource that the client can access.
 type ResourceLink struct {
 	Annotated
+	// Meta is a metadata object that is reserved by MCP for storing additional information.
+	Meta *Meta  `json:"_meta,omitempty"`
 	Type string `json:"type"` // Must be "resource_link"
 	// The URI of the resource.
 	URI string `json:"uri"`

--- a/mcp/types_test.go
+++ b/mcp/types_test.go
@@ -147,6 +147,33 @@ func TestResourceLinkTitleAndSize(t *testing.T) {
 	}
 }
 
+// TestResourceLinkMeta mirrors the _meta round-trip that Resource and the other
+// content blocks already have: per the MCP spec a ResourceLink carries the same
+// metadata as a Resource, so its _meta must survive JSON round-trips and be
+// omitted from the wire when unset.
+func TestResourceLinkMeta(t *testing.T) {
+	t.Run("meta omitted when unset", func(t *testing.T) {
+		rl := NewResourceLink("file:///x.txt", "x.txt", "", "")
+		data, err := json.Marshal(rl)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"_meta"`)
+	})
+
+	t.Run("meta round-trips when set", func(t *testing.T) {
+		rl := NewResourceLink("file:///x.txt", "x.txt", "", "")
+		rl.Meta = &Meta{AdditionalFields: map[string]any{"source_url": "https://example.com"}}
+
+		data, err := json.Marshal(rl)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"_meta"`)
+
+		var rt ResourceLink
+		require.NoError(t, json.Unmarshal(data, &rt))
+		require.NotNil(t, rt.Meta)
+		assert.Equal(t, "https://example.com", rt.Meta.AdditionalFields["source_url"])
+	})
+}
+
 func TestCallToolResultWithResourceLink(t *testing.T) {
 	result := &CallToolResult{
 		Content: []Content{

--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -667,6 +667,7 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 			}
 		}
 		c.Annotations = annotations
+		c.Meta = meta
 		return c, nil
 
 	case ContentTypeResource:

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -449,6 +449,28 @@ func TestParseContent(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "resource link with _meta",
+			contentMap: map[string]any{
+				"type": "resource_link",
+				"uri":  "file:///test.txt",
+				"name": "test.txt",
+				"_meta": map[string]any{
+					"source_url": "https://example.com",
+				},
+			},
+			expected: ResourceLink{
+				Type: ContentTypeLink,
+				URI:  "file:///test.txt",
+				Name: "test.txt",
+				Meta: &Meta{
+					AdditionalFields: map[string]any{
+						"source_url": "https://example.com",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
 			name: "text content with _meta containing progressToken",
 			contentMap: map[string]any{
 				"type": "text",

--- a/mcp/utils_test.go
+++ b/mcp/utils_test.go
@@ -676,6 +676,7 @@ func TestParseContent(t *testing.T) {
 					assert.Equal(t, exp.MIMEType, act.MIMEType)
 					assert.Equal(t, exp.Size, act.Size)
 					assert.Equal(t, exp.Annotations, act.Annotations)
+					assert.Equal(t, exp.Meta, act.Meta)
 				case EmbeddedResource:
 					act, ok := result.(EmbeddedResource)
 					assert.True(t, ok)


### PR DESCRIPTION
`ResourceLink` was the only content block without a `_meta` field, so any `_meta` a server put on a `resource_link` was silently dropped when unmarshaling into `Content`, and there was no way to set one either. `Resource` carries `_meta`, and `TestResourceLinkTitleAndSize` already treats `ResourceLink` as mirroring a Resource's metadata per the spec — this just extends that to `_meta`.

Added the `Meta *Meta` field to `ResourceLink` (matching the other content types) and set it in `ParseContent` alongside the annotations. The struct-unmarshal path picks it up automatically from the json tag.

Added a JSON round-trip test and a `ParseContent` case, mirroring the `_meta` coverage the other content blocks already have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resource links now support optional metadata through the `_meta` field.
  - Metadata is preserved when resource-link content is parsed and serialized.
  - Resource-link metadata, including source URLs and other associated details, remains available for downstream processing.
- **Bug Fixes**
  - Fixed an issue where metadata was lost while parsing resource-link content.
  - Unset metadata is omitted from serialized resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->