### PR TITLE
fix: reject SSE restart after close

### DIFF
--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -163,6 +163,9 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 // Start initiates the SSE connection to the server and waits for the endpoint information.
 // Returns an error if the connection fails or times out waiting for the endpoint.
 func (c *SSE) Start(ctx context.Context) error {
+	if c.closed.Load() {
+		return fmt.Errorf("transport has been closed")
+	}
 	if c.started.Load() {
 		return nil
 	}

--- a/client/transport/sse.go
+++ b/client/transport/sse.go
@@ -37,6 +37,8 @@ type SSE struct {
 	host           string
 	logger         *slog.Logger
 
+	startMu          sync.Mutex
+	lifecycleMu      sync.Mutex
 	started          atomic.Bool
 	closed           atomic.Bool
 	cancelSSEStream  context.CancelFunc
@@ -163,15 +165,32 @@ func NewSSE(baseURL string, options ...ClientOption) (*SSE, error) {
 // Start initiates the SSE connection to the server and waits for the endpoint information.
 // Returns an error if the connection fails or times out waiting for the endpoint.
 func (c *SSE) Start(ctx context.Context) error {
+	// Serialize starts so only one request can publish the active stream canceler.
+	c.startMu.Lock()
+	defer c.startMu.Unlock()
+
+	// Publish the canceler under the same lock that Close uses for the closed
+	// transition. Close therefore either rejects this start or observes its canceler.
+	c.lifecycleMu.Lock()
 	if c.closed.Load() {
-		return fmt.Errorf("transport has been closed")
+		c.lifecycleMu.Unlock()
+		return ErrTransportClosed
 	}
 	if c.started.Load() {
+		c.lifecycleMu.Unlock()
 		return nil
 	}
 
 	ctx, cancel := context.WithCancel(ctx)
 	c.cancelSSEStream = cancel
+	c.lifecycleMu.Unlock()
+
+	startSucceeded := false
+	defer func() {
+		if !startSucceeded {
+			cancel()
+		}
+	}()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL.String(), nil)
 	if err != nil {
@@ -282,7 +301,15 @@ func (c *SSE) Start(ctx context.Context) error {
 		return fmt.Errorf("timeout waiting for endpoint after %v", endpointTimeout)
 	}
 
+	// Do not publish a successful start after a concurrent Close has won.
+	c.lifecycleMu.Lock()
+	if c.closed.Load() {
+		c.lifecycleMu.Unlock()
+		return ErrTransportClosed
+	}
 	c.started.Store(true)
+	startSucceeded = true
+	c.lifecycleMu.Unlock()
 	return nil
 }
 
@@ -608,14 +635,21 @@ func (c *SSE) SendRequest(
 // Close shuts down the SSE client connection and cleans up any pending responses.
 // Returns an error if the shutdown process fails.
 func (c *SSE) Close() error {
-	if !c.closed.CompareAndSwap(false, true) {
+	// Synchronize the closed transition with Start's canceler publication so an
+	// in-flight start cannot escape shutdown with a live request context.
+	c.lifecycleMu.Lock()
+	if c.closed.Load() {
+		c.lifecycleMu.Unlock()
 		return nil // Already closed
 	}
+	c.closed.Store(true)
+	cancelSSEStream := c.cancelSSEStream
+	c.lifecycleMu.Unlock()
 
-	if c.cancelSSEStream != nil {
+	if cancelSSEStream != nil {
 		// It could stop the sse stream body, to quit the readSSE loop immediately
 		// Also, it could quit start() immediately if not receiving the endpoint
-		c.cancelSSEStream()
+		cancelSSEStream()
 	}
 
 	// Clean up any pending responses

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,6 +26,29 @@ type mockReaderWithError struct {
 	err      error
 	position int
 	closed   bool
+}
+
+type blockingDoneContext struct {
+	context.Context
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip delegates to the test function while satisfying http.RoundTripper.
+func (f roundTripFunc) RoundTrip(request *http.Request) (*http.Response, error) {
+	return f(request)
+}
+
+// Done pauses context cancellation setup so tests can exercise the lifecycle boundary.
+func (c *blockingDoneContext) Done() <-chan struct{} {
+	c.once.Do(func() {
+		close(c.entered)
+		<-c.release
+	})
+	return c.Context.Done()
 }
 
 func (m *mockReaderWithError) Read(p []byte) (n int, err error) {
@@ -681,16 +705,85 @@ func TestSSE(t *testing.T) {
 }
 
 func TestSSEStartAfterClose(t *testing.T) {
-	url, closeServer := startMockSSEEchoServer()
-	defer closeServer()
+	tests := []struct {
+		name             string
+		startBeforeClose bool
+		wantRequests     int32
+	}{
+		{name: "close before first start", wantRequests: 0},
+		{name: "close after successful start", startBeforeClose: true, wantRequests: 1},
+	}
 
-	transport, err := NewSSE(url)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var requestCount atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				requestCount.Add(1)
+				w.Header().Set("Content-Type", "text/event-stream")
+				flusher, ok := w.(http.Flusher)
+				if !ok {
+					http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+					return
+				}
+				_, _ = fmt.Fprint(w, "event: endpoint\ndata: /message\n\n")
+				flusher.Flush()
+				<-r.Context().Done()
+			}))
+			defer server.Close()
+
+			transport, err := NewSSE(server.URL)
+			require.NoError(t, err)
+			if tt.startBeforeClose {
+				require.NoError(t, transport.Start(t.Context()))
+			}
+			require.NoError(t, transport.Close())
+
+			err = transport.Start(t.Context())
+			require.ErrorIs(t, err, ErrTransportClosed)
+			require.Equal(t, tt.wantRequests, requestCount.Load())
+		})
+	}
+}
+
+func TestSSEConcurrentStartClosePublishesCancellation(t *testing.T) {
+	ctx := &blockingDoneContext{
+		Context: t.Context(),
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+	httpClient := &http.Client{
+		Transport: roundTripFunc(func(request *http.Request) (*http.Response, error) {
+			<-request.Context().Done()
+			return nil, request.Context().Err()
+		}),
+	}
+	transport, err := NewSSE("http://example.com/sse", WithHTTPClient(httpClient))
 	require.NoError(t, err)
-	require.NoError(t, transport.Start(t.Context()))
-	require.NoError(t, transport.Close())
 
-	err = transport.Start(t.Context())
-	require.EqualError(t, err, "transport has been closed")
+	startErr := make(chan error, 1)
+	go func() {
+		startErr <- transport.Start(ctx)
+	}()
+	<-ctx.entered
+
+	closeStarted := make(chan struct{})
+	closeErr := make(chan error, 1)
+	go func() {
+		close(closeStarted)
+		closeErr <- transport.Close()
+	}()
+	<-closeStarted
+
+	// Close must wait until Start publishes the stream canceler under lifecycleMu.
+	select {
+	case err := <-closeErr:
+		t.Fatalf("Close returned before Start published cancellation: %v", err)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(ctx.release)
+	require.NoError(t, <-closeErr)
+	require.ErrorIs(t, <-startErr, context.Canceled)
 }
 
 func TestSSEErrors(t *testing.T) {

--- a/client/transport/sse_test.go
+++ b/client/transport/sse_test.go
@@ -680,6 +680,19 @@ func TestSSE(t *testing.T) {
 	})
 }
 
+func TestSSEStartAfterClose(t *testing.T) {
+	url, closeServer := startMockSSEEchoServer()
+	defer closeServer()
+
+	transport, err := NewSSE(url)
+	require.NoError(t, err)
+	require.NoError(t, transport.Start(t.Context()))
+	require.NoError(t, transport.Close())
+
+	err = transport.Start(t.Context())
+	require.EqualError(t, err, "transport has been closed")
+}
+
 func TestSSEErrors(t *testing.T) {
 	t.Run("InvalidURL", func(t *testing.T) {
 		// Create a new SSE transport with an invalid URL


### PR DESCRIPTION
## Summary

- reject `SSE.Start` once the transport has entered its terminal closed state
- serialize concurrent starts and synchronize stream-canceler publication with `Close`
- return the shared `ErrTransportClosed` sentinel for `errors.Is` compatibility
- cover close-before-start, restart-after-close, request counts, and the concurrent lifecycle race

## Why

After `Close`, both `started` and `closed` are true. The previous `Start` implementation checked `started` first and returned success even though no live connection remained and every subsequent request failed as closed.

The initial fix also left a race between the closed-state check and `cancelSSEStream` publication. `Close` could return before the canceler existed, allowing `Start` to create a live request after shutdown. The lifecycle lock now makes those operations one synchronization boundary, while a separate start lock prevents concurrent starts from replacing the active canceler.

Fixes #967

## Test

- `go test ./client/transport -run 'TestSSE(StartAfterClose|ConcurrentStartClosePublishesCancellation)$' -race -count=10`
- `go test ./client/transport -race`
- `go test ./... -race`
- `golangci-lint run` using v2.8.0 — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented closed server-sent event connections from being restarted.
  * Standardized the error returned when attempting to start a connection after it has been closed.
  * Improved coordination between starting and closing connections, ensuring cancellation is reliably published and preventing race conditions during concurrent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
