### PR TITLE
fix(server): notifications from tool handlers are dropped ~half the time without an event store

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -799,17 +799,13 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 				func() {
 					mu.Lock()
 					defer mu.Unlock()
-					// if the done chan is closed, as the request is terminated, just return
-					select {
-					case <-done:
-						// The notification is already off the channel; with an
-						// event store it must still be recorded.
-						if resumable && canStream {
-							deliverResumable(nt, false)
-						}
-						return
-					default:
-					}
+					// The notification is already off the channel, so the
+					// response path's drain loop can no longer see it:
+					// returning here because done is closed would lose it
+					// outright. Fall through and deliver it exactly as if done
+					// were still open. Both paths that close done now wait on
+					// forwarderExited before writing, so this cannot interleave
+					// with the final response.
 					if !canStream {
 						// Without streaming we can't deliver notifications mid-flight;
 						// they will be dropped on the floor here. The final response
@@ -881,8 +877,15 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 	// Process message through MCPServer
 	response := s.server.HandleMessage(ctx, rawData)
 	if response == nil {
-		mu.Lock()
+		// Await the forwarder here too. It may be holding a notification it
+		// took off the channel but has not yet written; letting this path
+		// return first would either lose that notification or let the
+		// forwarder write to a ResponseWriter whose handler has already
+		// returned. Waiting settles both. If the forwarder does deliver, it
+		// sets upgradedHeader and this path correctly skips the 202.
 		close(done)
+		<-forwarderExited
+		mu.Lock()
 		if !upgradedHeader {
 			mu.Unlock()
 			w.WriteHeader(http.StatusAccepted)
@@ -894,13 +897,17 @@ func (s *StreamableHTTPServer) handlePost(w HTTPResponseWriter, r *HTTPRequest) 
 
 	// Write response
 	//
-	// With an event store, stop the forwarder before draining so that exactly
-	// one consumer records whatever notifications remain, preserving their
-	// order ahead of the response.
-	if resumable {
-		close(done)
-		<-forwarderExited
-	}
+	// Stop the forwarder and wait for it to exit before draining, so that
+	// exactly one consumer handles whatever notifications remain and their
+	// order ahead of the response is preserved.
+	//
+	// The wait is not an event-store concern. The forwarder takes a
+	// notification off the channel and THEN acquires mu; if the response path
+	// were to drain and close done in between, that notification would be
+	// stranded in the forwarder's local variable, where the drain loop cannot
+	// see it. Awaiting the forwarder is what makes delivery deterministic.
+	close(done)
+	<-forwarderExited
 	mu.Lock()
 
 drainLoop:
@@ -931,15 +938,6 @@ drainLoop:
 		}
 	}
 
-	// close the done chan before unlocking to signal the goroutine to stop.
-	// This is the exact complement of the resumable branch above, which
-	// already closed it: a request that is not resumable - including a modern
-	// request on a server that has an event store configured - must still stop
-	// its forwarder here, or the forwarder outlives the request and races the
-	// final response write.
-	if !resumable {
-		close(done)
-	}
 	mu.Unlock()
 	if ctx.Err() != nil {
 		// The connection is gone, but with an event store the response of an

--- a/server/streamable_http_notification_drop_test.go
+++ b/server/streamable_http_notification_drop_test.go
@@ -9,8 +9,38 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/mark3labs/mcp-go/mcp"
 )
+
+// countNotifications returns how many SSE data frames in body are JSON-RPC
+// notifications for the given method. Counting frames rather than substring
+// matching keeps the assertion exact: a response carrying the notification
+// twice is as wrong as one carrying it not at all.
+func countNotifications(t *testing.T, body, method string) int {
+	t.Helper()
+
+	n := 0
+	for _, line := range strings.Split(body, "\n") {
+		data, ok := strings.CutPrefix(strings.TrimSpace(line), "data:")
+		if !ok {
+			continue
+		}
+		var frame struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal([]byte(strings.TrimSpace(data)), &frame); err != nil {
+			// Not every frame is JSON-RPC we care about; skip quietly.
+			continue
+		}
+		if frame.Method == method {
+			n++
+		}
+	}
+	return n
+}
 
 // TestStreamableHTTP_NotificationNotDroppedWithoutEventStore pins that a
 // notification sent from a tool handler always reaches the POST response,
@@ -32,84 +62,77 @@ import (
 // One notification per call, so the assertion is exact rather than statistical.
 // Iterating converts a coin flip into a near-certain failure when the bug is
 // present: a single run reproduces only ~50% of the time, which is why the
-// existing TestStreamableHTTP_DrainNotifications — which sends 10 and only
-// logs informationally when fewer than 5 survive — did not catch it.
+// existing TestStreamableHTTP_DrainNotifications — which sends 10 and only logs
+// informationally when fewer than 5 survive — did not catch it.
 func TestStreamableHTTP_NotificationNotDroppedWithoutEventStore(t *testing.T) {
-	const iterations = 30
+	const (
+		iterations = 30
+		method     = "test/single"
+	)
 
-	run := func(t *testing.T, opts ...StreamableHTTPOption) (delivered, total int) {
-		t.Helper()
-
-		mcpServer := NewMCPServer("test-mcp-server", "1.0")
-		mcpServer.AddTool(mcp.Tool{Name: "notifyOnce"}, func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-			if srv := ServerFromContext(ctx); srv != nil {
-				_ = srv.SendNotificationToClient(ctx, "test/single", map[string]any{"n": 1})
-			}
-			return mcp.NewToolResultText("ok"), nil
-		})
-
-		server := NewTestStreamableHTTPServer(mcpServer, opts...)
-		defer server.Close()
-
-		resp, err := postJSON(server.URL, initRequest)
-		if err != nil {
-			t.Fatalf("initialize: %v", err)
-		}
-		sessionID := resp.Header.Get(HeaderKeySessionID)
-		resp.Body.Close()
-
-		body, err := json.Marshal(map[string]any{
-			"jsonrpc": "2.0",
-			"id":      1,
-			"method":  "tools/call",
-			"params":  map[string]any{"name": "notifyOnce"},
-		})
-		if err != nil {
-			t.Fatalf("marshal: %v", err)
-		}
-
-		for i := 0; i < iterations; i++ {
-			req, err := http.NewRequest("POST", server.URL, bytes.NewReader(body))
-			if err != nil {
-				t.Fatalf("new request: %v", err)
-			}
-			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Accept", "application/json, text/event-stream")
-			if sessionID != "" {
-				req.Header.Set(HeaderKeySessionID, sessionID)
-			}
-
-			resp, err := server.Client().Do(req)
-			if err != nil {
-				t.Fatalf("iteration %d: %v", i, err)
-			}
-			raw, err := io.ReadAll(resp.Body)
-			resp.Body.Close()
-			if err != nil {
-				t.Fatalf("iteration %d: read body: %v", i, err)
-			}
-
-			total++
-			if strings.Contains(string(raw), "test/single") {
-				delivered++
-			}
-		}
-		return delivered, total
+	tests := []struct {
+		name string
+		opts []StreamableHTTPOption
+	}{
+		{name: "without event store"},
+		{name: "with event store", opts: []StreamableHTTPOption{WithEventStore(NewInMemoryEventStore())}},
 	}
 
-	t.Run("without event store", func(t *testing.T) {
-		delivered, total := run(t)
-		if delivered != total {
-			t.Errorf("notification delivered on %d/%d responses; every response must carry it "+
-				"(the forwarder discarded the rest after taking them off the channel)",
-				delivered, total)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mcpServer := NewMCPServer("test-mcp-server", "1.0")
+			mcpServer.AddTool(mcp.Tool{Name: "notifyOnce"}, func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+				if srv := ServerFromContext(ctx); srv != nil {
+					_ = srv.SendNotificationToClient(ctx, method, map[string]any{"n": 1})
+				}
+				return mcp.NewToolResultText("ok"), nil
+			})
 
-	t.Run("with event store", func(t *testing.T) {
-		delivered, total := run(t, WithEventStore(NewInMemoryEventStore()))
-		if delivered != total {
-			t.Errorf("notification delivered on %d/%d responses with an event store", delivered, total)
-		}
-	})
+			server := NewTestStreamableHTTPServer(mcpServer, tt.opts...)
+			defer server.Close()
+
+			resp, err := postJSON(server.URL, initRequest)
+			require.NoError(t, err, "initialize")
+			sessionID := resp.Header.Get(HeaderKeySessionID)
+			resp.Body.Close()
+
+			body, err := json.Marshal(map[string]any{
+				"jsonrpc": "2.0",
+				"id":      1,
+				"method":  "tools/call",
+				"params":  map[string]any{"name": "notifyOnce"},
+			})
+			require.NoError(t, err)
+
+			delivered := 0
+			for i := range iterations {
+				req, err := http.NewRequest("POST", server.URL, bytes.NewReader(body))
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Accept", "application/json, text/event-stream")
+				if sessionID != "" {
+					req.Header.Set(HeaderKeySessionID, sessionID)
+				}
+
+				resp, err := server.Client().Do(req)
+				require.NoErrorf(t, err, "iteration %d", i)
+				raw, err := io.ReadAll(resp.Body)
+				resp.Body.Close()
+				require.NoErrorf(t, err, "iteration %d: read body", i)
+
+				got := countNotifications(t, string(raw), method)
+				assert.Equalf(t, 1, got,
+					"iteration %d: expected exactly one %s notification on the response, got %d",
+					i, method, got)
+				if got == 1 {
+					delivered++
+				}
+			}
+
+			assert.Equalf(t, iterations, delivered,
+				"notification delivered on %d/%d responses; every response must carry exactly one "+
+					"(the forwarder discarded the rest after taking them off the channel)",
+				delivered, iterations)
+		})
+	}
 }

--- a/server/streamable_http_notification_drop_test.go
+++ b/server/streamable_http_notification_drop_test.go
@@ -1,0 +1,115 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestStreamableHTTP_NotificationNotDroppedWithoutEventStore pins that a
+// notification sent from a tool handler always reaches the POST response,
+// whether or not an event store is configured.
+//
+// The forwarder goroutine and the response path race for it. The forwarder
+// takes a notification off session.notificationChannel and THEN acquires mu;
+// meanwhile the response path acquires mu, runs its drain loop — which finds
+// the channel empty, because the forwarder already took the value — closes
+// done, and unlocks. The forwarder then acquires mu, sees done closed, and
+// returns. The notification it is holding is discarded: it is no longer in the
+// channel, so the drain loop could not have rescued it either.
+//
+// The resumable path is immune because it does `close(done); <-forwarderExited`
+// before draining, leaving exactly one consumer. Without an event store the
+// forwarder is never awaited, so the race is live and costs roughly half of all
+// notifications.
+//
+// One notification per call, so the assertion is exact rather than statistical.
+// Iterating converts a coin flip into a near-certain failure when the bug is
+// present: a single run reproduces only ~50% of the time, which is why the
+// existing TestStreamableHTTP_DrainNotifications — which sends 10 and only
+// logs informationally when fewer than 5 survive — did not catch it.
+func TestStreamableHTTP_NotificationNotDroppedWithoutEventStore(t *testing.T) {
+	const iterations = 30
+
+	run := func(t *testing.T, opts ...StreamableHTTPOption) (delivered, total int) {
+		t.Helper()
+
+		mcpServer := NewMCPServer("test-mcp-server", "1.0")
+		mcpServer.AddTool(mcp.Tool{Name: "notifyOnce"}, func(ctx context.Context, _ mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			if srv := ServerFromContext(ctx); srv != nil {
+				_ = srv.SendNotificationToClient(ctx, "test/single", map[string]any{"n": 1})
+			}
+			return mcp.NewToolResultText("ok"), nil
+		})
+
+		server := NewTestStreamableHTTPServer(mcpServer, opts...)
+		defer server.Close()
+
+		resp, err := postJSON(server.URL, initRequest)
+		if err != nil {
+			t.Fatalf("initialize: %v", err)
+		}
+		sessionID := resp.Header.Get(HeaderKeySessionID)
+		resp.Body.Close()
+
+		body, err := json.Marshal(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "tools/call",
+			"params":  map[string]any{"name": "notifyOnce"},
+		})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		for i := 0; i < iterations; i++ {
+			req, err := http.NewRequest("POST", server.URL, bytes.NewReader(body))
+			if err != nil {
+				t.Fatalf("new request: %v", err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Accept", "application/json, text/event-stream")
+			if sessionID != "" {
+				req.Header.Set(HeaderKeySessionID, sessionID)
+			}
+
+			resp, err := server.Client().Do(req)
+			if err != nil {
+				t.Fatalf("iteration %d: %v", i, err)
+			}
+			raw, err := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if err != nil {
+				t.Fatalf("iteration %d: read body: %v", i, err)
+			}
+
+			total++
+			if strings.Contains(string(raw), "test/single") {
+				delivered++
+			}
+		}
+		return delivered, total
+	}
+
+	t.Run("without event store", func(t *testing.T) {
+		delivered, total := run(t)
+		if delivered != total {
+			t.Errorf("notification delivered on %d/%d responses; every response must carry it "+
+				"(the forwarder discarded the rest after taking them off the channel)",
+				delivered, total)
+		}
+	})
+
+	t.Run("with event store", func(t *testing.T) {
+		delivered, total := run(t, WithEventStore(NewInMemoryEventStore()))
+		if delivered != total {
+			t.Errorf("notification delivered on %d/%d responses with an event store", delivered, total)
+		}
+	})
+}


### PR DESCRIPTION
## Description

If a tool handler calls `SendNotificationToClient`, the notification only reaches the client about half the time — unless an event store happens to be configured. The HTTP response itself is perfectly well formed; the notification is simply missing from it, silently.

**Why.** Two goroutines race for the notification:

1. The forwarder takes it **off** `session.notificationChannel`, then waits for `mu`.
2. The response path gets `mu` first, runs its drain loop — the channel is now empty, because the forwarder already took the value — closes `done`, and unlocks.
3. The forwarder gets `mu`, sees `done` closed, and returns, discarding the notification it is holding.

The drain loop can't rescue it: the value isn't in the channel any more, it's a local variable in the other goroutine.

The event-store path is already immune, because it does `close(done); <-forwarderExited` before draining, leaving exactly one consumer. That wait was added in #930 to order event-store writes, and closing this race was an unremarked side effect — which is why it's still behind `if resumable`, even though the race has nothing to do with event stores.

**The fix.** Three changes, one idea — exactly one consumer, always:

- Await the forwarder before draining in **all** cases, not just when resumable. The trailing `if !resumable { close(done) }` becomes dead and is removed.
- Deliver, rather than discard, a notification the forwarder is already holding when `done` closes. Both paths that close `done` now wait for the forwarder, so this can't interleave with the final response write.
- Await the forwarder on the `response == nil` path too. It could otherwise return while the forwarder still held a notification — either losing it, or letting the forwarder write to a `ResponseWriter` whose handler had already returned.

Fixes #<issue_number> (no existing issue — happy to open one if you'd prefer it tracked separately)

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] MCP spec compatibility implementation
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Tests only (no functional changes)
- [ ] Other (please describe):

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated the documentation accordingly — no doc change needed; this restores the delivery behaviour the API already implies

## Additional Information

### Test

`TestStreamableHTTP_NotificationNotDroppedWithoutEventStore` sends one notification per call and asserts **exactly one** matching JSON-RPC frame per response, iterated 30 times so a coin flip becomes a near-certain failure.

| | before | after |
|---|---|---|
| without event store | 29/30, iteration 0 got 0 ❌ | 30/30 ✅ |
| with event store | 30/30 ✅ | 30/30 ✅ |

`TestStreamableHTTP_DrainNotifications` doesn't catch this today: it sends ten notifications and only logs informationally when fewer than five arrive.

### Verification

- `go test -race ./server/...` — passes
- `go test -race ./...` — passes, except `TestOAuthHandler_SetExpectedState_CrossRequestScenario`, which fails identically on unmodified `main` in my environment (it expects a fast connection refusal from `example.com` and instead times out)
- `cd otel && go test ./...` — passes

### How we found it

We serve MCP with `WithStateLess(true)` and send `notifications/tools/list_changed` from a `load_tool` handler. Clients were missing about half of them. A raw-HTTP probe that bypassed the Go client entirely showed 5 of 12 responses carrying the notification, with all 12 upgraded to `text/event-stream` — so the send always happened, and only the event bytes went missing.

Configuring an event store fixed delivery but wasn't viable for us: in stateless mode the session id is empty, `touchSession` is a no-op for empty ids, so `cleanupResumableState` never runs and each notification-bearing POST retains a `resumableStream` — measured at ~4.3 KB per notification, unbounded. Both configurations being unusable is what pointed at the gating rather than at our setup.

### One thing I did not change

CodeRabbit noted that concurrent requests in the same session may still receive a notification on the wrong response. That's true, and pre-existing: notifications are session-scoped, so any in-flight POST can pick one up. It's independent of this race and I've left it alone rather than widen the PR — happy to look at it separately if it's worth an issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where notifications sent during HTTP requests could be dropped before reaching the response.
  * Ensured notifications are delivered consistently for resumable and non-resumable requests, including configurations without an event store.
  * Improved request shutdown handling so all pending notifications are completed before the response is finalized.

* **Tests**
  * Added coverage verifying notification delivery across repeated tool calls and event store configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->