### PR TITLE
fix(streamable-http): clean up listening connections after disconnect

### DIFF
--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -288,7 +288,7 @@ type StreamableHTTPServer struct {
 	sessionResources         *sessionResourcesStore
 	sessionResourceTemplates *sessionResourceTemplatesStore
 	activeSessions           sync.Map // sessionId --> *streamableHttpSession (for sampling responses)
-	activeGetConnections     sync.Map // sessionId --> *activeGetConnection (non-resumable listening GET)
+	activeGETConnections     sync.Map // sessionId --> *activeGETConnection (non-resumable listening GET)
 	sessionLifecycle         sessionLifecycleLocker
 	requestIDCounter         atomic.Int64 // server -> client request IDs, shared across sessions
 
@@ -1040,6 +1040,16 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 		return
 	}
 
+	var deadlineWriter writeDeadlineSetter
+	if s.eventStore == nil {
+		var ok bool
+		deadlineWriter, ok = w.(writeDeadlineSetter)
+		if !ok {
+			writeHTTPError(w, "Streaming requires write-deadline support", http.StatusMethodNotAllowed)
+			return
+		}
+	}
+
 	// A GET carrying Last-Event-ID resumes a previously broken SSE stream
 	// rather than opening a fresh listening stream.
 	if s.eventStore != nil {
@@ -1060,7 +1070,7 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 	streamCtx := r.ctx()
 	var session *streamableHttpSession
 	var loaded bool
-	var connection *activeGetConnection
+	var connection *activeGETConnection
 	if registered := func() bool {
 		// Validation, listening-connection registration, and logical-session
 		// registration must be atomic with DELETE termination. Otherwise a GET
@@ -1083,16 +1093,14 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 		if s.eventStore == nil && sessionID != "" {
 			var cancel context.CancelFunc
 			streamCtx, cancel = context.WithCancel(streamCtx)
-			connection = &activeGetConnection{
+			connection = &activeGETConnection{
 				cancel: cancel,
 				done:   make(chan struct{}),
 			}
-			if deadlineWriter, ok := w.(interface{ SetWriteDeadline(time.Time) error }); ok {
-				connection.interruptWrite = func() {
-					_ = deadlineWriter.SetWriteDeadline(time.Now())
-				}
+			connection.interruptWrite = func() {
+				_ = deadlineWriter.SetWriteDeadline(time.Now())
 			}
-			if _, alreadyListening := s.activeGetConnections.LoadOrStore(sessionID, connection); alreadyListening {
+			if _, alreadyListening := s.activeGETConnections.LoadOrStore(sessionID, connection); alreadyListening {
 				cancel()
 				connection = nil
 				writeHTTPError(w, "A listening stream is already active for this session", http.StatusConflict)
@@ -1114,7 +1122,7 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 			s.activeSessions.Delete(sessionID)
 			if connection != nil {
 				connection.cancel()
-				s.activeGetConnections.CompareAndDelete(sessionID, connection)
+				s.activeGETConnections.CompareAndDelete(sessionID, connection)
 				close(connection.done)
 				connection = nil
 			}
@@ -1130,7 +1138,7 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 	if connection != nil {
 		defer func() {
 			connection.cancel()
-			s.activeGetConnections.CompareAndDelete(sessionID, connection)
+			s.activeGETConnections.CompareAndDelete(sessionID, connection)
 			close(connection.done)
 		}()
 	}
@@ -1512,11 +1520,11 @@ func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionI
 }
 
 func (s *StreamableHTTPServer) closeActiveGetConnection(ctx context.Context, sessionID string) {
-	value, ok := s.activeGetConnections.Load(sessionID)
+	value, ok := s.activeGETConnections.Load(sessionID)
 	if !ok {
 		return
 	}
-	connection := value.(*activeGetConnection)
+	connection := value.(*activeGETConnection)
 	connection.cancel()
 	if connection.interruptWrite != nil {
 		connection.interruptWrite()
@@ -1590,6 +1598,11 @@ func (s *StreamableHTTPServer) sweepExpiredSessions() {
 			mgr = s.sessionIdManagerResolver.ResolveSessionIdManager(nil)
 		}
 		unlockLifecycle := s.sessionLifecycle.lock(sessionID)
+		currentLastActive := lastActive.Load()
+		if currentLastActive != capturedLastActive || time.Now().UnixNano()-currentLastActive < ttlNanos {
+			unlockLifecycle()
+			return true
+		}
 		_, _ = mgr.Terminate(sessionID)
 		unlockLifecycle()
 		s.cleanupSessionState(context.Background(), sessionID)
@@ -1838,7 +1851,7 @@ type streamableHttpSession struct {
 	requestIDCounter *atomic.Int64 // shared per server so IDs stay unique across sessions with the same session ID
 }
 
-type activeGetConnection struct {
+type activeGETConnection struct {
 	cancel         context.CancelFunc
 	interruptWrite func()
 	done           chan struct{}
@@ -1848,6 +1861,8 @@ type sessionLifecycleLocker interface {
 	lock(sessionID string) (unlock func())
 }
 
+// sessionLifecycleLocks is safe for concurrent use. Callers must invoke the
+// unlock function returned by lock so unused per-session entries are reclaimed.
 type sessionLifecycleLocks struct {
 	mu      sync.Mutex
 	entries map[string]*sessionLifecycleLock

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -1502,7 +1502,7 @@ func (s *StreamableHTTPServer) touchSession(sessionID string) {
 
 // cleanupSessionState removes all per-session transport state for the given session ID.
 func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionID string) {
-	cleanupCtx, cancel := context.WithTimeout(ctx, sessionCleanupTimeout)
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), sessionCleanupTimeout)
 	defer cancel()
 
 	s.closeActiveGetConnection(cleanupCtx, sessionID)

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -22,6 +22,8 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
+const sessionCleanupTimeout = 5 * time.Second
+
 // StreamableHTTPOption defines a function type for configuring StreamableHTTPServer
 type StreamableHTTPOption func(*StreamableHTTPServer)
 
@@ -1135,7 +1137,11 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 
 	if !loaded {
 		if s.eventStore == nil {
-			defer s.server.UnregisterSession(r.ctx(), sessionID)
+			defer func() {
+				cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx()), sessionCleanupTimeout)
+				defer cancel()
+				s.server.UnregisterSession(cleanupCtx, sessionID)
+			}()
 			defer s.activeSessions.Delete(sessionID)
 		}
 		// With an event store, the session outlives the connection so that
@@ -1312,7 +1318,7 @@ func (s *StreamableHTTPServer) handleDelete(w HTTPResponseWriter, r *HTTPRequest
 		return
 	}
 
-	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx()), 5*time.Second)
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx()), sessionCleanupTimeout)
 	defer cancel()
 	s.cleanupSessionState(cleanupCtx, sessionID)
 
@@ -1488,7 +1494,7 @@ func (s *StreamableHTTPServer) touchSession(sessionID string) {
 
 // cleanupSessionState removes all per-session transport state for the given session ID.
 func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionID string) {
-	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	cleanupCtx, cancel := context.WithTimeout(ctx, sessionCleanupTimeout)
 	defer cancel()
 
 	s.closeActiveGetConnection(cleanupCtx, sessionID)

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -285,9 +285,9 @@ type StreamableHTTPServer struct {
 	sessionTools             *sessionToolsStore
 	sessionResources         *sessionResourcesStore
 	sessionResourceTemplates *sessionResourceTemplatesStore
-	activeSessions           sync.Map     // sessionId --> *streamableHttpSession (for sampling responses)
-	activeGetConnections     sync.Map     // sessionId --> *activeGetConnection (non-resumable listening GET)
-	sessionLifecycleMu       sync.Locker  // serializes listening GET registration with DELETE termination
+	activeSessions           sync.Map // sessionId --> *streamableHttpSession (for sampling responses)
+	activeGetConnections     sync.Map // sessionId --> *activeGetConnection (non-resumable listening GET)
+	sessionLifecycle         sessionLifecycleLocker
 	requestIDCounter         atomic.Int64 // server -> client request IDs, shared across sessions
 
 	eventStore         EventStore
@@ -347,7 +347,7 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 		logger:                   slog.Default(),
 		sessionResources:         newSessionResourcesStore(),
 		sessionResourceTemplates: newSessionResourceTemplatesStore(),
-		sessionLifecycleMu:       &sync.Mutex{},
+		sessionLifecycle:         newSessionLifecycleLocks(),
 	}
 
 	// Apply all options
@@ -545,9 +545,11 @@ func (s *StreamableHTTPServer) CloseSessions(ctx context.Context) {
 	}
 
 	for _, sessionID := range sessionIDs {
+		unlockLifecycle := s.sessionLifecycle.lock(sessionID)
 		if _, err := mgr.Terminate(sessionID); err != nil {
 			s.logger.Warn("failed to terminate session during CloseSessions", "sessionID", sessionID, "err", err)
 		}
+		unlockLifecycle()
 		s.cleanupSessionState(ctx, sessionID)
 	}
 }
@@ -1061,8 +1063,8 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 		// Validation, listening-connection registration, and logical-session
 		// registration must be atomic with DELETE termination. Otherwise a GET
 		// can validate, pause while DELETE cleans up, then recreate the session.
-		s.sessionLifecycleMu.Lock()
-		defer s.sessionLifecycleMu.Unlock()
+		unlockLifecycle := s.sessionLifecycle.lock(sessionID)
+		defer unlockLifecycle()
 
 		if sessionID != "" {
 			terminated, err := sessionIDManager.Validate(sessionID)
@@ -1102,6 +1104,7 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 		loaded = sessionLoaded
 		session = actual.(*streamableHttpSession)
 		if loaded {
+			s.touchSession(sessionID)
 			return true
 		}
 
@@ -1116,6 +1119,7 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 			writeHTTPErrorf(w, http.StatusBadRequest, "Session registration failed: %v", err)
 			return false
 		}
+		s.touchSession(sessionID)
 		return true
 	}(); !registered {
 		return
@@ -1138,8 +1142,6 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 		// messages produced while the client is away are recorded for
 		// replay; it is cleaned up on DELETE or by the idle sweeper.
 	}
-
-	s.touchSession(sessionID)
 
 	if s.eventStore != nil {
 		s.serveListeningStream(w, r, sessionID, session)
@@ -1298,9 +1300,9 @@ func (s *StreamableHTTPServer) handleDelete(w HTTPResponseWriter, r *HTTPRequest
 	// delete request terminate the session
 	sessionID := r.header().Get(HeaderKeySessionID)
 	sessionIdManager := s.resolveSessionIdManager(r)
-	s.sessionLifecycleMu.Lock()
+	unlockLifecycle := s.sessionLifecycle.lock(sessionID)
 	notAllowed, err := sessionIdManager.Terminate(sessionID)
-	s.sessionLifecycleMu.Unlock()
+	unlockLifecycle()
 	if err != nil {
 		writeHTTPErrorf(w, http.StatusInternalServerError, "Session termination failed: %v", err)
 		return
@@ -1581,7 +1583,9 @@ func (s *StreamableHTTPServer) sweepExpiredSessions() {
 		if mgr == nil {
 			mgr = s.sessionIdManagerResolver.ResolveSessionIdManager(nil)
 		}
+		unlockLifecycle := s.sessionLifecycle.lock(sessionID)
 		_, _ = mgr.Terminate(sessionID)
+		unlockLifecycle()
 		s.cleanupSessionState(context.Background(), sessionID)
 		return true
 	})
@@ -1832,6 +1836,46 @@ type activeGetConnection struct {
 	cancel         context.CancelFunc
 	interruptWrite func()
 	done           chan struct{}
+}
+
+type sessionLifecycleLocker interface {
+	lock(sessionID string) (unlock func())
+}
+
+type sessionLifecycleLocks struct {
+	mu      sync.Mutex
+	entries map[string]*sessionLifecycleLock
+}
+
+type sessionLifecycleLock struct {
+	mu   sync.Mutex
+	refs int
+}
+
+func newSessionLifecycleLocks() *sessionLifecycleLocks {
+	return &sessionLifecycleLocks{entries: make(map[string]*sessionLifecycleLock)}
+}
+
+func (l *sessionLifecycleLocks) lock(sessionID string) func() {
+	l.mu.Lock()
+	entry := l.entries[sessionID]
+	if entry == nil {
+		entry = &sessionLifecycleLock{}
+		l.entries[sessionID] = entry
+	}
+	entry.refs++
+	l.mu.Unlock()
+
+	entry.mu.Lock()
+	return func() {
+		entry.mu.Unlock()
+		l.mu.Lock()
+		entry.refs--
+		if entry.refs == 0 {
+			delete(l.entries, sessionID)
+		}
+		l.mu.Unlock()
+	}
 }
 
 func newStreamableHttpSession(sessionID string, toolStore *sessionToolsStore, resourcesStore *sessionResourcesStore, templatesStore *sessionResourceTemplatesStore, levels *sessionLogLevelsStore, requestIDCounter *atomic.Int64) *streamableHttpSession {

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -286,6 +286,7 @@ type StreamableHTTPServer struct {
 	sessionResources         *sessionResourcesStore
 	sessionResourceTemplates *sessionResourceTemplatesStore
 	activeSessions           sync.Map     // sessionId --> *streamableHttpSession (for sampling responses)
+	activeGetConnections     sync.Map     // sessionId --> *activeGetConnection (non-resumable listening GET)
 	requestIDCounter         atomic.Int64 // server -> client request IDs, shared across sessions
 
 	eventStore         EventStore
@@ -1043,12 +1044,39 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 	}
 
 	sessionID := r.header().Get(HeaderKeySessionID)
-	// The MCP specification doesn't require validating session ID for GET requests.
 	// If no session ID is provided by the client, generate one using the configured SessionIdManager
 	// so that custom session id generators are honored consistently across POST/GET flows.
+	sessionIDManager := s.resolveSessionIdManager(r)
 	if sessionID == "" {
-		sessionIdManager := s.resolveSessionIdManager(r)
-		sessionID = sessionIdManager.Generate()
+		sessionID = sessionIDManager.Generate()
+	}
+	if sessionID != "" {
+		terminated, err := sessionIDManager.Validate(sessionID)
+		if err != nil {
+			writeHTTPError(w, "Invalid session ID", http.StatusNotFound)
+			return
+		}
+		if terminated {
+			writeHTTPError(w, "Session terminated", http.StatusNotFound)
+			return
+		}
+	}
+
+	streamCtx := r.ctx()
+	if s.eventStore == nil && sessionID != "" {
+		var cancel context.CancelFunc
+		streamCtx, cancel = context.WithCancel(streamCtx)
+		connection := &activeGetConnection{cancel: cancel, done: make(chan struct{})}
+		if _, loaded := s.activeGetConnections.LoadOrStore(sessionID, connection); loaded {
+			cancel()
+			writeHTTPError(w, "A listening stream is already active for this session", http.StatusConflict)
+			return
+		}
+		defer func() {
+			cancel()
+			s.activeGetConnections.CompareAndDelete(sessionID, connection)
+			close(connection.done)
+		}()
 	}
 
 	// Get or create session atomically to prevent TOCTOU races
@@ -1091,10 +1119,16 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 
 	// Start notification handler for this session
 	done := make(chan struct{})
-	defer close(done)
+	var workers sync.WaitGroup
+	defer func() {
+		close(done)
+		workers.Wait()
+	}()
 	writeChan := make(chan any, 16)
 
+	workers.Add(1)
 	go func() {
+		defer workers.Done()
 		defer func() {
 			if r := recover(); r != nil {
 				s.logger.Error("panic in SSE notification writer", "panic", r)
@@ -1160,7 +1194,9 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 
 	if s.listenHeartbeatInterval > 0 {
 		// heartbeat to keep the connection alive
+		workers.Add(1)
 		go func() {
+			defer workers.Done()
 			defer func() {
 				if r := recover(); r != nil {
 					s.logger.Error("panic in heartbeat goroutine", "panic", r)
@@ -1190,8 +1226,6 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 		}()
 	}
 
-	ctx := r.ctx()
-
 	// Keep the connection open until the client disconnects
 	//
 	// There's will a Available() check when handler ends, and it maybe race with Flush(),
@@ -1208,7 +1242,7 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 			}
 			w.Flush()
 			s.touchSession(sessionID)
-		case <-ctx.Done():
+		case <-streamCtx.Done():
 			return
 		case <-session.done:
 			return
@@ -1237,7 +1271,9 @@ func (s *StreamableHTTPServer) handleDelete(w HTTPResponseWriter, r *HTTPRequest
 		return
 	}
 
-	s.cleanupSessionState(r.ctx(), sessionID)
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(r.ctx()), 5*time.Second)
+	defer cancel()
+	s.cleanupSessionState(cleanupCtx, sessionID)
 
 	w.WriteHeader(http.StatusOK)
 }
@@ -1411,6 +1447,7 @@ func (s *StreamableHTTPServer) touchSession(sessionID string) {
 
 // cleanupSessionState removes all per-session transport state for the given session ID.
 func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionID string) {
+	s.closeActiveGetConnection(ctx, sessionID)
 	if s.eventStore != nil {
 		s.cleanupResumableState(ctx, sessionID)
 	}
@@ -1422,6 +1459,20 @@ func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionI
 	s.sessionResourceTemplates.delete(sessionID)
 	s.sessionLogLevels.delete(sessionID)
 	s.sessionLastActive.Delete(sessionID)
+}
+
+func (s *StreamableHTTPServer) closeActiveGetConnection(ctx context.Context, sessionID string) {
+	value, ok := s.activeGetConnections.Load(sessionID)
+	if !ok {
+		return
+	}
+	connection := value.(*activeGetConnection)
+	connection.cancel()
+	select {
+	case <-connection.done:
+	case <-ctx.Done():
+		s.logger.Warn("timed out closing active GET connection", "sessionID", sessionID, "err", ctx.Err())
+	}
 }
 
 // startSessionSweeper launches a background goroutine that periodically removes
@@ -1730,6 +1781,11 @@ type streamableHttpSession struct {
 
 	samplingRequests sync.Map      // requestID -> pending sampling request context
 	requestIDCounter *atomic.Int64 // shared per server so IDs stay unique across sessions with the same session ID
+}
+
+type activeGetConnection struct {
+	cancel context.CancelFunc
+	done   chan struct{}
 }
 
 func newStreamableHttpSession(sessionID string, toolStore *sessionToolsStore, resourcesStore *sessionResourcesStore, templatesStore *sessionResourceTemplatesStore, levels *sessionLogLevelsStore, requestIDCounter *atomic.Int64) *streamableHttpSession {

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -287,7 +287,7 @@ type StreamableHTTPServer struct {
 	sessionResourceTemplates *sessionResourceTemplatesStore
 	activeSessions           sync.Map     // sessionId --> *streamableHttpSession (for sampling responses)
 	activeGetConnections     sync.Map     // sessionId --> *activeGetConnection (non-resumable listening GET)
-	sessionLifecycleMu       sync.Mutex   // serializes listening GET registration with DELETE termination
+	sessionLifecycleMu       sync.Locker  // serializes listening GET registration with DELETE termination
 	requestIDCounter         atomic.Int64 // server -> client request IDs, shared across sessions
 
 	eventStore         EventStore
@@ -347,6 +347,7 @@ func NewStreamableHTTPServer(server *MCPServer, opts ...StreamableHTTPOption) *S
 		logger:                   slog.Default(),
 		sessionResources:         newSessionResourcesStore(),
 		sessionResourceTemplates: newSessionResourceTemplatesStore(),
+		sessionLifecycleMu:       &sync.Mutex{},
 	}
 
 	// Apply all options

--- a/server/streamable_http.go
+++ b/server/streamable_http.go
@@ -287,6 +287,7 @@ type StreamableHTTPServer struct {
 	sessionResourceTemplates *sessionResourceTemplatesStore
 	activeSessions           sync.Map     // sessionId --> *streamableHttpSession (for sampling responses)
 	activeGetConnections     sync.Map     // sessionId --> *activeGetConnection (non-resumable listening GET)
+	sessionLifecycleMu       sync.Mutex   // serializes listening GET registration with DELETE termination
 	requestIDCounter         atomic.Int64 // server -> client request IDs, shared across sessions
 
 	eventStore         EventStore
@@ -1050,49 +1051,84 @@ func (s *StreamableHTTPServer) handleGet(w HTTPResponseWriter, r *HTTPRequest) {
 	if sessionID == "" {
 		sessionID = sessionIDManager.Generate()
 	}
-	if sessionID != "" {
-		terminated, err := sessionIDManager.Validate(sessionID)
-		if err != nil {
-			writeHTTPError(w, "Invalid session ID", http.StatusNotFound)
-			return
-		}
-		if terminated {
-			writeHTTPError(w, "Session terminated", http.StatusNotFound)
-			return
-		}
-	}
 
 	streamCtx := r.ctx()
-	if s.eventStore == nil && sessionID != "" {
-		var cancel context.CancelFunc
-		streamCtx, cancel = context.WithCancel(streamCtx)
-		connection := &activeGetConnection{cancel: cancel, done: make(chan struct{})}
-		if _, loaded := s.activeGetConnections.LoadOrStore(sessionID, connection); loaded {
-			cancel()
-			writeHTTPError(w, "A listening stream is already active for this session", http.StatusConflict)
-			return
+	var session *streamableHttpSession
+	var loaded bool
+	var connection *activeGetConnection
+	if registered := func() bool {
+		// Validation, listening-connection registration, and logical-session
+		// registration must be atomic with DELETE termination. Otherwise a GET
+		// can validate, pause while DELETE cleans up, then recreate the session.
+		s.sessionLifecycleMu.Lock()
+		defer s.sessionLifecycleMu.Unlock()
+
+		if sessionID != "" {
+			terminated, err := sessionIDManager.Validate(sessionID)
+			if err != nil {
+				writeHTTPError(w, "Invalid session ID", http.StatusNotFound)
+				return false
+			}
+			if terminated {
+				writeHTTPError(w, "Session terminated", http.StatusNotFound)
+				return false
+			}
 		}
+
+		if s.eventStore == nil && sessionID != "" {
+			var cancel context.CancelFunc
+			streamCtx, cancel = context.WithCancel(streamCtx)
+			connection = &activeGetConnection{
+				cancel: cancel,
+				done:   make(chan struct{}),
+			}
+			if deadlineWriter, ok := w.(interface{ SetWriteDeadline(time.Time) error }); ok {
+				connection.interruptWrite = func() {
+					_ = deadlineWriter.SetWriteDeadline(time.Now())
+				}
+			}
+			if _, alreadyListening := s.activeGetConnections.LoadOrStore(sessionID, connection); alreadyListening {
+				cancel()
+				connection = nil
+				writeHTTPError(w, "A listening stream is already active for this session", http.StatusConflict)
+				return false
+			}
+		}
+
+		// Get or create the logical session while DELETE is excluded.
+		newSession := newStreamableHttpSession(sessionID, s.sessionTools, s.sessionResources, s.sessionResourceTemplates, s.sessionLogLevels, &s.requestIDCounter)
+		actual, sessionLoaded := s.activeSessions.LoadOrStore(sessionID, newSession)
+		loaded = sessionLoaded
+		session = actual.(*streamableHttpSession)
+		if loaded {
+			return true
+		}
+
+		if err := s.server.RegisterSession(r.ctx(), session); err != nil {
+			s.activeSessions.Delete(sessionID)
+			if connection != nil {
+				connection.cancel()
+				s.activeGetConnections.CompareAndDelete(sessionID, connection)
+				close(connection.done)
+				connection = nil
+			}
+			writeHTTPErrorf(w, http.StatusBadRequest, "Session registration failed: %v", err)
+			return false
+		}
+		return true
+	}(); !registered {
+		return
+	}
+
+	if connection != nil {
 		defer func() {
-			cancel()
+			connection.cancel()
 			s.activeGetConnections.CompareAndDelete(sessionID, connection)
 			close(connection.done)
 		}()
 	}
 
-	// Get or create session atomically to prevent TOCTOU races
-	// where concurrent GETs could both create and register duplicate sessions
-	var session *streamableHttpSession
-	newSession := newStreamableHttpSession(sessionID, s.sessionTools, s.sessionResources, s.sessionResourceTemplates, s.sessionLogLevels, &s.requestIDCounter)
-	actual, loaded := s.activeSessions.LoadOrStore(sessionID, newSession)
-	session = actual.(*streamableHttpSession)
-
 	if !loaded {
-		// We created a new session, need to register it
-		if err := s.server.RegisterSession(r.ctx(), session); err != nil {
-			s.activeSessions.Delete(sessionID)
-			writeHTTPErrorf(w, http.StatusBadRequest, "Session registration failed: %v", err)
-			return
-		}
 		if s.eventStore == nil {
 			defer s.server.UnregisterSession(r.ctx(), sessionID)
 			defer s.activeSessions.Delete(sessionID)
@@ -1261,7 +1297,9 @@ func (s *StreamableHTTPServer) handleDelete(w HTTPResponseWriter, r *HTTPRequest
 	// delete request terminate the session
 	sessionID := r.header().Get(HeaderKeySessionID)
 	sessionIdManager := s.resolveSessionIdManager(r)
+	s.sessionLifecycleMu.Lock()
 	notAllowed, err := sessionIdManager.Terminate(sessionID)
+	s.sessionLifecycleMu.Unlock()
 	if err != nil {
 		writeHTTPErrorf(w, http.StatusInternalServerError, "Session termination failed: %v", err)
 		return
@@ -1447,12 +1485,15 @@ func (s *StreamableHTTPServer) touchSession(sessionID string) {
 
 // cleanupSessionState removes all per-session transport state for the given session ID.
 func (s *StreamableHTTPServer) cleanupSessionState(ctx context.Context, sessionID string) {
-	s.closeActiveGetConnection(ctx, sessionID)
+	cleanupCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	s.closeActiveGetConnection(cleanupCtx, sessionID)
 	if s.eventStore != nil {
-		s.cleanupResumableState(ctx, sessionID)
+		s.cleanupResumableState(cleanupCtx, sessionID)
 	}
 	// Unregister first to stop notification routing before deleting data.
-	s.server.UnregisterSession(ctx, sessionID)
+	s.server.UnregisterSession(cleanupCtx, sessionID)
 	s.activeSessions.Delete(sessionID)
 	s.sessionTools.delete(sessionID)
 	s.sessionResources.delete(sessionID)
@@ -1468,6 +1509,9 @@ func (s *StreamableHTTPServer) closeActiveGetConnection(ctx context.Context, ses
 	}
 	connection := value.(*activeGetConnection)
 	connection.cancel()
+	if connection.interruptWrite != nil {
+		connection.interruptWrite()
+	}
 	select {
 	case <-connection.done:
 	case <-ctx.Done():
@@ -1784,8 +1828,9 @@ type streamableHttpSession struct {
 }
 
 type activeGetConnection struct {
-	cancel context.CancelFunc
-	done   chan struct{}
+	cancel         context.CancelFunc
+	interruptWrite func()
+	done           chan struct{}
 }
 
 func newStreamableHttpSession(sessionID string, toolStore *sessionToolsStore, resourcesStore *sessionResourcesStore, templatesStore *sessionResourceTemplatesStore, levels *sessionLogLevelsStore, requestIDCounter *atomic.Int64) *streamableHttpSession {

--- a/server/streamable_http_connection_test.go
+++ b/server/streamable_http_connection_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -178,4 +179,220 @@ func TestStreamableHTTPInvalidListeningSessionReturnsNotFound(t *testing.T) {
 	_, err = io.Copy(io.Discard, resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+type blockingValidateSessionManager struct {
+	manager          *InsecureStatefulSessionIdManager
+	blockNext        atomic.Bool
+	validateEntered  chan struct{}
+	continueValidate chan struct{}
+}
+
+func (m *blockingValidateSessionManager) Generate() string {
+	return m.manager.Generate()
+}
+
+func (m *blockingValidateSessionManager) Validate(sessionID string) (bool, error) {
+	if m.blockNext.CompareAndSwap(true, false) {
+		close(m.validateEntered)
+		<-m.continueValidate
+	}
+	return m.manager.Validate(sessionID)
+}
+
+func (m *blockingValidateSessionManager) Terminate(sessionID string) (bool, error) {
+	return m.manager.Terminate(sessionID)
+}
+
+type deleteSignalResolver struct {
+	manager        SessionIdManager
+	deleteResolved chan struct{}
+	deleteOnce     sync.Once
+}
+
+func (r *deleteSignalResolver) ResolveSessionIdManager(req *http.Request) SessionIdManager {
+	if req != nil && req.Method == http.MethodDelete {
+		r.deleteOnce.Do(func() {
+			close(r.deleteResolved)
+		})
+	}
+	return r.manager
+}
+
+func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
+	manager := &blockingValidateSessionManager{
+		manager:          &InsecureStatefulSessionIdManager{},
+		validateEntered:  make(chan struct{}),
+		continueValidate: make(chan struct{}),
+	}
+	resolver := &deleteSignalResolver{
+		manager:        manager,
+		deleteResolved: make(chan struct{}),
+	}
+	transport := NewStreamableHTTPServer(
+		NewMCPServer("lifecycle-race-test", "1.0.0"),
+		WithSessionIdManagerResolver(resolver),
+	)
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+
+	sessionID := initializeLegacySession(t, ts.URL)
+	manager.blockNext.Store(true)
+
+	type responseResult struct {
+		response *http.Response
+		err      error
+	}
+	getResult := make(chan responseResult, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+		if err != nil {
+			getResult <- responseResult{err: err}
+			return
+		}
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set(HeaderKeySessionID, sessionID)
+		resp, err := http.DefaultClient.Do(req)
+		getResult <- responseResult{response: resp, err: err}
+	}()
+
+	select {
+	case <-manager.validateEntered:
+	case <-time.After(time.Second):
+		t.Fatal("listening GET did not reach session validation")
+	}
+
+	deleteResult := make(chan responseResult, 1)
+	go func() {
+		req, err := http.NewRequest(http.MethodDelete, ts.URL, nil)
+		if err != nil {
+			deleteResult <- responseResult{err: err}
+			return
+		}
+		req.Header.Set(HeaderKeySessionID, sessionID)
+		resp, err := http.DefaultClient.Do(req)
+		deleteResult <- responseResult{response: resp, err: err}
+	}()
+
+	select {
+	case <-resolver.deleteResolved:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE did not reach the lifecycle barrier")
+	}
+	close(manager.continueValidate)
+
+	get := <-getResult
+	require.NoError(t, get.err)
+	require.Equal(t, http.StatusOK, get.response.StatusCode)
+	require.NoError(t, get.response.Body.Close())
+
+	deleted := <-deleteResult
+	require.NoError(t, deleted.err)
+	require.Equal(t, http.StatusOK, deleted.response.StatusCode)
+	require.NoError(t, deleted.response.Body.Close())
+
+	_, getStillActive := transport.activeGetConnections.Load(sessionID)
+	assert.False(t, getStillActive)
+	_, sessionStillActive := transport.activeSessions.Load(sessionID)
+	assert.False(t, sessionStillActive)
+
+	staleReq, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	staleReq.Header.Set("Accept", "text/event-stream")
+	staleReq.Header.Set(HeaderKeySessionID, sessionID)
+	stale, err := http.DefaultClient.Do(staleReq)
+	require.NoError(t, err)
+	defer stale.Body.Close()
+	assert.Equal(t, http.StatusNotFound, stale.StatusCode)
+}
+
+type blockingStreamResponseWriter struct {
+	header        http.Header
+	writeStarted  chan struct{}
+	writeReleased chan struct{}
+	writeOnce     sync.Once
+	releaseOnce   sync.Once
+}
+
+func newBlockingStreamResponseWriter() *blockingStreamResponseWriter {
+	return &blockingStreamResponseWriter{
+		header:        make(http.Header),
+		writeStarted:  make(chan struct{}),
+		writeReleased: make(chan struct{}),
+	}
+}
+
+func (w *blockingStreamResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *blockingStreamResponseWriter) WriteHeader(int) {}
+
+func (w *blockingStreamResponseWriter) Write([]byte) (int, error) {
+	w.writeOnce.Do(func() {
+		close(w.writeStarted)
+	})
+	<-w.writeReleased
+	return 0, context.DeadlineExceeded
+}
+
+func (w *blockingStreamResponseWriter) Flush() {}
+
+func (w *blockingStreamResponseWriter) CanStream() bool {
+	return true
+}
+
+func (w *blockingStreamResponseWriter) SetWriteDeadline(deadline time.Time) error {
+	if !deadline.IsZero() {
+		w.releaseOnce.Do(func() {
+			close(w.writeReleased)
+		})
+	}
+	return nil
+}
+
+func TestStreamableHTTPCleanupInterruptsBlockedWrite(t *testing.T) {
+	manager := &InsecureStatefulSessionIdManager{}
+	transport := NewStreamableHTTPServer(
+		NewMCPServer("blocked-write-test", "1.0.0"),
+		WithSessionIdManager(manager),
+		WithHeartbeatInterval(time.Millisecond),
+	)
+	sessionID := manager.Generate()
+	w := newBlockingStreamResponseWriter()
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		transport.Handle(w, &HTTPRequest{
+			Method: http.MethodGet,
+			Header: http.Header{
+				"Accept":           []string{"text/event-stream"},
+				HeaderKeySessionID: []string{sessionID},
+			},
+			Context: t.Context(),
+		})
+	}()
+
+	select {
+	case <-w.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("heartbeat did not reach the blocked SSE write")
+	}
+
+	cleanupDone := make(chan struct{})
+	go func() {
+		defer close(cleanupDone)
+		transport.cleanupSessionState(context.WithoutCancel(t.Context()), sessionID)
+	}()
+
+	select {
+	case <-cleanupDone:
+	case <-time.After(time.Second):
+		t.Fatal("session cleanup did not interrupt the blocked SSE write")
+	}
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("listening handler did not exit after its write was interrupted")
+	}
 }

--- a/server/streamable_http_connection_test.go
+++ b/server/streamable_http_connection_test.go
@@ -158,10 +158,38 @@ func TestStreamableHTTPHeartbeatStopsWithListeningConnection(t *testing.T) {
 	assert.Equal(t, string(mcp.MethodPing), heartbeat.Method)
 
 	cancel()
-	stream.Body.Close()
+	require.NoError(t, stream.Body.Close())
 	requireConnectionClosed(t, done)
 	_, stillRegistered := transport.activeGetConnections.Load(sessionID)
 	assert.False(t, stillRegistered)
+}
+
+func TestStreamableHTTPDisconnectUnregistersWithLiveContext(t *testing.T) {
+	var unregisterCalls atomic.Int32
+	var unregisterContextCanceled atomic.Bool
+	hooks := &Hooks{}
+	hooks.AddOnUnregisterSession(func(ctx context.Context, _ ClientSession) {
+		unregisterCalls.Add(1)
+		unregisterContextCanceled.Store(ctx.Err() != nil)
+	})
+	manager := &InsecureStatefulSessionIdManager{}
+	transport := NewStreamableHTTPServer(
+		NewMCPServer("disconnect-cleanup-test", "1.0.0", WithHooks(hooks)),
+		WithSessionIdManager(manager),
+	)
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+
+	sessionID := manager.Generate()
+	stream, cancel := openListeningGet(t, ts.URL, sessionID)
+	require.Equal(t, http.StatusOK, stream.StatusCode)
+	done := activeGetDone(t, transport, sessionID)
+
+	cancel()
+	stream.Body.Close()
+	requireConnectionClosed(t, done)
+	assert.Equal(t, int32(1), unregisterCalls.Load())
+	assert.False(t, unregisterContextCanceled.Load())
 }
 
 func TestStreamableHTTPInvalidListeningSessionReturnsNotFound(t *testing.T) {

--- a/server/streamable_http_connection_test.go
+++ b/server/streamable_http_connection_test.go
@@ -215,19 +215,19 @@ func (m *blockingValidateSessionManager) Terminate(sessionID string) (bool, erro
 }
 
 type secondLockSignaler struct {
-	sync.Mutex
+	delegate      sessionLifecycleLocker
 	attempts      atomic.Int32
 	secondAttempt chan struct{}
 	signalOnce    sync.Once
 }
 
-func (l *secondLockSignaler) Lock() {
+func (l *secondLockSignaler) lock(sessionID string) func() {
 	if l.attempts.Add(1) == 2 {
 		l.signalOnce.Do(func() {
 			close(l.secondAttempt)
 		})
 	}
-	l.Mutex.Lock()
+	return l.delegate.lock(sessionID)
 }
 
 func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
@@ -241,8 +241,11 @@ func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
 		NewMCPServer("lifecycle-race-test", "1.0.0"),
 		WithSessionIdManager(manager),
 	)
-	lifecycleLock := &secondLockSignaler{secondAttempt: make(chan struct{})}
-	transport.sessionLifecycleMu = lifecycleLock
+	lifecycleLock := &secondLockSignaler{
+		delegate:      newSessionLifecycleLocks(),
+		secondAttempt: make(chan struct{}),
+	}
+	transport.sessionLifecycle = lifecycleLock
 
 	sessionID := manager.Generate()
 	manager.blockNext.Store(true)
@@ -335,6 +338,25 @@ func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
 	staleStatus := staleWriter.status
 	staleWriter.mu.Unlock()
 	assert.Equal(t, http.StatusNotFound, staleStatus)
+}
+
+func TestSessionLifecycleLocksDoNotBlockOtherSessions(t *testing.T) {
+	locks := newSessionLifecycleLocks()
+	unlockFirst := locks.lock("first")
+	defer unlockFirst()
+
+	secondCompleted := make(chan struct{})
+	go func() {
+		unlockSecond := locks.lock("second")
+		unlockSecond()
+		close(secondCompleted)
+	}()
+
+	select {
+	case <-secondCompleted:
+	case <-time.After(time.Second):
+		t.Fatal("one session's lifecycle lock blocked a different session")
+	}
 }
 
 type blockingStreamResponseWriter struct {

--- a/server/streamable_http_connection_test.go
+++ b/server/streamable_http_connection_test.go
@@ -182,10 +182,14 @@ func TestStreamableHTTPInvalidListeningSessionReturnsNotFound(t *testing.T) {
 }
 
 type blockingValidateSessionManager struct {
-	manager          *InsecureStatefulSessionIdManager
-	blockNext        atomic.Bool
-	validateEntered  chan struct{}
-	continueValidate chan struct{}
+	manager                *InsecureStatefulSessionIdManager
+	blockNext              atomic.Bool
+	validateReturned       atomic.Bool
+	terminateAfterValidate atomic.Bool
+	validateEntered        chan struct{}
+	continueValidate       chan struct{}
+	terminateEntered       chan struct{}
+	terminateOnce          sync.Once
 }
 
 func (m *blockingValidateSessionManager) Generate() string {
@@ -197,26 +201,33 @@ func (m *blockingValidateSessionManager) Validate(sessionID string) (bool, error
 		close(m.validateEntered)
 		<-m.continueValidate
 	}
-	return m.manager.Validate(sessionID)
+	terminated, err := m.manager.Validate(sessionID)
+	m.validateReturned.Store(true)
+	return terminated, err
 }
 
 func (m *blockingValidateSessionManager) Terminate(sessionID string) (bool, error) {
+	m.terminateAfterValidate.Store(m.validateReturned.Load())
+	m.terminateOnce.Do(func() {
+		close(m.terminateEntered)
+	})
 	return m.manager.Terminate(sessionID)
 }
 
-type deleteSignalResolver struct {
-	manager        SessionIdManager
-	deleteResolved chan struct{}
-	deleteOnce     sync.Once
+type secondLockSignaler struct {
+	sync.Mutex
+	attempts      atomic.Int32
+	secondAttempt chan struct{}
+	signalOnce    sync.Once
 }
 
-func (r *deleteSignalResolver) ResolveSessionIdManager(req *http.Request) SessionIdManager {
-	if req != nil && req.Method == http.MethodDelete {
-		r.deleteOnce.Do(func() {
-			close(r.deleteResolved)
+func (l *secondLockSignaler) Lock() {
+	if l.attempts.Add(1) == 2 {
+		l.signalOnce.Do(func() {
+			close(l.secondAttempt)
 		})
 	}
-	return r.manager
+	l.Mutex.Lock()
 }
 
 func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
@@ -224,36 +235,30 @@ func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
 		manager:          &InsecureStatefulSessionIdManager{},
 		validateEntered:  make(chan struct{}),
 		continueValidate: make(chan struct{}),
-	}
-	resolver := &deleteSignalResolver{
-		manager:        manager,
-		deleteResolved: make(chan struct{}),
+		terminateEntered: make(chan struct{}),
 	}
 	transport := NewStreamableHTTPServer(
 		NewMCPServer("lifecycle-race-test", "1.0.0"),
-		WithSessionIdManagerResolver(resolver),
+		WithSessionIdManager(manager),
 	)
-	ts := httptest.NewServer(transport)
-	defer ts.Close()
+	lifecycleLock := &secondLockSignaler{secondAttempt: make(chan struct{})}
+	transport.sessionLifecycleMu = lifecycleLock
 
-	sessionID := initializeLegacySession(t, ts.URL)
+	sessionID := manager.Generate()
 	manager.blockNext.Store(true)
 
-	type responseResult struct {
-		response *http.Response
-		err      error
-	}
-	getResult := make(chan responseResult, 1)
+	getWriter := newFlushableHTTPResponseWriter()
+	getDone := make(chan struct{})
 	go func() {
-		req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-		if err != nil {
-			getResult <- responseResult{err: err}
-			return
-		}
-		req.Header.Set("Accept", "text/event-stream")
-		req.Header.Set(HeaderKeySessionID, sessionID)
-		resp, err := http.DefaultClient.Do(req)
-		getResult <- responseResult{response: resp, err: err}
+		defer close(getDone)
+		transport.Handle(getWriter, &HTTPRequest{
+			Method: http.MethodGet,
+			Header: http.Header{
+				"Accept":           []string{"text/event-stream"},
+				HeaderKeySessionID: []string{sessionID},
+			},
+			Context: t.Context(),
+		})
 	}()
 
 	select {
@@ -262,48 +267,74 @@ func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
 		t.Fatal("listening GET did not reach session validation")
 	}
 
-	deleteResult := make(chan responseResult, 1)
+	deleteWriter := newBufferingHTTPResponseWriter()
+	deleteDone := make(chan struct{})
 	go func() {
-		req, err := http.NewRequest(http.MethodDelete, ts.URL, nil)
-		if err != nil {
-			deleteResult <- responseResult{err: err}
-			return
-		}
-		req.Header.Set(HeaderKeySessionID, sessionID)
-		resp, err := http.DefaultClient.Do(req)
-		deleteResult <- responseResult{response: resp, err: err}
+		defer close(deleteDone)
+		transport.Handle(deleteWriter, &HTTPRequest{
+			Method: http.MethodDelete,
+			Header: http.Header{
+				HeaderKeySessionID: []string{sessionID},
+			},
+			Context: t.Context(),
+		})
 	}()
 
 	select {
-	case <-resolver.deleteResolved:
+	case <-lifecycleLock.secondAttempt:
 	case <-time.After(time.Second):
-		t.Fatal("DELETE did not reach the lifecycle barrier")
+		t.Fatal("DELETE did not attempt to enter the held lifecycle lock")
+	}
+	select {
+	case <-manager.terminateEntered:
+		t.Fatal("DELETE entered Terminate before GET validation returned")
+	default:
 	}
 	close(manager.continueValidate)
 
-	get := <-getResult
-	require.NoError(t, get.err)
-	require.Equal(t, http.StatusOK, get.response.StatusCode)
-	require.NoError(t, get.response.Body.Close())
-
-	deleted := <-deleteResult
-	require.NoError(t, deleted.err)
-	require.Equal(t, http.StatusOK, deleted.response.StatusCode)
-	require.NoError(t, deleted.response.Body.Close())
+	select {
+	case <-getDone:
+	case <-time.After(time.Second):
+		t.Fatal("listening GET did not exit after DELETE")
+	}
+	select {
+	case <-deleteDone:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE did not complete")
+	}
+	getWriter.mu.Lock()
+	getStatus := getWriter.status
+	getWriter.mu.Unlock()
+	require.Equal(t, http.StatusOK, getStatus)
+	deleteWriter.mu.Lock()
+	deleteStatus := deleteWriter.status
+	deleteWriter.mu.Unlock()
+	require.Equal(t, http.StatusOK, deleteStatus)
+	select {
+	case <-manager.terminateEntered:
+	case <-time.After(time.Second):
+		t.Fatal("DELETE did not enter Terminate after GET validation returned")
+	}
+	assert.True(t, manager.terminateAfterValidate.Load())
 
 	_, getStillActive := transport.activeGetConnections.Load(sessionID)
 	assert.False(t, getStillActive)
 	_, sessionStillActive := transport.activeSessions.Load(sessionID)
 	assert.False(t, sessionStillActive)
 
-	staleReq, err := http.NewRequest(http.MethodGet, ts.URL, nil)
-	require.NoError(t, err)
-	staleReq.Header.Set("Accept", "text/event-stream")
-	staleReq.Header.Set(HeaderKeySessionID, sessionID)
-	stale, err := http.DefaultClient.Do(staleReq)
-	require.NoError(t, err)
-	defer stale.Body.Close()
-	assert.Equal(t, http.StatusNotFound, stale.StatusCode)
+	staleWriter := newFlushableHTTPResponseWriter()
+	transport.Handle(staleWriter, &HTTPRequest{
+		Method: http.MethodGet,
+		Header: http.Header{
+			"Accept":           []string{"text/event-stream"},
+			HeaderKeySessionID: []string{sessionID},
+		},
+		Context: t.Context(),
+	})
+	staleWriter.mu.Lock()
+	staleStatus := staleWriter.status
+	staleWriter.mu.Unlock()
+	assert.Equal(t, http.StatusNotFound, staleStatus)
 }
 
 type blockingStreamResponseWriter struct {

--- a/server/streamable_http_connection_test.go
+++ b/server/streamable_http_connection_test.go
@@ -1,0 +1,181 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func initializeLegacySession(t *testing.T, endpoint string) string {
+	t.Helper()
+	request := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": mcp.ProtocolVersion20250326,
+			"capabilities":    map[string]any{},
+			"clientInfo": map[string]any{
+				"name":    "connection-test",
+				"version": "1.0.0",
+			},
+		},
+	}
+	resp, err := postJSON(endpoint, request)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	sessionID := resp.Header.Get(HeaderKeySessionID)
+	require.NotEmpty(t, sessionID)
+	return sessionID
+}
+
+func openListeningGet(t *testing.T, endpoint, sessionID string) (*http.Response, context.CancelFunc) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(t.Context())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set(HeaderKeySessionID, sessionID)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	return resp, cancel
+}
+
+func activeGetDone(t *testing.T, transport *StreamableHTTPServer, sessionID string) <-chan struct{} {
+	t.Helper()
+	value, ok := transport.activeGetConnections.Load(sessionID)
+	require.True(t, ok)
+	return value.(*activeGetConnection).done
+}
+
+func requireConnectionClosed(t *testing.T, done <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("listening GET handler did not exit")
+	}
+}
+
+func TestStreamableHTTPListeningConnectionLifecycle(t *testing.T) {
+	var unregisterCalls atomic.Int32
+	var unregisterContextCanceled atomic.Bool
+	hooks := &Hooks{}
+	hooks.AddOnUnregisterSession(func(ctx context.Context, _ ClientSession) {
+		unregisterCalls.Add(1)
+		unregisterContextCanceled.Store(ctx.Err() != nil)
+	})
+	mcpServer := NewMCPServer("connection-test", "1.0.0", WithHooks(hooks))
+	transport := NewStreamableHTTPServer(mcpServer, WithStateful(true))
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+
+	sessionID := initializeLegacySession(t, ts.URL)
+	first, cancelFirst := openListeningGet(t, ts.URL, sessionID)
+	require.Equal(t, http.StatusOK, first.StatusCode)
+	firstDone := activeGetDone(t, transport, sessionID)
+
+	duplicateReq, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	duplicateReq.Header.Set("Accept", "text/event-stream")
+	duplicateReq.Header.Set(HeaderKeySessionID, sessionID)
+	duplicate, err := http.DefaultClient.Do(duplicateReq)
+	require.NoError(t, err)
+	duplicate.Body.Close()
+	require.Equal(t, http.StatusConflict, duplicate.StatusCode)
+
+	cancelFirst()
+	first.Body.Close()
+	requireConnectionClosed(t, firstDone)
+	_, stillRegistered := transport.activeGetConnections.Load(sessionID)
+	assert.False(t, stillRegistered)
+
+	reconnected, cancelReconnect := openListeningGet(t, ts.URL, sessionID)
+	require.Equal(t, http.StatusOK, reconnected.StatusCode)
+	reconnectDone := activeGetDone(t, transport, sessionID)
+
+	deleteReq, err := http.NewRequest(http.MethodDelete, ts.URL, nil)
+	require.NoError(t, err)
+	deleteReq.Header.Set(HeaderKeySessionID, sessionID)
+	deleted, err := http.DefaultClient.Do(deleteReq)
+	require.NoError(t, err)
+	deleted.Body.Close()
+	require.Equal(t, http.StatusOK, deleted.StatusCode)
+	requireConnectionClosed(t, reconnectDone)
+	cancelReconnect()
+	reconnected.Body.Close()
+	assert.Equal(t, int32(1), unregisterCalls.Load())
+	assert.False(t, unregisterContextCanceled.Load())
+
+	staleReq, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	staleReq.Header.Set("Accept", "text/event-stream")
+	staleReq.Header.Set(HeaderKeySessionID, sessionID)
+	stale, err := http.DefaultClient.Do(staleReq)
+	require.NoError(t, err)
+	defer stale.Body.Close()
+	assert.Equal(t, http.StatusNotFound, stale.StatusCode)
+}
+
+func TestStreamableHTTPHeartbeatStopsWithListeningConnection(t *testing.T) {
+	mcpServer := NewMCPServer("heartbeat-test", "1.0.0")
+	transport := NewStreamableHTTPServer(mcpServer,
+		WithStateful(true),
+		WithHeartbeatInterval(5*time.Millisecond),
+	)
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+
+	sessionID := initializeLegacySession(t, ts.URL)
+	stream, cancel := openListeningGet(t, ts.URL, sessionID)
+	require.Equal(t, http.StatusOK, stream.StatusCode)
+	done := activeGetDone(t, transport, sessionID)
+
+	reader := bufio.NewReader(stream.Body)
+	var payload string
+	for payload == "" {
+		line, err := reader.ReadString('\n')
+		require.NoError(t, err)
+		if data, ok := strings.CutPrefix(line, "data: "); ok {
+			payload = strings.TrimSpace(data)
+		}
+	}
+	var heartbeat mcp.JSONRPCRequest
+	require.NoError(t, json.Unmarshal([]byte(payload), &heartbeat))
+	assert.Equal(t, string(mcp.MethodPing), heartbeat.Method)
+
+	cancel()
+	stream.Body.Close()
+	requireConnectionClosed(t, done)
+	_, stillRegistered := transport.activeGetConnections.Load(sessionID)
+	assert.False(t, stillRegistered)
+}
+
+func TestStreamableHTTPInvalidListeningSessionReturnsNotFound(t *testing.T) {
+	transport := NewStreamableHTTPServer(NewMCPServer("invalid-test", "1.0.0"), WithStateful(true))
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL, nil)
+	require.NoError(t, err)
+	req.Header.Set("Accept", "text/event-stream")
+	req.Header.Set(HeaderKeySessionID, "not-a-session")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}

--- a/server/streamable_http_connection_test.go
+++ b/server/streamable_http_connection_test.go
@@ -56,9 +56,9 @@ func openListeningGet(t *testing.T, endpoint, sessionID string) (*http.Response,
 
 func activeGetDone(t *testing.T, transport *StreamableHTTPServer, sessionID string) <-chan struct{} {
 	t.Helper()
-	value, ok := transport.activeGetConnections.Load(sessionID)
+	value, ok := transport.activeGETConnections.Load(sessionID)
 	require.True(t, ok)
-	return value.(*activeGetConnection).done
+	return value.(*activeGETConnection).done
 }
 
 func requireConnectionClosed(t *testing.T, done <-chan struct{}) {
@@ -100,7 +100,7 @@ func TestStreamableHTTPListeningConnectionLifecycle(t *testing.T) {
 	cancelFirst()
 	first.Body.Close()
 	requireConnectionClosed(t, firstDone)
-	_, stillRegistered := transport.activeGetConnections.Load(sessionID)
+	_, stillRegistered := transport.activeGETConnections.Load(sessionID)
 	assert.False(t, stillRegistered)
 
 	reconnected, cancelReconnect := openListeningGet(t, ts.URL, sessionID)
@@ -160,7 +160,7 @@ func TestStreamableHTTPHeartbeatStopsWithListeningConnection(t *testing.T) {
 	cancel()
 	require.NoError(t, stream.Body.Close())
 	requireConnectionClosed(t, done)
-	_, stillRegistered := transport.activeGetConnections.Load(sessionID)
+	_, stillRegistered := transport.activeGETConnections.Load(sessionID)
 	assert.False(t, stillRegistered)
 }
 
@@ -207,6 +207,50 @@ func TestStreamableHTTPInvalidListeningSessionReturnsNotFound(t *testing.T) {
 	_, err = io.Copy(io.Discard, resp.Body)
 	require.NoError(t, err)
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
+}
+
+type nonInterruptibleStreamResponseWriter struct {
+	*bufferingHTTPResponseWriter
+}
+
+func (w *nonInterruptibleStreamResponseWriter) Flush() {}
+
+func (w *nonInterruptibleStreamResponseWriter) CanStream() bool {
+	return true
+}
+
+func TestStreamableHTTPRejectsNonInterruptibleCustomWriter(t *testing.T) {
+	manager := &InsecureStatefulSessionIdManager{}
+	transport := NewStreamableHTTPServer(
+		NewMCPServer("non-interruptible-writer-test", "1.0.0"),
+		WithSessionIdManager(manager),
+	)
+	sessionID := manager.Generate()
+	w := &nonInterruptibleStreamResponseWriter{newBufferingHTTPResponseWriter()}
+	transport.Handle(w, &HTTPRequest{
+		Method: http.MethodGet,
+		Header: http.Header{
+			"Accept":           []string{"text/event-stream"},
+			HeaderKeySessionID: []string{sessionID},
+		},
+		Context: t.Context(),
+	})
+
+	w.mu.Lock()
+	status := w.status
+	w.mu.Unlock()
+	require.Equal(t, http.StatusMethodNotAllowed, status)
+	_, stillRegistered := transport.activeGETConnections.Load(sessionID)
+	assert.False(t, stillRegistered)
+
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+	stream, cancel := openListeningGet(t, ts.URL, sessionID)
+	require.Equal(t, http.StatusOK, stream.StatusCode)
+	done := activeGetDone(t, transport, sessionID)
+	cancel()
+	require.NoError(t, stream.Body.Close())
+	requireConnectionClosed(t, done)
 }
 
 type blockingValidateSessionManager struct {
@@ -348,7 +392,7 @@ func TestStreamableHTTPDeleteSerializesWithListeningRegistration(t *testing.T) {
 	}
 	assert.True(t, manager.terminateAfterValidate.Load())
 
-	_, getStillActive := transport.activeGetConnections.Load(sessionID)
+	_, getStillActive := transport.activeGETConnections.Load(sessionID)
 	assert.False(t, getStillActive)
 	_, sessionStillActive := transport.activeSessions.Load(sessionID)
 	assert.False(t, sessionStillActive)
@@ -385,6 +429,82 @@ func TestSessionLifecycleLocksDoNotBlockOtherSessions(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("one session's lifecycle lock blocked a different session")
 	}
+}
+
+type firstLifecycleLockBarrier struct {
+	delegate sessionLifecycleLocker
+	target   string
+	once     sync.Once
+	entered  chan struct{}
+	release  chan struct{}
+}
+
+func (b *firstLifecycleLockBarrier) lock(sessionID string) func() {
+	shouldBlock := false
+	if sessionID == b.target {
+		b.once.Do(func() {
+			shouldBlock = true
+		})
+	}
+	if shouldBlock {
+		close(b.entered)
+		<-b.release
+	}
+	return b.delegate.lock(sessionID)
+}
+
+func TestStreamableHTTPSweeperRechecksActivityInsideLifecycleLock(t *testing.T) {
+	manager := &InsecureStatefulSessionIdManager{}
+	transport := NewStreamableHTTPServer(
+		NewMCPServer("sweeper-race-test", "1.0.0"),
+		WithSessionIdManager(manager),
+	)
+	transport.sessionIdleTTL = time.Minute
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+
+	sessionID := initializeLegacySession(t, ts.URL)
+	lastActive := new(atomic.Int64)
+	staleTimestamp := time.Now().Add(-2 * transport.sessionIdleTTL).UnixNano()
+	lastActive.Store(staleTimestamp)
+	transport.sessionLastActive.Store(sessionID, lastActive)
+	barrier := &firstLifecycleLockBarrier{
+		delegate: newSessionLifecycleLocks(),
+		target:   sessionID,
+		entered:  make(chan struct{}),
+		release:  make(chan struct{}),
+	}
+	transport.sessionLifecycle = barrier
+
+	sweepDone := make(chan struct{})
+	go func() {
+		defer close(sweepDone)
+		transport.sweepExpiredSessions()
+	}()
+	select {
+	case <-barrier.entered:
+	case <-time.After(time.Second):
+		t.Fatal("sweeper did not reach the lifecycle barrier")
+	}
+
+	stream, cancel := openListeningGet(t, ts.URL, sessionID)
+	require.Equal(t, http.StatusOK, stream.StatusCode)
+	done := activeGetDone(t, transport, sessionID)
+	require.NotEqual(t, staleTimestamp, lastActive.Load())
+	close(barrier.release)
+
+	select {
+	case <-sweepDone:
+	case <-time.After(time.Second):
+		t.Fatal("sweeper did not finish")
+	}
+	terminated, err := manager.Validate(sessionID)
+	require.NoError(t, err)
+	assert.False(t, terminated)
+
+	cancel()
+	require.NoError(t, stream.Body.Close())
+	requireConnectionClosed(t, done)
 }
 
 type blockingStreamResponseWriter struct {

--- a/server/streamable_http_connection_test.go
+++ b/server/streamable_http_connection_test.go
@@ -192,6 +192,30 @@ func TestStreamableHTTPDisconnectUnregistersWithLiveContext(t *testing.T) {
 	assert.False(t, unregisterContextCanceled.Load())
 }
 
+func TestStreamableHTTPCloseSessionsDetachesCanceledContext(t *testing.T) {
+	var unregisterCalls atomic.Int32
+	var unregisterContextCanceled atomic.Bool
+	hooks := &Hooks{}
+	hooks.AddOnUnregisterSession(func(ctx context.Context, _ ClientSession) {
+		unregisterCalls.Add(1)
+		unregisterContextCanceled.Store(ctx.Err() != nil)
+	})
+	transport := NewStreamableHTTPServer(
+		NewMCPServer("close-sessions-context-test", "1.0.0", WithHooks(hooks)),
+		WithStateful(true),
+	)
+	ts := httptest.NewServer(transport)
+	defer ts.Close()
+
+	initializeLegacySession(t, ts.URL)
+	cleanupCtx, cancel := context.WithCancel(t.Context())
+	cancel()
+	transport.CloseSessions(cleanupCtx)
+
+	assert.Equal(t, int32(1), unregisterCalls.Load())
+	assert.False(t, unregisterContextCanceled.Load())
+}
+
 func TestStreamableHTTPInvalidListeningSessionReturnsNotFound(t *testing.T) {
 	transport := NewStreamableHTTPServer(NewMCPServer("invalid-test", "1.0.0"), WithStateful(true))
 	ts := httptest.NewServer(transport)

--- a/server/streamable_http_handle.go
+++ b/server/streamable_http_handle.go
@@ -109,8 +109,17 @@ type HTTPResponseWriter interface {
 	Flush()
 	// CanStream reports whether Flush actually delivers bytes to the client
 	// immediately. When false, the server will not upgrade POST responses to
-	// SSE and will reject GET requests with 405 Method Not Allowed.
+	// SSE and will reject GET requests with 405 Method Not Allowed. Writers
+	// passed to Handle for non-resumable GET streams must also implement
+	// SetWriteDeadline(time.Time) so cleanup can interrupt a blocked write.
 	CanStream() bool
+}
+
+// writeDeadlineSetter is required for long-lived GET streams so session
+// cleanup can interrupt a blocked write. Implementations used only for
+// non-streaming responses do not need to provide it.
+type writeDeadlineSetter interface {
+	SetWriteDeadline(time.Time) error
 }
 
 // httpResponseWriterAdapter adapts an http.ResponseWriter to

--- a/server/streamable_http_handle_test.go
+++ b/server/streamable_http_handle_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -82,6 +83,8 @@ func (f *flushableHTTPResponseWriter) Flush() {
 }
 
 func (f *flushableHTTPResponseWriter) CanStream() bool { return true }
+
+func (f *flushableHTTPResponseWriter) SetWriteDeadline(time.Time) error { return nil }
 
 func TestStreamableHTTPServer_Handle_InitializeWithoutNetHTTP(t *testing.T) {
 	mcpServer := NewMCPServer("test-mcp-server", "1.0")

--- a/server/streamable_http_resume.go
+++ b/server/streamable_http_resume.go
@@ -484,7 +484,7 @@ func (s *StreamableHTTPServer) cleanupResumableState(ctx context.Context, sessio
 // returns a func that clears it again. Writers without deadline support,
 // e.g. adapters for other frameworks, are left untouched.
 func setWriteDeadline(w HTTPResponseWriter, d time.Duration) (restore func()) {
-	dw, ok := w.(interface{ SetWriteDeadline(time.Time) error })
+	dw, ok := w.(writeDeadlineSetter)
 	if !ok {
 		return func() {}
 	}


### PR DESCRIPTION
## Summary

- track one live non-resumable standalone GET connection per session
- release that registration as soon as the request context ends, allowing an immediate reconnect
- reject a genuinely simultaneous second GET with `409 Conflict`
- make DELETE cancel and join the active GET before session cleanup completes
- validate legacy GET session IDs so invalid and terminated stateful sessions return `404 Not Found`
- join notification and heartbeat workers before reporting the connection closed

## Context

This is the upstream portion of [render-oss/render-mcp-server#26](https://github.com/render-oss/render-mcp-server/issues/26). A black-box trace against v1.0.0/current main showed:

- standalone GET correctly returns 200
- disconnect followed by reconnect succeeds once the old handler has exited
- two simultaneous GETs for the same session are both accepted
- DELETE returns 200 but leaves the active GET handler running
- a GET using the terminated stateful session is not rejected before opening a new stream

`activeSessions` represents logical MCP session state and intentionally survives a non-resumable GET disconnect, so this patch adds a separate connection-scoped registration rather than unregistering the logical session.

The resumable event-store path is unchanged; this guard applies only to non-resumable listening GETs.

## Lifecycle

The connection registration owns a derived cancelable context and a completion signal. Request cancellation removes it in the handler defer. DELETE uses a bounded context detached from the request's cancellation, cancels the active GET, waits for its workers and handler to finish, then unregisters and deletes session state. Compare-and-delete prevents an old handler from removing a newer registration.

## Validation

- deterministic tests for disconnect/reconnect, active duplicate rejection, DELETE release, stale/invalid 404, GET 200, ping heartbeat, exactly-once unregister, live cleanup context, and worker completion
- full `server` package passes (aside from three pre-existing Windows zero-duration clock assertions when run unfiltered)
- all other locally runnable packages pass; upstream's Unix-only syscall test does not compile on Windows
- changed-diff golangci-lint: `0 issues`
- `go generate ./...` leaves generated code unchanged
- `git diff --check`

The repository's Ubuntu `go test ./... -race` workflow is the definitive race gate; local WSL became unavailable after its C:-backed virtual disk entered a read-only state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Streamable HTTP session validation, returning clear errors for unknown or terminated sessions.
  - Prevented multiple simultaneous listening connections for the same session.
  - Ensured listening connections, heartbeats, and related resources close cleanly when sessions are deleted or connections end.
  - Improved reconnection behavior after a listening connection is closed.
  - Improved coordination between session deletion and new listening connections.
  - Ensured cleanup can interrupt stalled connections so requests shut down reliably.
  - Standardized session cleanup timing for more consistent connection termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->