### PR TITLE
fix(mcp): decode the result envelope in the prompts/get and resources/read parsers

### DIFF
--- a/mcp/utils.go
+++ b/mcp/utils.go
@@ -730,6 +730,26 @@ func ParseContent(contentMap map[string]any) (Content, error) {
 	return nil, fmt.Errorf("unsupported content type: %s", contentType)
 }
 
+// resultEnvelope holds the fields a result carries outside its payload: the
+// SEP-2322 round-trip fields and the SEP-2549 cache hints.
+type resultEnvelope struct {
+	ResultType    ResultType    `json:"resultType"`
+	InputRequests InputRequests `json:"inputRequests"`
+	RequestState  string        `json:"requestState"`
+	TTLMs         *int64        `json:"ttlMs"`
+	CacheScope    CacheScope    `json:"cacheScope"`
+}
+
+// parseResultEnvelope decodes the envelope of a result whose payload holds
+// interface values and therefore has to be walked by hand.
+func parseResultEnvelope(rawMessage json.RawMessage) (resultEnvelope, error) {
+	var envelope resultEnvelope
+	if err := json.Unmarshal(rawMessage, &envelope); err != nil {
+		return resultEnvelope{}, fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+	return envelope, nil
+}
+
 func ParseGetPromptResult(rawMessage *json.RawMessage) (*GetPromptResult, error) {
 	if rawMessage == nil {
 		return nil, fmt.Errorf("response is nil")
@@ -740,7 +760,15 @@ func ParseGetPromptResult(rawMessage *json.RawMessage) (*GetPromptResult, error)
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	envelope, err := parseResultEnvelope(*rawMessage)
+	if err != nil {
+		return nil, err
+	}
+
 	result := GetPromptResult{}
+	result.ResultType = envelope.ResultType
+	result.InputRequests = envelope.InputRequests
+	result.RequestState = envelope.RequestState
 
 	meta, ok := jsonContent["_meta"]
 	if ok {
@@ -756,8 +784,10 @@ func ParseGetPromptResult(rawMessage *json.RawMessage) (*GetPromptResult, error)
 		}
 	}
 
+	// A null payload is treated like an absent one: an input_required result
+	// carries no messages, and so does a zero-valued GetPromptResult.
 	messages, ok := jsonContent["messages"]
-	if ok {
+	if ok && messages != nil {
 		messagesArr, ok := messages.([]any)
 		if !ok {
 			return nil, fmt.Errorf("messages is not an array")
@@ -864,7 +894,17 @@ func ParseReadResourceResult(rawMessage *json.RawMessage) (*ReadResourceResult, 
 		return nil, fmt.Errorf("failed to unmarshal response: %w", err)
 	}
 
+	envelope, err := parseResultEnvelope(*rawMessage)
+	if err != nil {
+		return nil, err
+	}
+
 	var result ReadResourceResult
+	result.ResultType = envelope.ResultType
+	result.InputRequests = envelope.InputRequests
+	result.RequestState = envelope.RequestState
+	result.TTLMs = envelope.TTLMs
+	result.CacheScope = envelope.CacheScope
 
 	meta, ok := jsonContent["_meta"]
 	if ok {
@@ -874,7 +914,12 @@ func ParseReadResourceResult(rawMessage *json.RawMessage) (*ReadResourceResult, 
 	}
 
 	contents, ok := jsonContent["contents"]
-	if !ok {
+	if !ok || contents == nil {
+		// An input_required result asks for more input instead of returning
+		// contents, so the payload is legitimately absent.
+		if result.NeedsInput() {
+			return &result, nil
+		}
 		return nil, fmt.Errorf("contents is missing")
 	}
 

--- a/mcp/utils_envelope_test.go
+++ b/mcp/utils_envelope_test.go
@@ -1,0 +1,122 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseGetPromptResultEnvelope(t *testing.T) {
+	tests := []struct {
+		name          string
+		raw           string
+		wantNeedsIn   bool
+		wantState     string
+		wantRequests  int
+		wantMessages  int
+		wantResultTyp ResultType
+	}{
+		{
+			name:          "input required carries round trip fields",
+			raw:           `{"resultType":"input_required","requestState":"state-token","inputRequests":{"city":{"method":"elicitation/create","params":{"message":"which city?"}}},"messages":null}`,
+			wantNeedsIn:   true,
+			wantState:     "state-token",
+			wantRequests:  1,
+			wantResultTyp: ResultTypeInputRequired,
+		},
+		{
+			name:          "complete result keeps messages",
+			raw:           `{"resultType":"complete","messages":[{"role":"user","content":{"type":"text","text":"hi"}}]}`,
+			wantMessages:  1,
+			wantResultTyp: ResultTypeComplete,
+		},
+		{
+			name: "absent result type is complete",
+			raw:  `{"messages":[{"role":"user","content":{"type":"text","text":"hi"}}]}`,
+
+			wantMessages: 1,
+		},
+		{
+			name: "null messages is treated as empty",
+			raw:  `{"messages":null}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := json.RawMessage(tt.raw)
+			result, err := ParseGetPromptResult(&raw)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.wantResultTyp, result.ResultType)
+			assert.Equal(t, tt.wantNeedsIn, result.NeedsInput())
+			assert.Equal(t, tt.wantState, result.RequestState)
+			assert.Len(t, result.InputRequests, tt.wantRequests)
+			assert.Len(t, result.Messages, tt.wantMessages)
+		})
+	}
+}
+
+func TestParseReadResourceResultEnvelope(t *testing.T) {
+	t.Run("input required carries round trip fields", func(t *testing.T) {
+		raw := json.RawMessage(`{"resultType":"input_required","requestState":"state-token","inputRequests":{"city":{"method":"elicitation/create","params":{"message":"which city?"}}},"contents":null}`)
+		result, err := ParseReadResourceResult(&raw)
+		require.NoError(t, err)
+
+		assert.True(t, result.NeedsInput())
+		assert.Equal(t, "state-token", result.RequestState)
+		assert.Len(t, result.InputRequests, 1)
+		assert.Empty(t, result.Contents)
+	})
+
+	t.Run("cache hints survive the round trip", func(t *testing.T) {
+		raw := json.RawMessage(`{"ttlMs":60000,"cacheScope":"public","contents":[{"uri":"file:///a.txt","mimeType":"text/plain","text":"hi"}]}`)
+		result, err := ParseReadResourceResult(&raw)
+		require.NoError(t, err)
+
+		ttl, ok := result.TTL()
+		assert.True(t, ok)
+		assert.Equal(t, int64(60000), ttl)
+		assert.Equal(t, CacheScopePublic, result.CacheScope)
+		assert.Len(t, result.Contents, 1)
+	})
+
+	t.Run("complete result still requires contents", func(t *testing.T) {
+		raw := json.RawMessage(`{"resultType":"complete"}`)
+		_, err := ParseReadResourceResult(&raw)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "contents is missing")
+	})
+}
+
+// The results the server's InputRequestBuilder produces must survive the trip
+// back through the client parsers.
+func TestParseResultsFromInputRequestBuilderWireForm(t *testing.T) {
+	promptResult := &GetPromptResult{
+		Result:               Result{ResultType: ResultTypeInputRequired},
+		MultiRoundTripResult: MultiRoundTripResult{RequestState: "state-token"},
+	}
+	rawPrompt, err := json.Marshal(promptResult)
+	require.NoError(t, err)
+
+	promptMsg := json.RawMessage(rawPrompt)
+	parsedPrompt, err := ParseGetPromptResult(&promptMsg)
+	require.NoError(t, err)
+	assert.True(t, parsedPrompt.NeedsInput())
+	assert.Equal(t, "state-token", parsedPrompt.RequestState)
+
+	resourceResult := &ReadResourceResult{
+		MultiRoundTripResult: MultiRoundTripResult{RequestState: "state-token"},
+	}
+	resourceResult.ResultType = ResultTypeInputRequired
+	rawResource, err := json.Marshal(resourceResult)
+	require.NoError(t, err)
+
+	resourceMsg := json.RawMessage(rawResource)
+	parsedResource, err := ParseReadResourceResult(&resourceMsg)
+	require.NoError(t, err)
+	assert.True(t, parsedResource.NeedsInput())
+	assert.Equal(t, "state-token", parsedResource.RequestState)
+}


### PR DESCRIPTION
`InputRequestBuilder.PromptResult()` and `.ResourceResult()` produce results that an mcp-go client can't read back. Both mark the result `input_required` and carry no payload, so `messages` and `contents` marshal as `null`, and `ParseGetPromptResult` / `ParseReadResourceResult` bail out with "messages is not an array" / "contents is not an array" before looking at anything else.

The reason is that those two parsers walk their payload by hand — its elements are interfaces, so `json.Unmarshal` can't do it — and while doing so they only ever read `_meta` plus the payload field. Everything else in the envelope is dropped: `resultType`, `inputRequests`, `requestState`. That's all of SEP-2322, so `NeedsInput()` can never return true and the retry loop in `client/mrtr.go` never fires. `ParseCallToolResult` avoids the problem only because `CallToolResult` has its own `UnmarshalJSON`, which is why the multi-round-trip flow works on tools and nowhere else.

Pulled the envelope decode into a small helper and called it from both parsers. A null payload is now treated like an absent one, and `resources/read` only insists on `contents` when the result isn't asking for more input — `{}` still errors as before. The same helper picks up the SEP-2549 `ttlMs`/`cacheScope` on `resources/read`, which were being lost in the same three lines; `resources/list` keeps them today only because it goes through a plain unmarshal.

Tests cover both parsers on the `input_required` shape and on the wire form the server builder actually emits; they fail on main with the errors above. Existing parser error cases are unchanged, and `go test ./... -race` is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of prompt and resource results that require additional input.
  * Preserved request state, input requests, result status, and cache hints when processing results.
  * Added support for results with absent or null message content where permitted.
* **Bug Fixes**
  * Resource results missing required content now return a clear validation error.
  * Results without an explicit status are treated as complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->